### PR TITLE
feat: Kubernetes health check 엔드포인트 추가 (/v1/healthz)

### DIFF
--- a/server/config/urls.py
+++ b/server/config/urls.py
@@ -16,9 +16,19 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
+from django.http import JsonResponse
 from ninja import NinjaAPI
 from campaigns.api import router as campaigns_router
 from campaigns.category_api import router as categories_router
+
+# Health check view
+def health_check(request):
+    """Kubernetes health check endpoint"""
+    return JsonResponse({
+        "status": "healthy",
+        "service": "reviewmaps-server",
+        "version": "1.0.0"
+    })
 
 # Django Ninja API 인스턴스 생성
 api = NinjaAPI(
@@ -34,4 +44,5 @@ api.add_router("/v1/categories", categories_router)
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', api.urls),  # /api/v1/campaigns로 접근
+    path('v1/healthz', health_check, name='health'),  # Kubernetes health check
 ]


### PR DESCRIPTION
## 📋 변경 사항 요약

### ✨ Health Check 엔드포인트 추가
- **경로**: `GET /v1/healthz`
- **응답**: `{"status": "healthy", "service": "reviewmaps-server", "version": "1.0.0"}`
- **용도**: Kubernetes livenessProbe, readinessProbe, startupProbe

### 🔧 구현 내용

#### config/urls.py
```python
def health_check(request):
    """Kubernetes health check endpoint"""
    return JsonResponse({
        "status": "healthy",
        "service": "reviewmaps-server",
        "version": "1.0.0"
    })

urlpatterns = [
    path('v1/healthz', health_check, name='health'),
]
```

### 🎯 배경
- **문제**: Pod가 404 에러로 계속 재시작
- **원인**: Django Ninja 프로젝트에 health check 엔드포인트 미구현
- **해결**: `/v1/healthz` 엔드포인트 추가로 시스템 표준과 통일

### 🔗 관련 PR
- Infra PR: https://github.com/ggorockee/infra/pull/509
- Helm 차트에서 해당 엔드포인트를 health check로 사용

### 📌 배포 순서
1. **이 PR 먼저 배포** (server)
2. Infra PR #509 배포 (Helm 차트)

### ✅ 테스트
```bash
# 로컬 테스트
curl http://localhost:8000/v1/healthz

# 예상 응답
{"status": "healthy", "service": "reviewmaps-server", "version": "1.0.0"}
```