### PR TITLE
refactor: URL 구조를 /v1 직접 경로로 변경

### DIFF
--- a/server/config/urls.py
+++ b/server/config/urls.py
@@ -16,9 +16,19 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
+from django.http import JsonResponse
 from ninja import NinjaAPI
 from campaigns.api import router as campaigns_router
 from campaigns.category_api import router as categories_router
+
+# Health check view
+def health_check(request):
+    """Kubernetes health check endpoint"""
+    return JsonResponse({
+        "status": "healthy",
+        "service": "reviewmaps-server",
+        "version": "1.0.0"
+    })
 
 # Django Ninja API 인스턴스 생성
 api = NinjaAPI(
@@ -34,4 +44,5 @@ api.add_router("/v1/categories", categories_router)
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', api.urls),  # /api/v1/campaigns로 접근
+    path('v1/healthz', health_check, name='health'),  # Kubernetes health check
 ]

--- a/server/config/urls.py
+++ b/server/config/urls.py
@@ -38,11 +38,11 @@ api = NinjaAPI(
 )
 
 # 라우터 등록
-api.add_router("/v1/", campaigns_router)
-api.add_router("/v1/categories", categories_router)
+api.add_router("/campaigns", campaigns_router)
+api.add_router("/categories", categories_router)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('api/', api.urls),  # /api/v1/campaigns로 접근
+    path('v1/', api.urls),  # /v1/campaigns, /v1/categories로 접근
     path('v1/healthz', health_check, name='health'),  # Kubernetes health check
 ]


### PR DESCRIPTION
## 📝 Summary
- API URL 구조를 `/api/v1/...`에서 `/v1/...`로 변경
- RESTful API 설계 표준에 맞춰 도메인 직후 버전 prefix 배치

## 🔧 Changes
- **config/urls.py**
  - API 라우터 prefix 변경: `/v1/` → `/campaigns`, `/categories`
  - urlpatterns 마운트 경로 변경: `path('api/', ...)` → `path('v1/', ...)`
  - 주석 업데이트

## 🎯 Before / After
### Before
- `[domain.com]/api/v1/campaigns`
- `[domain.com]/api/v1/categories`
- `[domain.com]/api/v1/docs`

### After
- `[domain.com]/v1/campaigns`
- `[domain.com]/v1/categories`
- `[domain.com]/v1/docs`

## ✅ Test Plan
- [ ] 로컬 환경에서 `/v1/campaigns` 엔드포인트 접근 확인
- [ ] `/v1/categories` 엔드포인트 정상 작동 확인
- [ ] Django Ninja 자동생성 문서 `/v1/docs` 접근 확인
- [ ] Health check `/v1/healthz` 정상 응답 확인

## 📌 Related
- URL 구조 표준화
- API 버전 관리 개선