### PR TITLE
fix: Django Ninja Swagger UI static 파일 404 오류 해결

### DIFF
--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,59 @@
+# Python
+__pycache__
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg-info
+dist/
+build/
+*.egg
+
+# Virtual Environment
+.venv/
+venv/
+ENV/
+
+# Django
+*.log
+db.sqlite3
+db.sqlite3-journal
+staticfiles/
+media/
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Git
+.git/
+.gitignore
+
+# Docker
+Dockerfile
+.dockerignore
+
+# CI/CD
+.github/
+
+# Documentation
+*.md
+docs/
+claudedocs/
+
+# Testing
+.coverage
+htmlcov/
+.pytest_cache/
+
+# Environment
+.env
+.env.*
+
+# Temporary files
+*.tmp
+*.bak
+my-request.txt

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,1 +1,5 @@
 my-request.txt
+
+# Django static files
+staticfiles/
+static/

--- a/server/config/settings.py
+++ b/server/config/settings.py
@@ -127,7 +127,11 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
-STATIC_URL = 'static/'
+STATIC_URL = '/static/'
+STATIC_ROOT = BASE_DIR / 'staticfiles'
+
+# Additional locations of static files
+STATICFILES_DIRS = []
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -9,11 +9,9 @@ PORT=${PORT:-8000}
 echo "Running Django migrations..."
 /app/.venv/bin/python manage.py migrate --noinput
 
-# Static 파일 수집 (필요한 경우)
-if [[ "${COLLECT_STATIC:-false}" == "true" ]]; then
-  echo "Collecting static files..."
-  /app/.venv/bin/python manage.py collectstatic --noinput
-fi
+# Static 파일 수집 (Django Ninja Swagger UI 등)
+echo "Collecting static files..."
+/app/.venv/bin/python manage.py collectstatic --noinput
 
 # Gunicorn + Uvicorn으로 Django ASGI 서버 실행
 echo "Starting Django server with Gunicorn (workers: ${WORKERS}, port: ${PORT})..."


### PR DESCRIPTION
## 📝 Summary
Django Ninja의 Swagger UI가 `/v1/docs` 접근 시 static 파일(CSS, JS)을 로드하지 못하는 404 오류를 해결합니다.

## 🐛 Problem
```
Not Found: /static/ninja/swagger-ui.css
Not Found: /static/ninja/swagger-ui-bundle.js
Not Found: /static/ninja/swagger-ui-init.js
```
- Django static 파일 설정이 누락되어 Swagger UI가 정상 작동하지 않음
- Docker 환경에서 static 파일 수집이 조건부로만 실행됨

## 🔧 Changes

### 1️⃣ Django Static 파일 설정 추가
**config/settings.py**
- `STATIC_URL = '/static/'` - static 파일 URL prefix
- `STATIC_ROOT = BASE_DIR / 'staticfiles'` - static 파일 수집 디렉토리
- `STATICFILES_DIRS = []` - 추가 static 파일 위치

**.gitignore**
- `staticfiles/` - 생성된 static 파일 디렉토리 제외
- `static/` - 추가 static 파일 디렉토리 제외

### 2️⃣ Docker 환경 최적화
**entrypoint.sh**
- `collectstatic` 명령을 항상 실행하도록 변경
- 기존: `COLLECT_STATIC` 환경변수가 true일 때만 실행
- 변경: 컨테이너 시작 시 자동 실행

**.dockerignore (신규)**
- Python 캐시 파일 제외 (`__pycache__`, `*.pyc`)
- 가상환경 제외 (`.venv/`)
- 로컬 DB 파일 제외 (`db.sqlite3`)
- IDE, Git, 문서 파일 제외
- Docker 이미지 크기 최적화 및 빌드 성능 향상

## ✅ Test Plan
- [ ] 로컬 환경에서 `python manage.py collectstatic` 실행 확인
- [ ] `/v1/docs` 접근 시 Swagger UI CSS/JS 정상 로드 확인
- [ ] Docker 빌드 및 실행 시 static 파일 자동 수집 확인
- [ ] Swagger UI 정상 작동 확인 (API 문서 조회 가능)

## 📊 Impact
✅ Swagger UI 정상 작동으로 API 문서 접근성 향상  
✅ Docker 이미지 빌드 최적화 (불필요한 파일 제외)  
✅ 프로덕션 환경에서 static 파일 자동 처리  

## 🔗 Related
- Django Ninja static files: https://django-ninja.rest-framework.com/
- Django collectstatic: https://docs.djangoproject.com/en/stable/ref/contrib/staticfiles/