### PR TITLE
feat: Swagger API 태그 중복 해결 및 Mobile App CORS 설정

### DIFF
--- a/server/campaigns/api.py
+++ b/server/campaigns/api.py
@@ -10,7 +10,7 @@ import math
 from .models import Campaign, Category
 from .schemas import CampaignListResponse, CampaignOut
 
-router = Router(tags=["campaigns"])
+router = Router()  # tags 제거 - URL prefix가 자동으로 태그가 됨
 
 
 def calculate_distance(lat1: Decimal, lng1: Decimal, lat2: Decimal, lng2: Decimal) -> float:

--- a/server/campaigns/category_api.py
+++ b/server/campaigns/category_api.py
@@ -15,7 +15,7 @@ from .category_schemas import (
     CategoryOrderUpdate
 )
 
-router = Router(tags=["categories"])
+router = Router()  # tags 제거 - URL prefix가 자동으로 태그가 됨
 
 
 @router.get("/", response=List[CategoryOut], summary="카테고리 목록 조회")

--- a/server/config/settings.py
+++ b/server/config/settings.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     # Third-party apps
+    'corsheaders',  # CORS 설정
     'ninja',
     # Local apps
     'users',
@@ -51,6 +52,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',  # WhiteNoise - static 파일 서빙
+    'corsheaders.middleware.CorsMiddleware',  # CORS - 최상단 가까이 위치
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -151,3 +153,40 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # Custom User Model
 AUTH_USER_MODEL = 'users.User'
+
+# CORS (Cross-Origin Resource Sharing) 설정
+# Mobile app (Android/iOS)에서 API 호출을 위한 설정
+# Mobile app은 Origin 헤더가 없거나 null이므로 모든 origin 허용
+CORS_ALLOW_ALL_ORIGINS = True  # Mobile app 지원
+
+# 또는 특정 도메인만 허용하려면 아래 사용 (웹 클라이언트 추가 시)
+# CORS_ALLOWED_ORIGINS = [
+#     "https://review-maps.com",
+#     "https://www.review-maps.com",
+# ]
+
+# CORS 허용 메서드
+CORS_ALLOW_METHODS = [
+    'DELETE',
+    'GET',
+    'OPTIONS',
+    'PATCH',
+    'POST',
+    'PUT',
+]
+
+# CORS 허용 헤더
+CORS_ALLOW_HEADERS = [
+    'accept',
+    'accept-encoding',
+    'authorization',
+    'content-type',
+    'dnt',
+    'origin',
+    'user-agent',
+    'x-csrftoken',
+    'x-requested-with',
+]
+
+# Credentials 허용 (쿠키, 인증 헤더 등)
+CORS_ALLOW_CREDENTIALS = True

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "django>=5.2.8",
+    "django-cors-headers>=4.9.0",
     "django-ninja>=1.5.0",
     "dotenv>=0.9.9",
     "gunicorn>=23.0.0",

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -56,6 +56,19 @@ wheels = [
 ]
 
 [[package]]
+name = "django-cors-headers"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/39/55822b15b7ec87410f34cd16ce04065ff390e50f9e29f31d6d116fc80456/django_cors_headers-4.9.0.tar.gz", hash = "sha256:fe5d7cb59fdc2c8c646ce84b727ac2bca8912a247e6e68e1fb507372178e59e8", size = 21458, upload-time = "2025-09-18T10:40:52.326Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/d8/19ed1e47badf477d17fb177c1c19b5a21da0fd2d9f093f23be3fb86c5fab/django_cors_headers-4.9.0-py3-none-any.whl", hash = "sha256:15c7f20727f90044dcee2216a9fd7303741a864865f0c3657e28b7056f61b449", size = 12809, upload-time = "2025-09-18T10:40:50.843Z" },
+]
+
+[[package]]
 name = "django-ninja"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -319,6 +332,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "django" },
+    { name = "django-cors-headers" },
     { name = "django-ninja" },
     { name = "dotenv" },
     { name = "gunicorn" },
@@ -338,6 +352,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "django", specifier = ">=5.2.8" },
+    { name = "django-cors-headers", specifier = ">=4.9.0" },
     { name = "django-ninja", specifier = ">=1.5.0" },
     { name = "dotenv", specifier = ">=0.9.9" },
     { name = "gunicorn", specifier = ">=23.0.0" },


### PR DESCRIPTION
## 📝 Summary
Swagger UI에서 API 태그가 중복 표시되는 문제를 해결하고, Mobile App (Android/iOS)에서 API 호출을 위한 CORS 설정을 추가합니다.

## 🐛 Problem 1: Swagger API 태그 중복
**현상:**
- Swagger UI에서 "campaigns/campaigns", "categories/categories"로 중복 표시
- URL: `/v1/campaigns` + Router tags: `["campaigns"]` → 중복

**원인:**
- `api.add_router("/campaigns", campaigns_router)` - URL prefix
- `Router(tags=["campaigns"])` - 명시적 태그
- Django Ninja가 두 가지를 모두 조합하여 중복 표시

## 🐛 Problem 2: Mobile App CORS 제한
**현상:**
- Android/iOS 앱에서 API 호출 시 CORS 오류 발생
- Mobile app은 Origin 헤더가 없거나 null

**요구사항:**
- 패키지명: com.reviewmaps.mobile
- Android/iOS 모두 지원 필요

## 🔧 Solution

### 1️⃣ API 태그 중복 해결

**campaigns/api.py, campaigns/category_api.py:**
```python
# Before
router = Router(tags=["campaigns"])

# After
router = Router()  # URL prefix가 자동으로 태그가 됨
```

**결과:**
- ✅ Swagger UI에 "campaigns", "categories"로 깔끔하게 표시
- ✅ URL 구조와 태그가 일치

### 2️⃣ Mobile App CORS 설정

**django-cors-headers 추가:**
```bash
uv add django-cors-headers
```

**config/settings.py:**
```python
INSTALLED_APPS = [
    ...
    'corsheaders',  # CORS 설정
    ...
]

MIDDLEWARE = [
    'django.middleware.security.SecurityMiddleware',
    'whitenoise.middleware.WhiteNoiseMiddleware',
    'corsheaders.middleware.CorsMiddleware',  # CommonMiddleware 전에 위치
    ...
]

# CORS 설정 - Mobile app 지원
CORS_ALLOW_ALL_ORIGINS = True  # Android/iOS 지원
CORS_ALLOW_CREDENTIALS = True  # 인증 헤더 지원
```

## ✅ Benefits

### API 태그 개선
✅ Swagger UI 가독성 향상  
✅ API 문서 구조 명확화  
✅ 태그와 URL 구조 일치  

### CORS 설정
✅ Android/iOS 앱에서 API 호출 가능  
✅ 모든 HTTP 메서드 지원 (GET, POST, PUT, DELETE 등)  
✅ 인증 헤더 및 Credentials 지원  
✅ 웹 클라이언트 추가 시 특정 도메인만 허용 가능 (주석으로 가이드 제공)  

## 🔒 Security Note

**Mobile App 환경:**
- Mobile app은 Origin 헤더가 없거나 null이므로 `CORS_ALLOW_ALL_ORIGINS = True` 필요
- Mobile app 패키지명 검증은 API 인증 레벨에서 처리 권장

**웹 클라이언트 추가 시:**
```python
# 특정 도메인만 허용
CORS_ALLOW_ALL_ORIGINS = False
CORS_ALLOWED_ORIGINS = [
    "https://review-maps.com",
    "https://www.review-maps.com",
]
```

## 🧪 Test Plan
- [ ] Swagger UI에서 태그가 "campaigns", "categories"로 정상 표시되는지 확인
- [ ] Android 앱에서 API 호출 테스트 (com.reviewmaps.mobile)
- [ ] iOS 앱에서 API 호출 테스트 (com.reviewmaps.mobile)
- [ ] OPTIONS preflight 요청 정상 응답 확인
- [ ] 인증 헤더와 함께 API 호출 테스트

## 📊 Impact
✅ Swagger UI 가독성 향상으로 개발자 경험 개선  
✅ Mobile app (Android/iOS) API 통신 가능  
✅ 향후 웹 클라이언트 추가 시 쉽게 도메인 제한 가능  

## 🔗 Related
- Mobile App Package: com.reviewmaps.mobile
- Django CORS Headers: https://github.com/adamchainz/django-cors-headers
- Django Ninja Tags: https://django-ninja.rest-framework.com/