### PR TITLE
fix: Kubernetes 헬스체크 엔드포인트 400 에러 수정

### DIFF
--- a/server/campaigns/health_api.py
+++ b/server/campaigns/health_api.py
@@ -1,0 +1,16 @@
+from ninja import Router
+
+router = Router()
+
+
+@router.get("/healthz", summary="헬스체크")
+def health_check(request):
+    """
+    Kubernetes 헬스체크 엔드포인트
+    서버가 정상적으로 실행 중이면 200 OK 반환
+    """
+    return {
+        "status": "healthy",
+        "service": "reviewmaps-server",
+        "version": "1.0.0"
+    }

--- a/server/config/urls.py
+++ b/server/config/urls.py
@@ -16,19 +16,10 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
-from django.http import JsonResponse
 from ninja import NinjaAPI
 from campaigns.api import router as campaigns_router
 from campaigns.category_api import router as categories_router
-
-# Health check view
-def health_check(request):
-    """Kubernetes health check endpoint"""
-    return JsonResponse({
-        "status": "healthy",
-        "service": "reviewmaps-server",
-        "version": "1.0.0"
-    })
+from campaigns.health_api import router as health_router
 
 # Django Ninja API 인스턴스 생성
 api = NinjaAPI(
@@ -40,9 +31,9 @@ api = NinjaAPI(
 # 라우터 등록
 api.add_router("/campaigns", campaigns_router)
 api.add_router("/categories", categories_router)
+api.add_router("", health_router)  # /v1/healthz로 접근
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('v1/', api.urls),  # /v1/campaigns, /v1/categories로 접근
-    path('v1/healthz', health_check, name='health'),  # Kubernetes health check
+    path('v1/', api.urls),  # /v1/campaigns, /v1/categories, /v1/healthz로 접근
 ]


### PR DESCRIPTION
## 문제 상황
Kubernetes가 `/v1/healthz` 엔드포인트를 호출할 때 400 Bad Request 에러가 발생했습니다.

```
10.42.2.1:49384 - "GET /v1/healthz HTTP/1.1" 400
10.42.2.1:55700 - "GET /v1/healthz HTTP/1.1" 400
```

## 원인 분석
- `/v1/healthz`가 Django 일반 뷰로 구현되어 있었음
- Django Ninja API가 `/v1/` prefix를 사용하면서 라우팅 충돌 발생
- Ninja API의 요청 검증 로직에 의해 400 에러 반환

## 해결 방법

### 1. Django Ninja Router로 헬스체크 구현
`campaigns/health_api.py` 신규 생성:
```python
from ninja import Router

router = Router()

@router.get("/healthz", summary="헬스체크")
def health_check(request):
    return {
        "status": "healthy",
        "service": "reviewmaps-server",
        "version": "1.0.0"
    }
```

### 2. 라우터 등록
`config/urls.py` 수정:
- Django 일반 뷰 제거
- `health_router`를 Ninja API에 등록
- `/v1/healthz` 경로 유지

## 변경 사항
- ✅ `campaigns/health_api.py` 신규 생성
- ✅ `config/urls.py` Django 일반 뷰 제거 및 Ninja Router 등록
- ✅ `/v1/healthz` 경로 유지 (Kubernetes와 호환)

## 테스트
- [x] `python manage.py check` 통과
- [x] Django Ninja API 구조 검증

## 예상 결과
이제 Kubernetes가 `/v1/healthz`를 호출하면:
```
HTTP/1.1 200 OK
{
  "status": "healthy",
  "service": "reviewmaps-server",
  "version": "1.0.0"
}
```

## 참고
- backup 폴더의 FastAPI 구현 참고
- Kubernetes liveness/readiness probe와 호환