### PR TITLE
fix: healthz 엔드포인트 400 에러 수정 (파라미터 검증 문제)

### DIFF
--- a/server/campaigns/health_api.py
+++ b/server/campaigns/health_api.py
@@ -4,10 +4,13 @@ router = Router()
 
 
 @router.get("/healthz", summary="헬스체크")
-def health_check(request):
+def health_check():
     """
     Kubernetes 헬스체크 엔드포인트
     서버가 정상적으로 실행 중이면 200 OK 반환
+
+    Note: Django Ninja에서 타입 힌트 없는 파라미터는 쿼리 파라미터로 해석되므로
+    헬스체크처럼 파라미터가 필요 없는 경우 함수 시그니처에서 제거해야 함
     """
     return {
         "status": "healthy",


### PR DESCRIPTION
## 문제 상황
Kubernetes가 `/v1/healthz` 엔드포인트를 호출할 때 계속 400 Bad Request 에러가 발생:

```
10.42.2.1:43986 - "GET /v1/healthz HTTP/1.1" 400
10.42.2.1:38676 - "GET /v1/healthz HTTP/1.1" 400
```

## 근본 원인 분석 (Sequential Thinking)

Django Ninja의 파라미터 처리 메커니즘:
- **타입 힌트가 있는 파라미터**: 자동으로 타입 검증
- **타입 힌트가 없는 파라미터**: 쿼리/경로/바디 파라미터로 해석

### 문제가 된 코드:
```python
@router.get("/healthz")
def health_check(request):  # ← request를 쿼리 파라미터로 해석!
    return {...}
```

### 동작 흐름:
1. Kubernetes: `GET /v1/healthz` 호출 (쿼리 파라미터 없음)
2. Django Ninja: 'request' 쿼리 파라미터 찾으려 시도
3. 파라미터 없음 → 검증 실패
4. **400 Bad Request** 반환

## 해결 방법

backup 폴더의 FastAPI 구현을 참고하여 파라미터 제거:

### Before:
```python
def health_check(request):
    return {...}
```

### After:
```python
def health_check():  # 파라미터 완전 제거
    return {...}
```

### 추가 개선:
- 향후 같은 실수 방지를 위한 주석 추가
- Django Ninja 파라미터 해석 방식 설명

## 변경 사항
- ✅ `campaigns/health_api.py`: request 파라미터 제거
- ✅ 설명 주석 추가
- ✅ `python manage.py check` 검증 통과

## 예상 결과
이제 Kubernetes 헬스체크가 정상 작동:
```
GET /v1/healthz
HTTP/1.1 200 OK
{
  "status": "healthy",
  "service": "reviewmaps-server",
  "version": "1.0.0"
}
```

## 참고
- CORS/CSRF는 문제가 아니었음 (GET 요청, Origin 헤더 없음)
- 실제 원인은 Django Ninja의 파라미터 자동 검증 메커니즘