### PR TITLE
feat: 인증 API 통합 및 내정보 화면 구현

### DIFF
--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -205,7 +205,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1640;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C8080294A63A400263BE5 = {
@@ -268,13 +268,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -364,13 +360,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/mobile/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/mobile/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1640"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/mobile/lib/models/auth_models.dart
+++ b/mobile/lib/models/auth_models.dart
@@ -124,7 +124,7 @@ class UserInfo {
 
   factory UserInfo.fromJson(Map<String, dynamic> json) {
     return UserInfo(
-      id: json['id'] as String,
+      id: json['id'].toString(), // int 또는 String을 안전하게 String으로 변환
       email: json['email'] as String,
       name: json['name'] as String?,
       isAnonymous: json['is_anonymous'] as bool? ?? false,

--- a/mobile/lib/models/auth_models.dart
+++ b/mobile/lib/models/auth_models.dart
@@ -1,0 +1,140 @@
+/// 인증 관련 모델 클래스들
+/// - API 요청/응답 데이터 구조 정의
+/// - JSON 직렬화/역직렬화 지원
+
+/// 회원가입 요청 데이터
+class SignUpRequest {
+  final String email;
+  final String password;
+
+  SignUpRequest({
+    required this.email,
+    required this.password,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'email': email,
+    'password': password,
+  };
+}
+
+/// 로그인 요청 데이터
+class LoginRequest {
+  final String email;
+  final String password;
+
+  LoginRequest({
+    required this.email,
+    required this.password,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'email': email,
+    'password': password,
+  };
+}
+
+/// 토큰 갱신 요청 데이터
+class RefreshTokenRequest {
+  final String refreshToken;
+
+  RefreshTokenRequest({
+    required this.refreshToken,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'refresh_token': refreshToken,
+  };
+}
+
+/// 익명 사용자 전환 요청 데이터
+class ConvertAnonymousRequest {
+  final String sessionToken;
+  final String email;
+  final String password;
+
+  ConvertAnonymousRequest({
+    required this.sessionToken,
+    required this.email,
+    required this.password,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'session_token': sessionToken,
+    'email': email,
+    'password': password,
+  };
+}
+
+/// 인증 응답 데이터 (access_token, refresh_token)
+class AuthResponse {
+  final String accessToken;
+  final String refreshToken;
+
+  AuthResponse({
+    required this.accessToken,
+    required this.refreshToken,
+  });
+
+  factory AuthResponse.fromJson(Map<String, dynamic> json) {
+    return AuthResponse(
+      accessToken: json['access_token'] as String,
+      refreshToken: json['refresh_token'] as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'access_token': accessToken,
+    'refresh_token': refreshToken,
+  };
+}
+
+/// 익명 로그인 응답 데이터 (session_token)
+class AnonymousResponse {
+  final String sessionToken;
+
+  AnonymousResponse({
+    required this.sessionToken,
+  });
+
+  factory AnonymousResponse.fromJson(Map<String, dynamic> json) {
+    return AnonymousResponse(
+      sessionToken: json['session_token'] as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'session_token': sessionToken,
+  };
+}
+
+/// 사용자 정보 응답 데이터
+class UserInfo {
+  final String id;
+  final String email;
+  final String? name;
+  final bool isAnonymous;
+
+  UserInfo({
+    required this.id,
+    required this.email,
+    this.name,
+    required this.isAnonymous,
+  });
+
+  factory UserInfo.fromJson(Map<String, dynamic> json) {
+    return UserInfo(
+      id: json['id'] as String,
+      email: json['email'] as String,
+      name: json['name'] as String?,
+      isAnonymous: json['is_anonymous'] as bool? ?? false,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'email': email,
+    'name': name,
+    'is_anonymous': isAnonymous,
+  };
+}

--- a/mobile/lib/screens/auth/login_screen.dart
+++ b/mobile/lib/screens/auth/login_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:mobile/screens/auth/sign_up_screen.dart';
 import 'package:mobile/screens/main_screen.dart';
 import 'package:mobile/services/auth_service.dart';
+import 'package:mobile/const/colors.dart';
 
 /// Login Version 1 화면
 /// Figma 디자인을 기반으로 한 로그인 화면
@@ -34,8 +35,13 @@ class _LoginScreenState extends State<LoginScreen> {
     final password = _passwordController.text.trim();
 
     // 유효성 검사
-    if (email.isEmpty || password.isEmpty) {
-      _showErrorDialog('이메일과 비밀번호를 입력해 주세요.');
+    if (email.isEmpty) {
+      _showErrorDialog('이메일을 입력해 주세요.');
+      return;
+    }
+
+    if (password.isEmpty) {
+      _showErrorDialog('비밀번호를 입력해 주세요.');
       return;
     }
 
@@ -57,9 +63,24 @@ class _LoginScreenState extends State<LoginScreen> {
     } catch (e) {
       if (!mounted) return;
 
-      String errorMessage = '로그인에 실패했습니다.';
-      if (e.toString().contains('Exception:')) {
-        errorMessage = e.toString().replaceAll('Exception:', '').trim();
+      String errorMessage = '로그인할 수 없습니다.\n잠시 후 다시 시도해 주세요.';
+      final errorText = e.toString();
+
+      if (errorText.contains('Exception:')) {
+        final serverMessage = errorText.replaceAll('Exception:', '').trim();
+
+        // 서버에서 온 에러 메시지를 네이버 스타일로 변환
+        if (serverMessage.contains('Invalid credentials') ||
+            serverMessage.contains('incorrect') ||
+            serverMessage.contains('wrong')) {
+          errorMessage = '아이디 또는 비밀번호를 다시 확인해 주세요.\n등록되지 않은 아이디이거나, 아이디 또는 비밀번호를 잘못 입력하셨습니다.';
+        } else if (serverMessage.contains('not found') || serverMessage.contains('존재하지')) {
+          errorMessage = '등록되지 않은 이메일입니다.\n이메일을 다시 확인해 주세요.';
+        } else if (serverMessage.contains('network') || serverMessage.contains('timeout')) {
+          errorMessage = '네트워크 연결이 불안정합니다.\n잠시 후 다시 시도해 주세요.';
+        } else {
+          errorMessage = serverMessage;
+        }
       }
 
       _showErrorDialog(errorMessage);
@@ -92,9 +113,17 @@ class _LoginScreenState extends State<LoginScreen> {
     } catch (e) {
       if (!mounted) return;
 
-      String errorMessage = '익명 로그인에 실패했습니다.';
-      if (e.toString().contains('Exception:')) {
-        errorMessage = e.toString().replaceAll('Exception:', '').trim();
+      String errorMessage = '일시적인 오류가 발생했습니다.\n잠시 후 다시 시도해 주세요.';
+      final errorText = e.toString();
+
+      if (errorText.contains('Exception:')) {
+        final serverMessage = errorText.replaceAll('Exception:', '').trim();
+
+        if (serverMessage.contains('network') || serverMessage.contains('timeout')) {
+          errorMessage = '네트워크 연결이 불안정합니다.\n잠시 후 다시 시도해 주세요.';
+        } else {
+          errorMessage = serverMessage;
+        }
       }
 
       _showErrorDialog(errorMessage);
@@ -376,8 +405,8 @@ class _LoginScreenState extends State<LoginScreen> {
           begin: Alignment.topCenter,
           end: Alignment.bottomCenter,
           colors: [
-            const Color(0xFF1D61E7),
-            const Color(0xFF1D61E7),
+            PRIMARY_COLOR,
+            PRIMARY_COLOR,
           ],
         ),
         borderRadius: BorderRadius.circular(10.r),
@@ -385,7 +414,7 @@ class _LoginScreenState extends State<LoginScreen> {
       child: ElevatedButton(
         onPressed: _isLoading ? null : _handleLogin,
         style: ElevatedButton.styleFrom(
-          backgroundColor: const Color(0xFF1D61E7),
+          backgroundColor: PRIMARY_COLOR,
           foregroundColor: Colors.white,
           elevation: 0,
           shape: RoundedRectangleBorder(

--- a/mobile/lib/screens/auth/login_screen.dart
+++ b/mobile/lib/screens/auth/login_screen.dart
@@ -163,18 +163,18 @@ class _LoginScreenState extends State<LoginScreen> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              SizedBox(height: 56.h),
-              
+              SizedBox(height: 32.h),
+
               // 헤드라인
               _buildHeadline(),
-              
-              SizedBox(height: 32.h),
+
+              SizedBox(height: 24.h),
               
               // 이메일 입력 필드
               _buildInputField(
-                title: 'Email',
+                title: '이메일',
                 controller: _emailController,
-                hintText: 'Loisbecket@gmail.com',
+                hintText: '이메일을 입력해 주세요',
                 prefixIcon: Icons.person_outline,
               ),
               
@@ -185,46 +185,46 @@ class _LoginScreenState extends State<LoginScreen> {
               
               SizedBox(height: 8.h),
               
-              // Forgot Password
+              // 비밀번호 찾기
               Align(
                 alignment: Alignment.centerRight,
                 child: TextButton(
                   onPressed: () {
-                    // TODO: Forgot Password 처리
+                    // TODO: 비밀번호 찾기 처리
                   },
                   child: Text(
-                    'Forgot Password ?',
+                    '비밀번호를 잊으셨나요?',
                     style: TextStyle(
                       fontSize: 12.sp,
                       fontWeight: FontWeight.w600,
-                      color: const Color(0xFF4D81E7),
+                      color: PRIMARY_COLOR,
                       letterSpacing: -0.12,
                     ),
                   ),
                 ),
               ),
+
+              SizedBox(height: 12.h),
               
-              SizedBox(height: 16.h),
-              
-              // Log In 버튼
+              // 로그인 버튼
               _buildLoginButton(),
-              
-              SizedBox(height: 16.h),
-              
-              // Or 구분선
+
+              SizedBox(height: 12.h),
+
+              // 또는 구분선
               _buildOrDivider(),
-              
-              SizedBox(height: 16.h),
-              
+
+              SizedBox(height: 12.h),
+
               // 소셜 로그인 버튼들
               _buildSocialLoginButtons(),
-              
-              SizedBox(height: 32.h),
-              
-              // Sign Up 링크
+
+              SizedBox(height: 20.h),
+
+              // 회원가입 링크
               _buildSignUpLink(),
-              
-              SizedBox(height: 32.h),
+
+              SizedBox(height: 24.h),
             ],
           ),
         ),
@@ -238,7 +238,7 @@ class _LoginScreenState extends State<LoginScreen> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          'Sign in',
+          '로그인',
           style: TextStyle(
             fontSize: 32.sp,
             fontWeight: FontWeight.w700,
@@ -249,7 +249,7 @@ class _LoginScreenState extends State<LoginScreen> {
         ),
         SizedBox(height: 12.h),
         Text(
-          'Enter your email and password to log in ',
+          '이메일과 비밀번호를 입력해 주세요',
           style: TextStyle(
             fontSize: 12.sp,
             fontWeight: FontWeight.w500,
@@ -329,7 +329,7 @@ class _LoginScreenState extends State<LoginScreen> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          'Password',
+          '비밀번호',
           style: TextStyle(
             fontSize: 12.sp,
             fontWeight: FontWeight.w500,
@@ -358,7 +358,7 @@ class _LoginScreenState extends State<LoginScreen> {
               letterSpacing: -0.14,
             ),
             decoration: InputDecoration(
-              hintText: '*******',
+              hintText: '비밀번호를 입력해 주세요',
               hintStyle: TextStyle(
                 fontSize: 14.sp,
                 fontWeight: FontWeight.w500,
@@ -481,30 +481,30 @@ class _LoginScreenState extends State<LoginScreen> {
       children: [
         // Google
         _buildSocialButton(
-          text: 'Continue with Google',
+          text: 'Google로 시작하기',
           onPressed: () {
             // TODO: Google 로그인
           },
         ),
-        SizedBox(height: 15.h),
-        
+        SizedBox(height: 12.h),
+
         // Apple
         _buildSocialButton(
-          text: 'Continue with Apple',
+          text: 'Apple로 시작하기',
           onPressed: () {
             // TODO: Apple 로그인
           },
         ),
-        SizedBox(height: 15.h),
-        
+        SizedBox(height: 12.h),
+
         // Kakao
         _buildSocialButton(
-          text: 'Continue with Kakao',
+          text: 'Kakao로 시작하기',
           onPressed: () {
             // TODO: Kakao 로그인
           },
         ),
-        SizedBox(height: 15.h),
+        SizedBox(height: 12.h),
         
         // 회원가입 없이 시작하기
         _buildSocialButton(

--- a/mobile/lib/screens/auth/sign_up_screen.dart
+++ b/mobile/lib/screens/auth/sign_up_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:mobile/screens/main_screen.dart';
 import 'package:mobile/services/auth_service.dart';
+import 'package:mobile/const/colors.dart';
 
 /// Sign Up Version 1 화면
 /// Figma 디자인을 기반으로 한 회원가입 화면
@@ -39,21 +40,26 @@ class _SignUpScreenState extends State<SignUpScreen> {
     final password = _passwordController.text.trim();
 
     // 유효성 검사
-    if (email.isEmpty || password.isEmpty) {
-      _showErrorDialog('이메일과 비밀번호를 입력해 주세요.');
+    if (email.isEmpty) {
+      _showErrorDialog('이메일을 입력해 주세요.');
       return;
     }
 
     // 이메일 형식 검증
     final emailRegex = RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$');
     if (!emailRegex.hasMatch(email)) {
-      _showErrorDialog('올바른 이메일 형식이 아닙니다.');
+      _showErrorDialog('이메일 주소를 다시 확인해 주세요.\n올바른 형식의 이메일을 입력해 주세요.');
+      return;
+    }
+
+    if (password.isEmpty) {
+      _showErrorDialog('비밀번호를 입력해 주세요.');
       return;
     }
 
     // 비밀번호 길이 검증
     if (password.length < 6) {
-      _showErrorDialog('비밀번호는 최소 6자 이상이어야 합니다.');
+      _showErrorDialog('비밀번호는 6자 이상 입력해 주세요.');
       return;
     }
 
@@ -75,9 +81,26 @@ class _SignUpScreenState extends State<SignUpScreen> {
     } catch (e) {
       if (!mounted) return;
 
-      String errorMessage = '회원가입에 실패했습니다.';
-      if (e.toString().contains('Exception:')) {
-        errorMessage = e.toString().replaceAll('Exception:', '').trim();
+      String errorMessage = '회원가입할 수 없습니다.\n잠시 후 다시 시도해 주세요.';
+      final errorText = e.toString();
+
+      if (errorText.contains('Exception:')) {
+        final serverMessage = errorText.replaceAll('Exception:', '').trim();
+
+        // 서버에서 온 에러 메시지를 네이버 스타일로 변환
+        if (serverMessage.contains('already exists') ||
+            serverMessage.contains('duplicate') ||
+            serverMessage.contains('이미')) {
+          errorMessage = '이미 가입된 이메일입니다.\n다른 이메일을 사용하시거나 로그인해 주세요.';
+        } else if (serverMessage.contains('invalid email') || serverMessage.contains('이메일')) {
+          errorMessage = '이메일 주소를 다시 확인해 주세요.';
+        } else if (serverMessage.contains('password') && serverMessage.contains('weak')) {
+          errorMessage = '더 안전한 비밀번호를 사용해 주세요.\n영문, 숫자, 특수문자를 조합해 주세요.';
+        } else if (serverMessage.contains('network') || serverMessage.contains('timeout')) {
+          errorMessage = '네트워크 연결이 불안정합니다.\n잠시 후 다시 시도해 주세요.';
+        } else {
+          errorMessage = serverMessage;
+        }
       }
 
       _showErrorDialog(errorMessage);
@@ -525,8 +548,8 @@ class _SignUpScreenState extends State<SignUpScreen> {
           begin: Alignment.topCenter,
           end: Alignment.bottomCenter,
           colors: [
-            const Color(0xFF1D61E7),
-            const Color(0xFF1D61E7),
+            PRIMARY_COLOR,
+            PRIMARY_COLOR,
           ],
         ),
         borderRadius: BorderRadius.circular(10.r),
@@ -534,7 +557,7 @@ class _SignUpScreenState extends State<SignUpScreen> {
       child: ElevatedButton(
         onPressed: _isLoading ? null : _handleSignUp,
         style: ElevatedButton.styleFrom(
-          backgroundColor: const Color(0xFF1D61E7),
+          backgroundColor: PRIMARY_COLOR,
           foregroundColor: Colors.white,
           elevation: 0,
           shape: RoundedRectangleBorder(

--- a/mobile/lib/screens/auth/sign_up_screen.dart
+++ b/mobile/lib/screens/auth/sign_up_screen.dart
@@ -140,8 +140,8 @@ class _SignUpScreenState extends State<SignUpScreen> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              SizedBox(height: 32.h),
-              
+              SizedBox(height: 24.h),
+
               // 뒤로가기 버튼
               IconButton(
                 icon: Icon(
@@ -155,29 +155,29 @@ class _SignUpScreenState extends State<SignUpScreen> {
                 padding: EdgeInsets.zero,
                 constraints: const BoxConstraints(),
               ),
-              
-              SizedBox(height: 24.h),
-              
+
+              SizedBox(height: 16.h),
+
               // 헤드라인
               _buildHeadline(),
+
+              SizedBox(height: 24.h),
               
-              SizedBox(height: 32.h),
-              
-              // Full Name 입력 필드
+              // 이름 입력 필드
               _buildInputField(
-                title: 'Full Name',
+                title: '이름',
                 controller: _fullNameController,
-                hintText: 'Lois Becket',
+                hintText: '이름을 입력해 주세요',
                 prefixIcon: Icons.person_outline,
               ),
-              
+
               SizedBox(height: 16.h),
-              
-              // Email 입력 필드
+
+              // 이메일 입력 필드
               _buildInputField(
-                title: 'Email',
+                title: '이메일',
                 controller: _emailController,
-                hintText: 'Loisbecket@gmail.com',
+                hintText: '이메일을 입력해 주세요',
                 prefixIcon: Icons.email_outlined,
               ),
               
@@ -196,17 +196,17 @@ class _SignUpScreenState extends State<SignUpScreen> {
               // Set Password 입력 필드
               _buildPasswordField(),
               
-              SizedBox(height: 24.h),
-              
-              // Register 버튼
+              SizedBox(height: 20.h),
+
+              // 가입하기 버튼
               _buildRegisterButton(),
-              
-              SizedBox(height: 24.h),
-              
-              // Login 링크
+
+              SizedBox(height: 20.h),
+
+              // 로그인 링크
               _buildLoginLink(),
-              
-              SizedBox(height: 32.h),
+
+              SizedBox(height: 24.h),
             ],
           ),
         ),
@@ -220,7 +220,7 @@ class _SignUpScreenState extends State<SignUpScreen> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          'Sign up',
+          '회원가입',
           style: TextStyle(
             fontSize: 32.sp,
             fontWeight: FontWeight.w700,
@@ -231,7 +231,7 @@ class _SignUpScreenState extends State<SignUpScreen> {
         ),
         SizedBox(height: 12.h),
         Text(
-          'Create an account to continue!',
+          '계정을 만들어 서비스를 시작하세요',
           style: TextStyle(
             fontSize: 12.sp,
             fontWeight: FontWeight.w500,
@@ -285,8 +285,8 @@ class _SignUpScreenState extends State<SignUpScreen> {
               hintText: hintText,
               hintStyle: TextStyle(
                 fontSize: 14.sp,
-                fontWeight: FontWeight.w500,
-                color: const Color(0xFF1A1C1E),
+                fontWeight: FontWeight.w400,
+                color: const Color(0xFFADB5BD),
               ),
               prefixIcon: Icon(
                 prefixIcon,
@@ -311,7 +311,7 @@ class _SignUpScreenState extends State<SignUpScreen> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          'Birth of date',
+          '생년월일',
           style: TextStyle(
             fontSize: 12.sp,
             fontWeight: FontWeight.w500,
@@ -352,11 +352,11 @@ class _SignUpScreenState extends State<SignUpScreen> {
               letterSpacing: -0.14,
             ),
             decoration: InputDecoration(
-              hintText: '18/03/2024',
+              hintText: '생년월일을 선택해 주세요',
               hintStyle: TextStyle(
                 fontSize: 14.sp,
-                fontWeight: FontWeight.w500,
-                color: const Color(0xFF1A1C1E),
+                fontWeight: FontWeight.w400,
+                color: const Color(0xFFADB5BD),
               ),
               prefixIcon: Icon(
                 Icons.calendar_today_outlined,
@@ -386,7 +386,7 @@ class _SignUpScreenState extends State<SignUpScreen> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          'Phone Number',
+          '휴대전화',
           style: TextStyle(
             fontSize: 12.sp,
             fontWeight: FontWeight.w500,
@@ -445,11 +445,11 @@ class _SignUpScreenState extends State<SignUpScreen> {
                     letterSpacing: -0.14,
                   ),
                   decoration: InputDecoration(
-                    hintText: '(454) 726-0592',
+                    hintText: '휴대전화 번호를 입력해 주세요',
                     hintStyle: TextStyle(
                       fontSize: 14.sp,
-                      fontWeight: FontWeight.w500,
-                      color: const Color(0xFF1A1C1E),
+                      fontWeight: FontWeight.w400,
+                      color: const Color(0xFFADB5BD),
                     ),
                     border: InputBorder.none,
                     contentPadding: EdgeInsets.symmetric(
@@ -472,7 +472,7 @@ class _SignUpScreenState extends State<SignUpScreen> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          'Set Password',
+          '비밀번호',
           style: TextStyle(
             fontSize: 12.sp,
             fontWeight: FontWeight.w500,
@@ -501,11 +501,11 @@ class _SignUpScreenState extends State<SignUpScreen> {
               letterSpacing: -0.14,
             ),
             decoration: InputDecoration(
-              hintText: '*******',
+              hintText: '비밀번호를 입력해 주세요',
               hintStyle: TextStyle(
                 fontSize: 14.sp,
-                fontWeight: FontWeight.w500,
-                color: const Color(0xFF1A1C1E),
+                fontWeight: FontWeight.w400,
+                color: const Color(0xFFADB5BD),
               ),
               prefixIcon: Icon(
                 Icons.lock_outline,
@@ -593,7 +593,7 @@ class _SignUpScreenState extends State<SignUpScreen> {
         mainAxisSize: MainAxisSize.min,
         children: [
           Text(
-            'Already have an account?',
+            '이미 계정이 있으신가요?',
             style: TextStyle(
               fontSize: 12.sp,
               fontWeight: FontWeight.w500,
@@ -607,7 +607,7 @@ class _SignUpScreenState extends State<SignUpScreen> {
               Navigator.pop(context);
             },
             child: Text(
-              'Login',
+              '로그인',
               style: TextStyle(
                 fontSize: 12.sp,
                 fontWeight: FontWeight.w600,

--- a/mobile/lib/screens/main_screen.dart
+++ b/mobile/lib/screens/main_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:mobile/screens/home_screen.dart';
 import 'package:mobile/screens/map_screen.dart';
+import 'package:mobile/screens/my_page_screen.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:mobile/widgets/friendly.dart';
@@ -19,7 +20,7 @@ import 'package:mobile/providers/location_provider.dart';
 /// MainScreen
 /// ------------------------------------------------------
 /// 하단 탭 내비게이션 컨테이너.
-/// - 탭: 홈 / 지도
+/// - 탭: 홈 / 지도 / 내정보
 /// - 상태 보존: IndexedStack 사용 → 탭 전환 시 각 화면의 상태(스크롤, 지도 컨트롤러 등) 유지
 /// - 배포: 미사용 import/코드 제거, 최소 로직
 class MainScreen extends ConsumerStatefulWidget {
@@ -64,7 +65,7 @@ class _MainScreenState extends ConsumerState<MainScreen> {
     _tabs = [
       const HomeScreen(),
       null, // MapScreen은 아직 생성하지 않음 → 권한 팝업 안뜸
-      // const MyPageScreen(),
+      const MyPageScreen(),
     ];
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -135,6 +136,7 @@ class _MainScreenState extends ConsumerState<MainScreen> {
               children: [
                 _tabs[0]!,
                 _tabs[1] ?? const SizedBox.shrink(),
+                _tabs[2]!,
               ],
             ),
           ),
@@ -151,7 +153,10 @@ class _MainScreenState extends ConsumerState<MainScreen> {
             icon: Icon(Icons.map_outlined, size: (isTab ? 32.0 : 24.0) * (1.0 + (MediaQuery.textScalerOf(context).textScaleFactor - 1.0) * 0.3).clamp(1.0, 1.2)),
             label: '지도'
           ),
-          // BottomNavigationBarItem(icon: Icon(Icons.person_outline), label: '마이'),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.person_outline, size: (isTab ? 32.0 : 24.0) * (1.0 + (MediaQuery.textScalerOf(context).textScaleFactor - 1.0) * 0.3).clamp(1.0, 1.2)),
+            label: '내정보'
+          ),
         ],
         currentIndex: _selectedIndex,
         selectedItemColor: Theme.of(context).primaryColor,

--- a/mobile/lib/screens/my_page_screen.dart
+++ b/mobile/lib/screens/my_page_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:mobile/services/auth_service.dart';
 import 'package:mobile/const/colors.dart';
 import 'package:mobile/screens/auth/login_screen.dart';
+import 'package:mobile/models/auth_models.dart';
 
 /// 내정보 화면
 class MyPageScreen extends StatefulWidget {
@@ -17,7 +18,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
   bool _isLoading = true;
   bool _isLoggedIn = false;
   bool _isAnonymous = false;
-  String? _userEmail;
+  UserInfo? _userInfo;
 
   @override
   void initState() {
@@ -41,19 +42,19 @@ class _MyPageScreenState extends State<MyPageScreen> {
         _isLoading = false;
       });
 
-      // 로그인되어 있고 익명이 아니면 사용자 정보 가져오기
-      if (isLoggedIn && !isAnonymous) {
+      // 로그인되어 있으면 사용자 정보 가져오기
+      if (isLoggedIn) {
         try {
           final userInfo = await _authService.getUserInfo();
           setState(() {
-            _userEmail = userInfo.email;
+            _userInfo = userInfo;
           });
         } catch (e) {
-          print('[MyPageScreen] 사용자 정보 조회 실패: $e');
+          debugPrint('[MyPageScreen] 사용자 정보 조회 실패: $e');
         }
       }
     } catch (e) {
-      print('[MyPageScreen] 로그인 상태 확인 실패: $e');
+      debugPrint('[MyPageScreen] 로그인 상태 확인 실패: $e');
       setState(() {
         _isLoading = false;
       });
@@ -159,10 +160,21 @@ class _MyPageScreenState extends State<MyPageScreen> {
                     SizedBox(height: 32.h),
 
                     // 계정 정보
-                    if (_isLoggedIn && !_isAnonymous) ...[
+                    if (_isLoggedIn && _userInfo != null) ...[
                       _buildSectionTitle('계정 정보'),
                       SizedBox(height: 16.h),
-                      _buildInfoItem('이메일', _userEmail ?? '정보 없음'),
+                      _buildInfoItem('사용자 ID', _userInfo!.id),
+                      SizedBox(height: 12.h),
+                      if (_userInfo!.name != null) ...[
+                        _buildInfoItem('이름', _userInfo!.name!),
+                        SizedBox(height: 12.h),
+                      ],
+                      _buildInfoItem('이메일', _userInfo!.email),
+                      SizedBox(height: 12.h),
+                      _buildInfoItem(
+                        '계정 유형',
+                        _userInfo!.isAnonymous ? '익명 사용자' : '일반 사용자'
+                      ),
                       SizedBox(height: 32.h),
                     ],
 
@@ -190,7 +202,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
         ),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.05),
+            color: Colors.black.withValues(alpha: 0.05),
             blurRadius: 10,
             offset: const Offset(0, 2),
           ),
@@ -203,7 +215,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
             width: 80.w,
             height: 80.w,
             decoration: BoxDecoration(
-              color: PRIMARY_COLOR.withOpacity(0.1),
+              color: PRIMARY_COLOR.withValues(alpha: 0.1),
               shape: BoxShape.circle,
             ),
             child: Icon(
@@ -229,12 +241,12 @@ class _MyPageScreenState extends State<MyPageScreen> {
 
           SizedBox(height: 8.h),
 
-          // 사용자 이메일 또는 안내 메시지
+          // 사용자 정보 또는 안내 메시지
           Text(
             _isLoggedIn
-                ? (_isAnonymous
-                    ? '회원가입 없이 이용 중입니다'
-                    : _userEmail ?? '정보를 불러오는 중...')
+                ? (_userInfo != null
+                    ? (_userInfo!.name ?? _userInfo!.email)
+                    : '정보를 불러오는 중...')
                 : '로그인하여 더 많은 기능을 이용하세요',
             style: TextStyle(
               fontSize: 14.sp,

--- a/mobile/lib/screens/my_page_screen.dart
+++ b/mobile/lib/screens/my_page_screen.dart
@@ -1,10 +1,331 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:mobile/services/auth_service.dart';
+import 'package:mobile/const/colors.dart';
+import 'package:mobile/screens/auth/login_screen.dart';
 
-class MyPageScreen extends StatelessWidget {
+/// 내정보 화면
+class MyPageScreen extends StatefulWidget {
   const MyPageScreen({super.key});
 
   @override
+  State<MyPageScreen> createState() => _MyPageScreenState();
+}
+
+class _MyPageScreenState extends State<MyPageScreen> {
+  final AuthService _authService = AuthService();
+  bool _isLoading = true;
+  bool _isLoggedIn = false;
+  bool _isAnonymous = false;
+  String? _userEmail;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadUserInfo();
+  }
+
+  /// 사용자 정보 로드
+  Future<void> _loadUserInfo() async {
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      final isLoggedIn = await _authService.isLoggedIn();
+      final isAnonymous = await _authService.isAnonymous();
+
+      setState(() {
+        _isLoggedIn = isLoggedIn;
+        _isAnonymous = isAnonymous;
+        _isLoading = false;
+      });
+
+      // 로그인되어 있고 익명이 아니면 사용자 정보 가져오기
+      if (isLoggedIn && !isAnonymous) {
+        try {
+          final userInfo = await _authService.getUserInfo();
+          setState(() {
+            _userEmail = userInfo.email;
+          });
+        } catch (e) {
+          print('[MyPageScreen] 사용자 정보 조회 실패: $e');
+        }
+      }
+    } catch (e) {
+      print('[MyPageScreen] 로그인 상태 확인 실패: $e');
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+
+  /// 로그아웃 처리
+  Future<void> _handleLogout() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('로그아웃'),
+        content: const Text('로그아웃 하시겠습니까?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('취소'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(
+              '로그아웃',
+              style: TextStyle(color: PRIMARY_COLOR),
+            ),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true) {
+      setState(() {
+        _isLoading = true;
+      });
+
+      try {
+        await _authService.logout();
+
+        if (!mounted) return;
+
+        // 로그인 화면으로 이동
+        Navigator.of(context).pushAndRemoveUntil(
+          MaterialPageRoute(
+            builder: (context) => const LoginScreen(),
+          ),
+          (route) => false,
+        );
+      } catch (e) {
+        if (!mounted) return;
+
+        showDialog(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: const Text('알림'),
+            content: const Text('로그아웃에 실패했습니다.\n잠시 후 다시 시도해 주세요.'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('확인'),
+              ),
+            ],
+          ),
+        );
+      } finally {
+        if (mounted) {
+          setState(() {
+            _isLoading = false;
+          });
+        }
+      }
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        title: Text(
+          '내정보',
+          style: TextStyle(
+            fontSize: 18.sp,
+            fontWeight: FontWeight.w700,
+            color: const Color(0xFF1A1C1E),
+          ),
+        ),
+        backgroundColor: Colors.white,
+        elevation: 0,
+        centerTitle: true,
+      ),
+      body: _isLoading
+          ? const Center(
+              child: CircularProgressIndicator(),
+            )
+          : SafeArea(
+              child: SingleChildScrollView(
+                padding: EdgeInsets.symmetric(horizontal: 24.w, vertical: 24.h),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // 프로필 카드
+                    _buildProfileCard(),
+
+                    SizedBox(height: 32.h),
+
+                    // 계정 정보
+                    if (_isLoggedIn && !_isAnonymous) ...[
+                      _buildSectionTitle('계정 정보'),
+                      SizedBox(height: 16.h),
+                      _buildInfoItem('이메일', _userEmail ?? '정보 없음'),
+                      SizedBox(height: 32.h),
+                    ],
+
+                    // 로그아웃 버튼
+                    if (_isLoggedIn)
+                      _buildLogoutButton(),
+                  ],
+                ),
+              ),
+            ),
+    );
+  }
+
+  /// 프로필 카드
+  Widget _buildProfileCard() {
+    return Container(
+      width: double.infinity,
+      padding: EdgeInsets.all(24.w),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16.r),
+        border: Border.all(
+          color: const Color(0xFFEDF1F3),
+          width: 1,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 10,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        children: [
+          // 프로필 아이콘
+          Container(
+            width: 80.w,
+            height: 80.w,
+            decoration: BoxDecoration(
+              color: PRIMARY_COLOR.withOpacity(0.1),
+              shape: BoxShape.circle,
+            ),
+            child: Icon(
+              Icons.person,
+              size: 40.sp,
+              color: PRIMARY_COLOR,
+            ),
+          ),
+
+          SizedBox(height: 16.h),
+
+          // 사용자 상태
+          Text(
+            _isLoggedIn
+                ? (_isAnonymous ? '익명 사용자' : '로그인됨')
+                : '로그인 필요',
+            style: TextStyle(
+              fontSize: 20.sp,
+              fontWeight: FontWeight.w700,
+              color: const Color(0xFF1A1C1E),
+            ),
+          ),
+
+          SizedBox(height: 8.h),
+
+          // 사용자 이메일 또는 안내 메시지
+          Text(
+            _isLoggedIn
+                ? (_isAnonymous
+                    ? '회원가입 없이 이용 중입니다'
+                    : _userEmail ?? '정보를 불러오는 중...')
+                : '로그인하여 더 많은 기능을 이용하세요',
+            style: TextStyle(
+              fontSize: 14.sp,
+              fontWeight: FontWeight.w500,
+              color: const Color(0xFF6C7278),
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 섹션 제목
+  Widget _buildSectionTitle(String title) {
+    return Text(
+      title,
+      style: TextStyle(
+        fontSize: 16.sp,
+        fontWeight: FontWeight.w700,
+        color: const Color(0xFF1A1C1E),
+      ),
+    );
+  }
+
+  /// 정보 항목
+  Widget _buildInfoItem(String label, String value) {
+    return Container(
+      padding: EdgeInsets.all(16.w),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF8F9FA),
+        borderRadius: BorderRadius.circular(12.r),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 14.sp,
+              fontWeight: FontWeight.w600,
+              color: const Color(0xFF6C7278),
+            ),
+          ),
+          Text(
+            value,
+            style: TextStyle(
+              fontSize: 14.sp,
+              fontWeight: FontWeight.w500,
+              color: const Color(0xFF1A1C1E),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 로그아웃 버튼
+  Widget _buildLogoutButton() {
+    return Container(
+      width: double.infinity,
+      height: 48.h,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(10.r),
+        border: Border.all(
+          color: const Color(0xFFEFF0F6),
+          width: 1,
+        ),
+      ),
+      child: TextButton(
+        onPressed: _handleLogout,
+        style: TextButton.styleFrom(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(10.r),
+          ),
+        ),
+        child: Text(
+          '로그아웃',
+          style: TextStyle(
+            fontSize: 14.sp,
+            fontWeight: FontWeight.w600,
+            color: Colors.red,
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _authService.dispose();
+    super.dispose();
   }
 }

--- a/mobile/lib/screens/splash_screen.dart
+++ b/mobile/lib/screens/splash_screen.dart
@@ -119,11 +119,27 @@ class _SplashScreenState extends State<SplashScreen>
 
   /// 공지사항 팝업 표시 후 메인 화면으로 이동
   Future<void> _showNoticeAndNavigate() async {
-    // 공지사항 팝업 표시
-    await NoticeDialog.show(context);
-    
-    // 공지사항 팝업이 닫힌 후 메인 화면으로 이동
+    // 공지사항 기능 임시 비활성화 (앱 시작 블로킹 방지)
+    // TODO: 공지사항 기능이 필요하면 아래 주석을 해제하세요
+    /*
+    try {
+      print('[SplashScreen] 공지사항 팝업 표시 시작');
+      // 공지사항 팝업 표시 (5초 타임아웃)
+      await NoticeDialog.show(context).timeout(
+        const Duration(seconds: 5),
+        onTimeout: () {
+          print('[SplashScreen] 공지사항 팝업 타임아웃');
+        },
+      );
+      print('[SplashScreen] 공지사항 팝업 닫힘');
+    } catch (e) {
+      print('[SplashScreen] 공지사항 팝업 오류: $e');
+    }
+    */
+
+    // 메인 화면으로 이동
     if (mounted) {
+      print('[SplashScreen] 화면 이동 준비');
       _navigateToMain();
     }
   }

--- a/mobile/lib/screens/splash_screen.dart
+++ b/mobile/lib/screens/splash_screen.dart
@@ -95,11 +95,13 @@ class _SplashScreenState extends State<SplashScreen>
 
     // 로그인 상태 확인
     final isLoggedIn = await _authService.isLoggedIn();
+    print('[SplashScreen] 로그인 상태 확인: ${isLoggedIn ? "로그인됨" : "로그인 안됨"}');
 
     if (!mounted) return;
 
     // 로그인되어 있으면 MainScreen, 아니면 LoginScreen으로 이동
     final targetScreen = isLoggedIn ? const MainScreen() : const LoginScreen();
+    print('[SplashScreen] ${isLoggedIn ? "메인 화면" : "로그인 화면"}으로 이동');
 
     Navigator.of(context).pushReplacement(
       PageRouteBuilder(

--- a/mobile/lib/screens/splash_screen.dart
+++ b/mobile/lib/screens/splash_screen.dart
@@ -2,8 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:mobile/services/app_open_ad_service.dart';
 import 'package:mobile/services/ad_service.dart';
+import 'package:mobile/services/auth_service.dart';
 import 'package:mobile/const/colors.dart';
 import 'package:mobile/screens/main_screen.dart';
+import 'package:mobile/screens/auth/login_screen.dart';
 import 'package:mobile/widgets/friendly.dart';
 import 'package:mobile/widgets/notice_dialog.dart';
 
@@ -28,6 +30,7 @@ class _SplashScreenState extends State<SplashScreen>
 
   final AppOpenAdService _appOpenAdService = AppOpenAdService();
   final AdService _adService = AdService();
+  final AuthService _authService = AuthService();
 
   @override
   void initState() {
@@ -86,13 +89,21 @@ class _SplashScreenState extends State<SplashScreen>
     _showNoticeAndNavigate();
   }
 
-  /// 메인 화면으로 이동
-  void _navigateToMain() {
+  /// 로그인 상태 확인 후 적절한 화면으로 이동
+  Future<void> _navigateToMain() async {
     if (!mounted) return;
-    
+
+    // 로그인 상태 확인
+    final isLoggedIn = await _authService.isLoggedIn();
+
+    if (!mounted) return;
+
+    // 로그인되어 있으면 MainScreen, 아니면 LoginScreen으로 이동
+    final targetScreen = isLoggedIn ? const MainScreen() : const LoginScreen();
+
     Navigator.of(context).pushReplacement(
       PageRouteBuilder(
-        pageBuilder: (context, animation, secondaryAnimation) => const MainScreen(),
+        pageBuilder: (context, animation, secondaryAnimation) => targetScreen,
         transitionsBuilder: (context, animation, secondaryAnimation, child) {
           return FadeTransition(
             opacity: animation,

--- a/mobile/lib/services/ad_service.dart
+++ b/mobile/lib/services/ad_service.dart
@@ -52,7 +52,7 @@ class AdService {
         name: 'ad_service_initialized',
         parameters: {
           'platform': Platform.isIOS ? 'ios' : 'android',
-          'tracking_permission': _isTrackingPermissionGranted,
+          'tracking_permission': _isTrackingPermissionGranted ? 'granted' : 'denied',
         },
       );
 
@@ -84,12 +84,12 @@ class AdService {
         );
       } else {
         _isTrackingPermissionGranted = status == TrackingStatus.authorized;
-        
+
         await _analytics.logEvent(
           name: 'tracking_permission_status',
           parameters: {
             'status': _isTrackingPermissionGranted ? 'granted' : 'denied',
-            'already_determined': true,
+            'already_determined': 'yes',
           },
         );
       }

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -1,0 +1,325 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:http/http.dart' as http;
+import 'package:http/io_client.dart';
+import 'package:flutter/foundation.dart';
+
+import '../models/auth_models.dart';
+import '../config/config.dart';
+import 'token_storage_service.dart';
+
+/// AuthService
+/// ------------------------------------------------------------
+/// - 인증 관련 API 호출 전용 서비스
+/// - 회원가입, 로그인, 토큰 갱신, 익명 로그인 등 지원
+/// - 토큰 저장소와 연동하여 자동 토큰 관리
+class AuthService {
+  final String baseUrl;
+  final String apiKey;
+  late final http.Client _client;
+  final TokenStorageService _tokenStorage = TokenStorageService();
+
+  AuthService({
+    String? baseUrl,
+    String? apiKey,
+  })  : baseUrl = baseUrl ?? AppConfig.ReviewMapbaseUrl,
+        apiKey = apiKey ?? AppConfig.ReviewMapApiKey {
+    final io = HttpClient()
+      ..connectionTimeout = const Duration(seconds: 10)
+      ..idleTimeout = const Duration(seconds: 10);
+    _client = IOClient(io);
+  }
+
+  /// 공통 헤더
+  Map<String, String> get _headers => {
+        'X-API-KEY': apiKey,
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      };
+
+  /// 인증 헤더 (Bearer 토큰 포함)
+  Future<Map<String, String>> _authHeaders() async {
+    final accessToken = await _tokenStorage.getAccessToken();
+    return {
+      ..._headers,
+      if (accessToken != null) 'Authorization': 'Bearer $accessToken',
+    };
+  }
+
+  /// 디버깅 모드에서 API 응답 출력
+  void _debugPrintResponse(String method, String url, http.Response response) {
+    if (!AppConfig.isDebugMode) return;
+
+    debugPrint('=== AUTH API DEBUG ===');
+    debugPrint('Method: $method');
+    debugPrint('URL: $url');
+    debugPrint('Status Code: ${response.statusCode}');
+    debugPrint('Response Body: ${response.body}');
+    debugPrint('======================');
+  }
+
+  /// 리소스 정리
+  void dispose() {
+    _client.close();
+  }
+
+  /// 회원가입
+  /// POST /v1/auth/signup
+  /// - email, password를 받아 access_token, refresh_token 반환
+  Future<AuthResponse> signUp({
+    required String email,
+    required String password,
+  }) async {
+    final uri = Uri.parse('$baseUrl/auth/signup');
+    final request = SignUpRequest(email: email, password: password);
+
+    try {
+      final response = await _client
+          .post(
+            uri,
+            headers: _headers,
+            body: jsonEncode(request.toJson()),
+          )
+          .timeout(const Duration(seconds: 10));
+
+      _debugPrintResponse('POST', uri.toString(), response);
+
+      if (response.statusCode != 200 && response.statusCode != 201) {
+        final errorBody = jsonDecode(utf8.decode(response.bodyBytes));
+        throw Exception(errorBody['detail'] ?? '회원가입에 실패했습니다.');
+      }
+
+      final authResponse =
+          AuthResponse.fromJson(jsonDecode(utf8.decode(response.bodyBytes)));
+
+      // 토큰 저장
+      await _tokenStorage.saveAuthTokens(
+        accessToken: authResponse.accessToken,
+        refreshToken: authResponse.refreshToken,
+      );
+
+      return authResponse;
+    } catch (e) {
+      debugPrint('회원가입 오류: $e');
+      rethrow;
+    }
+  }
+
+  /// 로그인
+  /// POST /v1/auth/login
+  /// - email, password를 받아 access_token, refresh_token 반환
+  Future<AuthResponse> login({
+    required String email,
+    required String password,
+  }) async {
+    final uri = Uri.parse('$baseUrl/auth/login');
+    final request = LoginRequest(email: email, password: password);
+
+    try {
+      final response = await _client
+          .post(
+            uri,
+            headers: _headers,
+            body: jsonEncode(request.toJson()),
+          )
+          .timeout(const Duration(seconds: 10));
+
+      _debugPrintResponse('POST', uri.toString(), response);
+
+      if (response.statusCode != 200) {
+        final errorBody = jsonDecode(utf8.decode(response.bodyBytes));
+        throw Exception(errorBody['detail'] ?? '로그인에 실패했습니다.');
+      }
+
+      final authResponse =
+          AuthResponse.fromJson(jsonDecode(utf8.decode(response.bodyBytes)));
+
+      // 토큰 저장
+      await _tokenStorage.saveAuthTokens(
+        accessToken: authResponse.accessToken,
+        refreshToken: authResponse.refreshToken,
+      );
+
+      return authResponse;
+    } catch (e) {
+      debugPrint('로그인 오류: $e');
+      rethrow;
+    }
+  }
+
+  /// 토큰 갱신
+  /// POST /v1/auth/refresh
+  /// - refresh_token을 받아 새로운 access_token, refresh_token 반환
+  Future<AuthResponse> refreshToken() async {
+    final uri = Uri.parse('$baseUrl/auth/refresh');
+    final refreshToken = await _tokenStorage.getRefreshToken();
+
+    if (refreshToken == null) {
+      throw Exception('Refresh token이 없습니다.');
+    }
+
+    final request = RefreshTokenRequest(refreshToken: refreshToken);
+
+    try {
+      final response = await _client
+          .post(
+            uri,
+            headers: _headers,
+            body: jsonEncode(request.toJson()),
+          )
+          .timeout(const Duration(seconds: 10));
+
+      _debugPrintResponse('POST', uri.toString(), response);
+
+      if (response.statusCode != 200) {
+        final errorBody = jsonDecode(utf8.decode(response.bodyBytes));
+        throw Exception(errorBody['detail'] ?? '토큰 갱신에 실패했습니다.');
+      }
+
+      final authResponse =
+          AuthResponse.fromJson(jsonDecode(utf8.decode(response.bodyBytes)));
+
+      // 새로운 토큰 저장
+      await _tokenStorage.saveAuthTokens(
+        accessToken: authResponse.accessToken,
+        refreshToken: authResponse.refreshToken,
+      );
+
+      return authResponse;
+    } catch (e) {
+      debugPrint('토큰 갱신 오류: $e');
+      rethrow;
+    }
+  }
+
+  /// 익명 로그인
+  /// POST /v1/auth/anonymous
+  /// - session_token 반환
+  Future<AnonymousResponse> loginAnonymous() async {
+    final uri = Uri.parse('$baseUrl/auth/anonymous');
+
+    try {
+      final response = await _client
+          .post(
+            uri,
+            headers: _headers,
+          )
+          .timeout(const Duration(seconds: 10));
+
+      _debugPrintResponse('POST', uri.toString(), response);
+
+      if (response.statusCode != 200 && response.statusCode != 201) {
+        final errorBody = jsonDecode(utf8.decode(response.bodyBytes));
+        throw Exception(errorBody['detail'] ?? '익명 로그인에 실패했습니다.');
+      }
+
+      final anonymousResponse =
+          AnonymousResponse.fromJson(jsonDecode(utf8.decode(response.bodyBytes)));
+
+      // 세션 토큰 저장
+      await _tokenStorage.saveSessionToken(anonymousResponse.sessionToken);
+
+      return anonymousResponse;
+    } catch (e) {
+      debugPrint('익명 로그인 오류: $e');
+      rethrow;
+    }
+  }
+
+  /// 익명 사용자 전환
+  /// POST /v1/auth/convert-anonymous
+  /// - session_token, email, password를 받아 access_token, refresh_token 반환
+  Future<AuthResponse> convertAnonymous({
+    required String email,
+    required String password,
+  }) async {
+    final uri = Uri.parse('$baseUrl/auth/convert-anonymous');
+    final sessionToken = await _tokenStorage.getSessionToken();
+
+    if (sessionToken == null) {
+      throw Exception('Session token이 없습니다.');
+    }
+
+    final request = ConvertAnonymousRequest(
+      sessionToken: sessionToken,
+      email: email,
+      password: password,
+    );
+
+    try {
+      final response = await _client
+          .post(
+            uri,
+            headers: _headers,
+            body: jsonEncode(request.toJson()),
+          )
+          .timeout(const Duration(seconds: 10));
+
+      _debugPrintResponse('POST', uri.toString(), response);
+
+      if (response.statusCode != 200) {
+        final errorBody = jsonDecode(utf8.decode(response.bodyBytes));
+        throw Exception(errorBody['detail'] ?? '계정 전환에 실패했습니다.');
+      }
+
+      final authResponse =
+          AuthResponse.fromJson(jsonDecode(utf8.decode(response.bodyBytes)));
+
+      // 토큰 저장 (익명 → 일반 사용자)
+      await _tokenStorage.saveAuthTokens(
+        accessToken: authResponse.accessToken,
+        refreshToken: authResponse.refreshToken,
+      );
+
+      return authResponse;
+    } catch (e) {
+      debugPrint('익명 사용자 전환 오류: $e');
+      rethrow;
+    }
+  }
+
+  /// 사용자 정보 조회
+  /// GET /v1/auth/me
+  /// - 현재 로그인된 사용자 정보 반환
+  Future<UserInfo> getUserInfo() async {
+    final uri = Uri.parse('$baseUrl/auth/me');
+    final headers = await _authHeaders();
+
+    try {
+      final response = await _client
+          .get(
+            uri,
+            headers: headers,
+          )
+          .timeout(const Duration(seconds: 10));
+
+      _debugPrintResponse('GET', uri.toString(), response);
+
+      if (response.statusCode != 200) {
+        final errorBody = jsonDecode(utf8.decode(response.bodyBytes));
+        throw Exception(errorBody['detail'] ?? '사용자 정보 조회에 실패했습니다.');
+      }
+
+      return UserInfo.fromJson(jsonDecode(utf8.decode(response.bodyBytes)));
+    } catch (e) {
+      debugPrint('사용자 정보 조회 오류: $e');
+      rethrow;
+    }
+  }
+
+  /// 로그아웃
+  /// - 로컬 토큰 삭제
+  Future<void> logout() async {
+    await _tokenStorage.clearTokens();
+  }
+
+  /// 로그인 상태 확인
+  Future<bool> isLoggedIn() async {
+    return await _tokenStorage.isLoggedIn();
+  }
+
+  /// 익명 사용자 여부 확인
+  Future<bool> isAnonymous() async {
+    return await _tokenStorage.isAnonymous();
+  }
+}

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -86,7 +86,7 @@ class AuthService {
 
       if (response.statusCode != 200 && response.statusCode != 201) {
         final errorBody = jsonDecode(utf8.decode(response.bodyBytes));
-        throw Exception(errorBody['detail'] ?? '회원가입에 실패했습니다.');
+        throw Exception(errorBody['detail'] ?? '회원가입할 수 없습니다. 잠시 후 다시 시도해 주세요.');
       }
 
       final authResponse =
@@ -128,7 +128,7 @@ class AuthService {
 
       if (response.statusCode != 200) {
         final errorBody = jsonDecode(utf8.decode(response.bodyBytes));
-        throw Exception(errorBody['detail'] ?? '로그인에 실패했습니다.');
+        throw Exception(errorBody['detail'] ?? '로그인할 수 없습니다. 잠시 후 다시 시도해 주세요.');
       }
 
       final authResponse =
@@ -155,7 +155,7 @@ class AuthService {
     final refreshToken = await _tokenStorage.getRefreshToken();
 
     if (refreshToken == null) {
-      throw Exception('Refresh token이 없습니다.');
+      throw Exception('다시 로그인해 주세요.');
     }
 
     final request = RefreshTokenRequest(refreshToken: refreshToken);
@@ -173,7 +173,7 @@ class AuthService {
 
       if (response.statusCode != 200) {
         final errorBody = jsonDecode(utf8.decode(response.bodyBytes));
-        throw Exception(errorBody['detail'] ?? '토큰 갱신에 실패했습니다.');
+        throw Exception(errorBody['detail'] ?? '다시 로그인해 주세요.');
       }
 
       final authResponse =
@@ -210,7 +210,7 @@ class AuthService {
 
       if (response.statusCode != 200 && response.statusCode != 201) {
         final errorBody = jsonDecode(utf8.decode(response.bodyBytes));
-        throw Exception(errorBody['detail'] ?? '익명 로그인에 실패했습니다.');
+        throw Exception(errorBody['detail'] ?? '일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.');
       }
 
       final anonymousResponse =
@@ -237,7 +237,7 @@ class AuthService {
     final sessionToken = await _tokenStorage.getSessionToken();
 
     if (sessionToken == null) {
-      throw Exception('Session token이 없습니다.');
+      throw Exception('세션이 만료되었습니다. 다시 로그인해 주세요.');
     }
 
     final request = ConvertAnonymousRequest(
@@ -259,7 +259,7 @@ class AuthService {
 
       if (response.statusCode != 200) {
         final errorBody = jsonDecode(utf8.decode(response.bodyBytes));
-        throw Exception(errorBody['detail'] ?? '계정 전환에 실패했습니다.');
+        throw Exception(errorBody['detail'] ?? '계정 전환할 수 없습니다. 잠시 후 다시 시도해 주세요.');
       }
 
       final authResponse =
@@ -297,7 +297,7 @@ class AuthService {
 
       if (response.statusCode != 200) {
         final errorBody = jsonDecode(utf8.decode(response.bodyBytes));
-        throw Exception(errorBody['detail'] ?? '사용자 정보 조회에 실패했습니다.');
+        throw Exception(errorBody['detail'] ?? '사용자 정보를 불러올 수 없습니다. 잠시 후 다시 시도해 주세요.');
       }
 
       return UserInfo.fromJson(jsonDecode(utf8.decode(response.bodyBytes)));

--- a/mobile/lib/services/token_storage_service.dart
+++ b/mobile/lib/services/token_storage_service.dart
@@ -1,0 +1,83 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// TokenStorageService
+/// ------------------------------------------------------------
+/// - SharedPreferences를 사용한 토큰 저장/로드 서비스
+/// - 인증 토큰(access_token, refresh_token) 및 익명 세션 토큰 관리
+/// - 로그아웃 시 모든 토큰 삭제
+class TokenStorageService {
+  static const String _accessTokenKey = 'access_token';
+  static const String _refreshTokenKey = 'refresh_token';
+  static const String _sessionTokenKey = 'session_token';
+  static const String _isAnonymousKey = 'is_anonymous';
+
+  /// Access Token 저장
+  Future<void> saveAccessToken(String token) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_accessTokenKey, token);
+  }
+
+  /// Refresh Token 저장
+  Future<void> saveRefreshToken(String token) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_refreshTokenKey, token);
+  }
+
+  /// 인증 토큰 쌍(access + refresh) 저장
+  Future<void> saveAuthTokens({
+    required String accessToken,
+    required String refreshToken,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_accessTokenKey, accessToken);
+    await prefs.setString(_refreshTokenKey, refreshToken);
+    await prefs.setBool(_isAnonymousKey, false);
+  }
+
+  /// 익명 세션 토큰 저장
+  Future<void> saveSessionToken(String token) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_sessionTokenKey, token);
+    await prefs.setBool(_isAnonymousKey, true);
+  }
+
+  /// Access Token 조회
+  Future<String?> getAccessToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_accessTokenKey);
+  }
+
+  /// Refresh Token 조회
+  Future<String?> getRefreshToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_refreshTokenKey);
+  }
+
+  /// 익명 세션 토큰 조회
+  Future<String?> getSessionToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_sessionTokenKey);
+  }
+
+  /// 익명 사용자 여부 확인
+  Future<bool> isAnonymous() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_isAnonymousKey) ?? false;
+  }
+
+  /// 로그인 상태 확인 (토큰 존재 여부)
+  Future<bool> isLoggedIn() async {
+    final accessToken = await getAccessToken();
+    final sessionToken = await getSessionToken();
+    return accessToken != null || sessionToken != null;
+  }
+
+  /// 모든 토큰 삭제 (로그아웃)
+  Future<void> clearTokens() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_accessTokenKey);
+    await prefs.remove(_refreshTokenKey);
+    await prefs.remove(_sessionTokenKey);
+    await prefs.remove(_isAnonymousKey);
+  }
+}


### PR DESCRIPTION
## 📝 변경 사항

### 주요 기능
- ✅ 인증 API 완전 통합 (로그인, 회원가입, 익명 로그인)
- ✅ 하단 탭에 내정보 페이지 추가 (홈 / 지도 / 내정보)
- ✅ 사용자 프로필 화면 완전 구현 (ID, 이름, 이메일, 계정 유형 표시)
- ✅ 로그인 상태 기반 자동 라우팅 (SplashScreen)
- ✅ 로그아웃 기능 구현

### 버그 수정
- 🐛 공지사항 팝업으로 인한 앱 멈춤 현상 해결
- 🐛 UserInfo 모델 ID 필드 타입 캐스팅 에러 수정 (int → String 변환)
- 🐛 Firebase Analytics 파라미터 타입 에러 수정 (boolean → String 변환)

### UI/UX 개선
- 🎨 로그인/회원가입 화면 간격 최적화
- 🎨 네이버 스타일 한글 적용
- 🎨 버튼 색상 PRIMARY_COLOR 통일

### 기술적 개선
- 📊 로그인 상태 확인 디버그 로그 추가
- 🔧 Xcode 프로젝트 설정 자동 업데이트

## 🧪 테스트 계획
- [ ] 로그인/회원가입 플로우 테스트
- [ ] 익명 로그인 → 정회원 전환 테스트
- [ ] 내정보 화면 데이터 표시 확인
- [ ] 로그아웃 기능 테스트
- [ ] 앱 시작 시 자동 라우팅 확인
- [ ] iOS/Android 양쪽 플랫폼 검증

## 📦 관련 파일
- `lib/screens/auth/` - 로그인/회원가입 화면
- `lib/screens/my_page_screen.dart` - 내정보 화면
- `lib/screens/splash_screen.dart` - 앱 시작 및 라우팅
- `lib/screens/main_screen.dart` - 하단 탭 네비게이션
- `lib/services/auth_service.dart` - 인증 서비스
- `lib/models/auth_models.dart` - 인증 모델

## ⚠️ 주의사항
- 공지사항 팝업 기능은 임시 비활성화 (TODO 주석으로 보존)
- .env 파일에 API 엔드포인트 및 키 설정 필요

## 🔗 관련 이슈
해당 없음