### PR TITLE
feat: 사용자 프로필 개선 및 키워드 알람 기능 구현

### DIFF
--- a/mobile/lib/models/keyword_models.dart
+++ b/mobile/lib/models/keyword_models.dart
@@ -1,0 +1,142 @@
+/// 키워드 알람 관련 모델 클래스들
+/// - API 요청/응답 데이터 구조 정의
+/// - JSON 직렬화/역직렬화 지원
+
+/// 키워드 등록 요청 데이터
+class KeywordRegisterRequest {
+  final String keyword;
+
+  KeywordRegisterRequest({
+    required this.keyword,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'keyword': keyword,
+  };
+}
+
+/// 키워드 정보
+class KeywordInfo {
+  final int id;
+  final String keyword;
+  final bool isActive;
+  final String createdAt;
+
+  KeywordInfo({
+    required this.id,
+    required this.keyword,
+    required this.isActive,
+    required this.createdAt,
+  });
+
+  factory KeywordInfo.fromJson(Map<String, dynamic> json) {
+    return KeywordInfo(
+      id: json['id'] as int,
+      keyword: json['keyword'] as String,
+      isActive: json['is_active'] as bool,
+      createdAt: json['created_at'] as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'keyword': keyword,
+    'is_active': isActive,
+    'created_at': createdAt,
+  };
+}
+
+/// 키워드 목록 응답 데이터
+class KeywordListResponse {
+  final List<KeywordInfo> keywords;
+
+  KeywordListResponse({
+    required this.keywords,
+  });
+
+  factory KeywordListResponse.fromJson(Map<String, dynamic> json) {
+    final keywordsList = json['keywords'] as List<dynamic>;
+    return KeywordListResponse(
+      keywords: keywordsList
+          .map((item) => KeywordInfo.fromJson(item as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+}
+
+/// 알람 정보
+class AlertInfo {
+  final int id;
+  final String keyword;
+  final int campaignId;
+  final String campaignTitle;
+  final String matchedField;
+  final bool isRead;
+  final String createdAt;
+
+  AlertInfo({
+    required this.id,
+    required this.keyword,
+    required this.campaignId,
+    required this.campaignTitle,
+    required this.matchedField,
+    required this.isRead,
+    required this.createdAt,
+  });
+
+  factory AlertInfo.fromJson(Map<String, dynamic> json) {
+    return AlertInfo(
+      id: json['id'] as int,
+      keyword: json['keyword'] as String,
+      campaignId: json['campaign_id'] as int,
+      campaignTitle: json['campaign_title'] as String,
+      matchedField: json['matched_field'] as String,
+      isRead: json['is_read'] as bool,
+      createdAt: json['created_at'] as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'keyword': keyword,
+    'campaign_id': campaignId,
+    'campaign_title': campaignTitle,
+    'matched_field': matchedField,
+    'is_read': isRead,
+    'created_at': createdAt,
+  };
+}
+
+/// 알람 목록 응답 데이터
+class AlertListResponse {
+  final List<AlertInfo> alerts;
+  final int unreadCount;
+
+  AlertListResponse({
+    required this.alerts,
+    required this.unreadCount,
+  });
+
+  factory AlertListResponse.fromJson(Map<String, dynamic> json) {
+    final alertsList = json['alerts'] as List<dynamic>;
+    return AlertListResponse(
+      alerts: alertsList
+          .map((item) => AlertInfo.fromJson(item as Map<String, dynamic>))
+          .toList(),
+      unreadCount: json['unread_count'] as int,
+    );
+  }
+}
+
+/// 알람 읽음 처리 요청 데이터
+class MarkAlertsReadRequest {
+  final List<int> alertIds;
+
+  MarkAlertsReadRequest({
+    required this.alertIds,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'alert_ids': alertIds,
+  };
+}

--- a/mobile/lib/screens/keyword_alerts_screen.dart
+++ b/mobile/lib/screens/keyword_alerts_screen.dart
@@ -1,0 +1,507 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:mobile/services/keyword_service.dart';
+import 'package:mobile/const/colors.dart';
+import 'package:mobile/models/keyword_models.dart';
+
+/// 키워드 알람 관리 화면
+class KeywordAlertsScreen extends StatefulWidget {
+  const KeywordAlertsScreen({super.key});
+
+  @override
+  State<KeywordAlertsScreen> createState() => _KeywordAlertsScreenState();
+}
+
+class _KeywordAlertsScreenState extends State<KeywordAlertsScreen>
+    with SingleTickerProviderStateMixin {
+  final KeywordService _keywordService = KeywordService();
+  late TabController _tabController;
+
+  bool _isLoading = true;
+  List<KeywordInfo> _keywords = [];
+  List<AlertInfo> _allAlerts = [];
+  List<AlertInfo> _unreadAlerts = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+    _loadData();
+  }
+
+  /// 데이터 로드
+  Future<void> _loadData() async {
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      final keywords = await _keywordService.getMyKeywords();
+      final allAlertsResponse = await _keywordService.getMyAlerts();
+      final unreadAlertsResponse =
+          await _keywordService.getMyAlerts(isRead: false);
+
+      setState(() {
+        _keywords = keywords;
+        _allAlerts = allAlertsResponse.alerts;
+        _unreadAlerts = unreadAlertsResponse.alerts;
+        _isLoading = false;
+      });
+    } catch (e) {
+      debugPrint('[KeywordAlertsScreen] 데이터 로드 실패: $e');
+      setState(() {
+        _isLoading = false;
+      });
+
+      if (mounted) {
+        _showErrorDialog('데이터를 불러올 수 없습니다.\n잠시 후 다시 시도해 주세요.');
+      }
+    }
+  }
+
+  /// 키워드 추가
+  Future<void> _addKeyword() async {
+    final controller = TextEditingController();
+
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('키워드 등록'),
+        content: TextField(
+          controller: controller,
+          decoration: const InputDecoration(
+            hintText: '키워드를 입력하세요',
+            border: OutlineInputBorder(),
+          ),
+          autofocus: true,
+          textInputAction: TextInputAction.done,
+          onSubmitted: (_) => Navigator.of(context).pop(true),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('취소'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(
+              '등록',
+              style: TextStyle(color: PRIMARY_COLOR),
+            ),
+          ),
+        ],
+      ),
+    );
+
+    if (result == true && controller.text.trim().isNotEmpty) {
+      try {
+        await _keywordService.registerKeyword(controller.text.trim());
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('키워드가 등록되었습니다.')),
+          );
+        }
+        _loadData();
+      } catch (e) {
+        if (mounted) {
+          _showErrorDialog('키워드를 등록할 수 없습니다.\n잠시 후 다시 시도해 주세요.');
+        }
+      }
+    }
+  }
+
+  /// 키워드 삭제
+  Future<void> _deleteKeyword(KeywordInfo keyword) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('키워드 삭제'),
+        content: Text('\'${keyword.keyword}\' 키워드를 삭제하시겠습니까?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('취소'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text(
+              '삭제',
+              style: TextStyle(color: Colors.red),
+            ),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true) {
+      try {
+        await _keywordService.deleteKeyword(keyword.id);
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('키워드가 삭제되었습니다.')),
+          );
+        }
+        _loadData();
+      } catch (e) {
+        if (mounted) {
+          _showErrorDialog('키워드를 삭제할 수 없습니다.\n잠시 후 다시 시도해 주세요.');
+        }
+      }
+    }
+  }
+
+  /// 알람 읽음 처리
+  Future<void> _markAlertsAsRead(List<int> alertIds) async {
+    try {
+      await _keywordService.markAlertsAsRead(alertIds);
+      _loadData();
+    } catch (e) {
+      debugPrint('[KeywordAlertsScreen] 알람 읽음 처리 실패: $e');
+    }
+  }
+
+  /// 에러 다이얼로그 표시
+  void _showErrorDialog(String message) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('알림'),
+        content: Text(message),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('확인'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        title: Text(
+          '키워드 알람',
+          style: TextStyle(
+            fontSize: 18.sp,
+            fontWeight: FontWeight.w700,
+            color: const Color(0xFF1A1C1E),
+          ),
+        ),
+        backgroundColor: Colors.white,
+        elevation: 0,
+        centerTitle: true,
+        iconTheme: const IconThemeData(color: Color(0xFF1A1C1E)),
+        bottom: TabBar(
+          controller: _tabController,
+          labelColor: PRIMARY_COLOR,
+          unselectedLabelColor: const Color(0xFF6C7278),
+          indicatorColor: PRIMARY_COLOR,
+          tabs: const [
+            Tab(text: '등록 키워드'),
+            Tab(text: '알람'),
+          ],
+        ),
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : TabBarView(
+              controller: _tabController,
+              children: [
+                _buildKeywordsTab(),
+                _buildAlertsTab(),
+              ],
+            ),
+      floatingActionButton: _tabController.index == 0
+          ? FloatingActionButton(
+              onPressed: _addKeyword,
+              backgroundColor: PRIMARY_COLOR,
+              child: const Icon(Icons.add, color: Colors.white),
+            )
+          : null,
+    );
+  }
+
+  /// 키워드 탭
+  Widget _buildKeywordsTab() {
+    if (_keywords.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.search_off,
+              size: 64.sp,
+              color: const Color(0xFF6C7278),
+            ),
+            SizedBox(height: 16.h),
+            Text(
+              '등록된 키워드가 없습니다',
+              style: TextStyle(
+                fontSize: 16.sp,
+                fontWeight: FontWeight.w600,
+                color: const Color(0xFF6C7278),
+              ),
+            ),
+            SizedBox(height: 8.h),
+            Text(
+              '관심 키워드를 등록하면\n새로운 체험단이 등록될 때 알려드립니다',
+              style: TextStyle(
+                fontSize: 14.sp,
+                fontWeight: FontWeight.w400,
+                color: const Color(0xFF6C7278),
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      );
+    }
+
+    return ListView.separated(
+      padding: EdgeInsets.all(16.w),
+      itemCount: _keywords.length,
+      separatorBuilder: (context, index) => SizedBox(height: 12.h),
+      itemBuilder: (context, index) {
+        final keyword = _keywords[index];
+        return _buildKeywordCard(keyword);
+      },
+    );
+  }
+
+  /// 키워드 카드
+  Widget _buildKeywordCard(KeywordInfo keyword) {
+    return Container(
+      padding: EdgeInsets.all(16.w),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12.r),
+        border: Border.all(
+          color: const Color(0xFFEDF1F3),
+          width: 1,
+        ),
+      ),
+      child: Row(
+        children: [
+          // 키워드 아이콘
+          Container(
+            width: 40.w,
+            height: 40.w,
+            decoration: BoxDecoration(
+              color: PRIMARY_COLOR.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(8.r),
+            ),
+            child: Icon(
+              Icons.label,
+              size: 20.sp,
+              color: PRIMARY_COLOR,
+            ),
+          ),
+
+          SizedBox(width: 12.w),
+
+          // 키워드 정보
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  keyword.keyword,
+                  style: TextStyle(
+                    fontSize: 15.sp,
+                    fontWeight: FontWeight.w600,
+                    color: const Color(0xFF1A1C1E),
+                  ),
+                ),
+                SizedBox(height: 4.h),
+                Text(
+                  _formatDate(keyword.createdAt),
+                  style: TextStyle(
+                    fontSize: 12.sp,
+                    fontWeight: FontWeight.w400,
+                    color: const Color(0xFF6C7278),
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          // 삭제 버튼
+          IconButton(
+            onPressed: () => _deleteKeyword(keyword),
+            icon: const Icon(Icons.delete_outline),
+            color: Colors.red,
+            iconSize: 20.sp,
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 알람 탭
+  Widget _buildAlertsTab() {
+    if (_allAlerts.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.notifications_none,
+              size: 64.sp,
+              color: const Color(0xFF6C7278),
+            ),
+            SizedBox(height: 16.h),
+            Text(
+              '알람이 없습니다',
+              style: TextStyle(
+                fontSize: 16.sp,
+                fontWeight: FontWeight.w600,
+                color: const Color(0xFF6C7278),
+              ),
+            ),
+            SizedBox(height: 8.h),
+            Text(
+              '등록한 키워드와 일치하는 체험단이 있으면\n알림을 보내드립니다',
+              style: TextStyle(
+                fontSize: 14.sp,
+                fontWeight: FontWeight.w400,
+                color: const Color(0xFF6C7278),
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      );
+    }
+
+    return ListView.separated(
+      padding: EdgeInsets.all(16.w),
+      itemCount: _allAlerts.length,
+      separatorBuilder: (context, index) => SizedBox(height: 12.h),
+      itemBuilder: (context, index) {
+        final alert = _allAlerts[index];
+        return _buildAlertCard(alert);
+      },
+    );
+  }
+
+  /// 알람 카드
+  Widget _buildAlertCard(AlertInfo alert) {
+    return GestureDetector(
+      onTap: () {
+        if (!alert.isRead) {
+          _markAlertsAsRead([alert.id]);
+        }
+        // TODO: 캠페인 상세 화면으로 이동
+      },
+      child: Container(
+        padding: EdgeInsets.all(16.w),
+        decoration: BoxDecoration(
+          color: alert.isRead ? Colors.white : PRIMARY_COLOR.withValues(alpha: 0.05),
+          borderRadius: BorderRadius.circular(12.r),
+          border: Border.all(
+            color: alert.isRead
+                ? const Color(0xFFEDF1F3)
+                : PRIMARY_COLOR.withValues(alpha: 0.3),
+            width: 1,
+          ),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 헤더
+            Row(
+              children: [
+                // 키워드 뱃지
+                Container(
+                  padding: EdgeInsets.symmetric(horizontal: 8.w, vertical: 4.h),
+                  decoration: BoxDecoration(
+                    color: PRIMARY_COLOR.withValues(alpha: 0.1),
+                    borderRadius: BorderRadius.circular(4.r),
+                  ),
+                  child: Text(
+                    alert.keyword,
+                    style: TextStyle(
+                      fontSize: 12.sp,
+                      fontWeight: FontWeight.w600,
+                      color: PRIMARY_COLOR,
+                    ),
+                  ),
+                ),
+                const Spacer(),
+                // 읽음 상태
+                if (!alert.isRead)
+                  Container(
+                    width: 8.w,
+                    height: 8.w,
+                    decoration: const BoxDecoration(
+                      color: Colors.red,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+              ],
+            ),
+
+            SizedBox(height: 12.h),
+
+            // 캠페인 제목
+            Text(
+              alert.campaignTitle,
+              style: TextStyle(
+                fontSize: 15.sp,
+                fontWeight: FontWeight.w600,
+                color: const Color(0xFF1A1C1E),
+              ),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+
+            SizedBox(height: 8.h),
+
+            // 날짜
+            Text(
+              _formatDate(alert.createdAt),
+              style: TextStyle(
+                fontSize: 12.sp,
+                fontWeight: FontWeight.w400,
+                color: const Color(0xFF6C7278),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 날짜 포맷
+  String _formatDate(String dateString) {
+    try {
+      final date = DateTime.parse(dateString);
+      final now = DateTime.now();
+      final difference = now.difference(date);
+
+      if (difference.inDays > 7) {
+        return '${date.year}.${date.month.toString().padLeft(2, '0')}.${date.day.toString().padLeft(2, '0')}';
+      } else if (difference.inDays > 0) {
+        return '${difference.inDays}일 전';
+      } else if (difference.inHours > 0) {
+        return '${difference.inHours}시간 전';
+      } else if (difference.inMinutes > 0) {
+        return '${difference.inMinutes}분 전';
+      } else {
+        return '방금 전';
+      }
+    } catch (e) {
+      return dateString;
+    }
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    _keywordService.dispose();
+    super.dispose();
+  }
+}

--- a/mobile/lib/screens/my_page_screen.dart
+++ b/mobile/lib/screens/my_page_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:mobile/services/auth_service.dart';
+import 'package:mobile/services/keyword_service.dart';
 import 'package:mobile/const/colors.dart';
 import 'package:mobile/screens/auth/login_screen.dart';
+import 'package:mobile/screens/keyword_alerts_screen.dart';
 import 'package:mobile/models/auth_models.dart';
 
 /// 내정보 화면
@@ -15,10 +17,14 @@ class MyPageScreen extends StatefulWidget {
 
 class _MyPageScreenState extends State<MyPageScreen> {
   final AuthService _authService = AuthService();
+  final KeywordService _keywordService = KeywordService();
   bool _isLoading = true;
   bool _isLoggedIn = false;
   bool _isAnonymous = false;
   UserInfo? _userInfo;
+  AnonymousUserInfo? _anonymousUserInfo;
+  int _keywordCount = 0;
+  int _unreadAlertCount = 0;
 
   @override
   void initState() {
@@ -39,25 +45,54 @@ class _MyPageScreenState extends State<MyPageScreen> {
       setState(() {
         _isLoggedIn = isLoggedIn;
         _isAnonymous = isAnonymous;
-        _isLoading = false;
       });
 
-      // 로그인되어 있으면 사용자 정보 가져오기
       if (isLoggedIn) {
-        try {
-          final userInfo = await _authService.getUserInfo();
-          setState(() {
-            _userInfo = userInfo;
-          });
-        } catch (e) {
-          debugPrint('[MyPageScreen] 사용자 정보 조회 실패: $e');
+        if (isAnonymous) {
+          // 익명 사용자 정보 로드
+          try {
+            final anonymousInfo = await _authService.getAnonymousUserInfo();
+            setState(() {
+              _anonymousUserInfo = anonymousInfo;
+            });
+          } catch (e) {
+            debugPrint('[MyPageScreen] 익명 사용자 정보 조회 실패: $e');
+          }
+        } else {
+          // 일반 사용자 정보 로드
+          try {
+            final userInfo = await _authService.getUserInfo();
+            setState(() {
+              _userInfo = userInfo;
+            });
+          } catch (e) {
+            debugPrint('[MyPageScreen] 사용자 정보 조회 실패: $e');
+          }
         }
+
+        // 키워드 및 알람 정보 로드
+        await _loadKeywordInfo();
       }
     } catch (e) {
       debugPrint('[MyPageScreen] 로그인 상태 확인 실패: $e');
+    } finally {
       setState(() {
         _isLoading = false;
       });
+    }
+  }
+
+  /// 키워드 및 알람 정보 로드
+  Future<void> _loadKeywordInfo() async {
+    try {
+      final keywords = await _keywordService.getMyKeywords();
+      final alerts = await _keywordService.getMyAlerts(isRead: false);
+      setState(() {
+        _keywordCount = keywords.length;
+        _unreadAlertCount = alerts.unreadCount;
+      });
+    } catch (e) {
+      debugPrint('[MyPageScreen] 키워드 정보 조회 실패: $e');
     }
   }
 
@@ -67,7 +102,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('로그아웃'),
-        content: const Text('로그아웃 하시겠습니까?'),
+        content: const Text('로그아웃하시겠습니까?'),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),
@@ -108,7 +143,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
           context: context,
           builder: (context) => AlertDialog(
             title: const Text('알림'),
-            content: const Text('로그아웃에 실패했습니다.\n잠시 후 다시 시도해 주세요.'),
+            content: const Text('로그아웃할 수 없습니다.\n잠시 후 다시 시도해 주세요.'),
             actions: [
               TextButton(
                 onPressed: () => Navigator.of(context).pop(),
@@ -159,8 +194,18 @@ class _MyPageScreenState extends State<MyPageScreen> {
 
                     SizedBox(height: 32.h),
 
-                    // 계정 정보
-                    if (_isLoggedIn && _userInfo != null) ...[
+                    // 익명 사용자 세션 정보
+                    if (_isLoggedIn && _isAnonymous && _anonymousUserInfo != null) ...[
+                      _buildSectionTitle('세션 정보'),
+                      SizedBox(height: 16.h),
+                      _buildInfoItem('세션 ID', _anonymousUserInfo!.sessionId),
+                      SizedBox(height: 12.h),
+                      _buildExpiryWarning(),
+                      SizedBox(height: 32.h),
+                    ],
+
+                    // 일반 사용자 계정 정보
+                    if (_isLoggedIn && !_isAnonymous && _userInfo != null) ...[
                       _buildSectionTitle('계정 정보'),
                       SizedBox(height: 16.h),
                       _buildInfoItem('사용자 ID', _userInfo!.id),
@@ -171,10 +216,15 @@ class _MyPageScreenState extends State<MyPageScreen> {
                       ],
                       _buildInfoItem('이메일', _userInfo!.email),
                       SizedBox(height: 12.h),
-                      _buildInfoItem(
-                        '계정 유형',
-                        _userInfo!.isAnonymous ? '익명 사용자' : '일반 사용자'
-                      ),
+                      _buildInfoItem('로그인 방식', _userInfo!.loginMethodDisplayName),
+                      SizedBox(height: 32.h),
+                    ],
+
+                    // 키워드 알람 섹션
+                    if (_isLoggedIn) ...[
+                      _buildSectionTitle('키워드 알람'),
+                      SizedBox(height: 16.h),
+                      _buildKeywordAlertCard(),
                       SizedBox(height: 32.h),
                     ],
 
@@ -190,6 +240,22 @@ class _MyPageScreenState extends State<MyPageScreen> {
 
   /// 프로필 카드
   Widget _buildProfileCard() {
+    String title;
+    String subtitle;
+
+    if (!_isLoggedIn) {
+      title = '로그인 필요';
+      subtitle = '로그인하여 더 많은 기능을 이용하세요';
+    } else if (_isAnonymous) {
+      title = '익명 사용자';
+      subtitle = _anonymousUserInfo != null
+          ? '남은 시간: ${_anonymousUserInfo!.remainingTimeDisplay}'
+          : '세션 정보를 불러오는 중...';
+    } else {
+      title = _userInfo?.name ?? _userInfo?.email ?? '로그인됨';
+      subtitle = _userInfo?.email ?? '';
+    }
+
     return Container(
       width: double.infinity,
       padding: EdgeInsets.all(24.w),
@@ -229,9 +295,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
 
           // 사용자 상태
           Text(
-            _isLoggedIn
-                ? (_isAnonymous ? '익명 사용자' : '로그인됨')
-                : '로그인 필요',
+            title,
             style: TextStyle(
               fontSize: 20.sp,
               fontWeight: FontWeight.w700,
@@ -243,11 +307,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
 
           // 사용자 정보 또는 안내 메시지
           Text(
-            _isLoggedIn
-                ? (_userInfo != null
-                    ? (_userInfo!.name ?? _userInfo!.email)
-                    : '정보를 불러오는 중...')
-                : '로그인하여 더 많은 기능을 이용하세요',
+            subtitle,
             style: TextStyle(
               fontSize: 14.sp,
               fontWeight: FontWeight.w500,
@@ -256,6 +316,142 @@ class _MyPageScreenState extends State<MyPageScreen> {
             textAlign: TextAlign.center,
           ),
         ],
+      ),
+    );
+  }
+
+  /// 만료 경고
+  Widget _buildExpiryWarning() {
+    if (_anonymousUserInfo == null) return const SizedBox.shrink();
+
+    final remainingHours = _anonymousUserInfo!.remainingHours;
+    Color warningColor;
+    IconData warningIcon;
+    String warningText;
+
+    if (remainingHours < 1) {
+      warningColor = Colors.red;
+      warningIcon = Icons.error;
+      warningText = '세션이 곧 만료됩니다. 회원가입하여 데이터를 보존하세요.';
+    } else if (remainingHours < 24) {
+      warningColor = Colors.orange;
+      warningIcon = Icons.warning;
+      warningText = '세션 만료까지 ${_anonymousUserInfo!.remainingTimeDisplay} 남았습니다.';
+    } else {
+      warningColor = Colors.blue;
+      warningIcon = Icons.info;
+      warningText = '세션 만료까지 ${_anonymousUserInfo!.remainingTimeDisplay} 남았습니다.';
+    }
+
+    return Container(
+      padding: EdgeInsets.all(16.w),
+      decoration: BoxDecoration(
+        color: warningColor.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(12.r),
+        border: Border.all(
+          color: warningColor.withValues(alpha: 0.3),
+          width: 1,
+        ),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            warningIcon,
+            size: 20.sp,
+            color: warningColor,
+          ),
+          SizedBox(width: 12.w),
+          Expanded(
+            child: Text(
+              warningText,
+              style: TextStyle(
+                fontSize: 13.sp,
+                fontWeight: FontWeight.w500,
+                color: warningColor,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 키워드 알람 카드
+  Widget _buildKeywordAlertCard() {
+    return GestureDetector(
+      onTap: () async {
+        await Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => const KeywordAlertsScreen(),
+          ),
+        );
+        // 돌아왔을 때 정보 새로고침
+        _loadKeywordInfo();
+      },
+      child: Container(
+        padding: EdgeInsets.all(20.w),
+        decoration: BoxDecoration(
+          color: const Color(0xFFF8F9FA),
+          borderRadius: BorderRadius.circular(12.r),
+          border: Border.all(
+            color: const Color(0xFFEDF1F3),
+            width: 1,
+          ),
+        ),
+        child: Row(
+          children: [
+            // 아이콘
+            Container(
+              width: 48.w,
+              height: 48.w,
+              decoration: BoxDecoration(
+                color: PRIMARY_COLOR.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(12.r),
+              ),
+              child: Icon(
+                Icons.notifications_active,
+                size: 24.sp,
+                color: PRIMARY_COLOR,
+              ),
+            ),
+
+            SizedBox(width: 16.w),
+
+            // 텍스트 정보
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '키워드 알람 관리',
+                    style: TextStyle(
+                      fontSize: 15.sp,
+                      fontWeight: FontWeight.w600,
+                      color: const Color(0xFF1A1C1E),
+                    ),
+                  ),
+                  SizedBox(height: 4.h),
+                  Text(
+                    '등록 키워드 $_keywordCount개 · 읽지 않은 알람 $_unreadAlertCount개',
+                    style: TextStyle(
+                      fontSize: 13.sp,
+                      fontWeight: FontWeight.w500,
+                      color: const Color(0xFF6C7278),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
+            // 화살표
+            Icon(
+              Icons.chevron_right,
+              size: 24.sp,
+              color: const Color(0xFF6C7278),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -291,12 +487,16 @@ class _MyPageScreenState extends State<MyPageScreen> {
               color: const Color(0xFF6C7278),
             ),
           ),
-          Text(
-            value,
-            style: TextStyle(
-              fontSize: 14.sp,
-              fontWeight: FontWeight.w500,
-              color: const Color(0xFF1A1C1E),
+          Flexible(
+            child: Text(
+              value,
+              style: TextStyle(
+                fontSize: 14.sp,
+                fontWeight: FontWeight.w500,
+                color: const Color(0xFF1A1C1E),
+              ),
+              textAlign: TextAlign.right,
+              overflow: TextOverflow.ellipsis,
             ),
           ),
         ],
@@ -338,6 +538,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
   @override
   void dispose() {
     _authService.dispose();
+    _keywordService.dispose();
     super.dispose();
   }
 }

--- a/mobile/lib/services/keyword_service.dart
+++ b/mobile/lib/services/keyword_service.dart
@@ -1,0 +1,189 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:mobile/config/config.dart';
+import 'package:mobile/models/keyword_models.dart';
+import 'package:mobile/services/token_storage_service.dart';
+
+/// 키워드 알람 서비스
+/// - 키워드 등록, 조회, 삭제
+/// - 알람 조회 및 읽음 처리
+class KeywordService {
+  final String baseUrl = '${AppConfig.ReviewMapbaseUrl}/keyword-alerts';
+  final http.Client _client = http.Client();
+  final TokenStorageService _tokenStorage = TokenStorageService();
+
+  final Map<String, String> _headers = {
+    'Content-Type': 'application/json; charset=utf-8',
+    'X-API-KEY': AppConfig.ReviewMapApiKey,
+  };
+
+  /// 디버그 출력
+  void _debugPrintResponse(String method, String url, http.Response response) {
+    debugPrint('[$method] $url');
+    debugPrint('Status: ${response.statusCode}');
+    if (response.statusCode != 200 && response.statusCode != 201) {
+      debugPrint('Response: ${utf8.decode(response.bodyBytes)}');
+    }
+  }
+
+  /// 인증 헤더 생성
+  Future<Map<String, String>> _getAuthHeaders() async {
+    final token = await _tokenStorage.getAccessToken() ??
+                  await _tokenStorage.getSessionToken();
+
+    if (token == null) {
+      throw Exception('로그인이 필요합니다.');
+    }
+
+    return {
+      ..._headers,
+      'Authorization': 'Bearer $token',
+    };
+  }
+
+  /// 키워드 등록
+  /// POST /v1/keyword-alerts/keywords
+  Future<KeywordInfo> registerKeyword(String keyword) async {
+    final uri = Uri.parse('$baseUrl/keywords');
+    final headers = await _getAuthHeaders();
+    final request = KeywordRegisterRequest(keyword: keyword);
+
+    try {
+      final response = await _client
+          .post(
+            uri,
+            headers: headers,
+            body: jsonEncode(request.toJson()),
+          )
+          .timeout(const Duration(seconds: 10));
+
+      _debugPrintResponse('POST', uri.toString(), response);
+
+      if (response.statusCode != 200 && response.statusCode != 201) {
+        final errorBody = jsonDecode(utf8.decode(response.bodyBytes));
+        throw Exception(errorBody['detail'] ?? '키워드를 등록할 수 없습니다. 잠시 후 다시 시도해 주세요.');
+      }
+
+      return KeywordInfo.fromJson(jsonDecode(utf8.decode(response.bodyBytes)));
+    } catch (e) {
+      debugPrint('키워드 등록 오류: $e');
+      rethrow;
+    }
+  }
+
+  /// 내 키워드 목록 조회
+  /// GET /v1/keyword-alerts/keywords
+  Future<List<KeywordInfo>> getMyKeywords() async {
+    final uri = Uri.parse('$baseUrl/keywords');
+    final headers = await _getAuthHeaders();
+
+    try {
+      final response = await _client
+          .get(uri, headers: headers)
+          .timeout(const Duration(seconds: 10));
+
+      _debugPrintResponse('GET', uri.toString(), response);
+
+      if (response.statusCode != 200) {
+        final errorBody = jsonDecode(utf8.decode(response.bodyBytes));
+        throw Exception(errorBody['detail'] ?? '키워드 목록을 불러올 수 없습니다. 잠시 후 다시 시도해 주세요.');
+      }
+
+      final keywordList = KeywordListResponse.fromJson(
+        jsonDecode(utf8.decode(response.bodyBytes)),
+      );
+      return keywordList.keywords;
+    } catch (e) {
+      debugPrint('키워드 목록 조회 오류: $e');
+      rethrow;
+    }
+  }
+
+  /// 키워드 삭제
+  /// DELETE /v1/keyword-alerts/keywords/{keyword_id}
+  Future<void> deleteKeyword(int keywordId) async {
+    final uri = Uri.parse('$baseUrl/keywords/$keywordId');
+    final headers = await _getAuthHeaders();
+
+    try {
+      final response = await _client
+          .delete(uri, headers: headers)
+          .timeout(const Duration(seconds: 10));
+
+      _debugPrintResponse('DELETE', uri.toString(), response);
+
+      if (response.statusCode != 200) {
+        final errorBody = jsonDecode(utf8.decode(response.bodyBytes));
+        throw Exception(errorBody['detail'] ?? '키워드를 삭제할 수 없습니다. 잠시 후 다시 시도해 주세요.');
+      }
+    } catch (e) {
+      debugPrint('키워드 삭제 오류: $e');
+      rethrow;
+    }
+  }
+
+  /// 내 알람 목록 조회
+  /// GET /v1/keyword-alerts/alerts
+  Future<AlertListResponse> getMyAlerts({bool? isRead}) async {
+    final queryParams = <String, String>{};
+    if (isRead != null) {
+      queryParams['is_read'] = isRead.toString();
+    }
+
+    final uri = Uri.parse('$baseUrl/alerts').replace(queryParameters: queryParams);
+    final headers = await _getAuthHeaders();
+
+    try {
+      final response = await _client
+          .get(uri, headers: headers)
+          .timeout(const Duration(seconds: 10));
+
+      _debugPrintResponse('GET', uri.toString(), response);
+
+      if (response.statusCode != 200) {
+        final errorBody = jsonDecode(utf8.decode(response.bodyBytes));
+        throw Exception(errorBody['detail'] ?? '알람 목록을 불러올 수 없습니다. 잠시 후 다시 시도해 주세요.');
+      }
+
+      return AlertListResponse.fromJson(
+        jsonDecode(utf8.decode(response.bodyBytes)),
+      );
+    } catch (e) {
+      debugPrint('알람 목록 조회 오류: $e');
+      rethrow;
+    }
+  }
+
+  /// 알람 읽음 처리
+  /// POST /v1/keyword-alerts/alerts/read
+  Future<void> markAlertsAsRead(List<int> alertIds) async {
+    final uri = Uri.parse('$baseUrl/alerts/read');
+    final headers = await _getAuthHeaders();
+    final request = MarkAlertsReadRequest(alertIds: alertIds);
+
+    try {
+      final response = await _client
+          .post(
+            uri,
+            headers: headers,
+            body: jsonEncode(request.toJson()),
+          )
+          .timeout(const Duration(seconds: 10));
+
+      _debugPrintResponse('POST', uri.toString(), response);
+
+      if (response.statusCode != 200) {
+        final errorBody = jsonDecode(utf8.decode(response.bodyBytes));
+        throw Exception(errorBody['detail'] ?? '알람을 읽음 처리할 수 없습니다. 잠시 후 다시 시도해 주세요.');
+      }
+    } catch (e) {
+      debugPrint('알람 읽음 처리 오류: $e');
+      rethrow;
+    }
+  }
+
+  void dispose() {
+    _client.close();
+  }
+}


### PR DESCRIPTION
- 익명 사용자 세션 만료 시간 표시 추가
- SNS 로그인 방식 표시 기능 추가
- 키워드 알람 등록/관리 기능 완전 구현
- 네이버 스타일 메시지 적용 (공손하고 정중하며 간결)

## 주요 변경사항

### 모델 업데이트 (auth_models.dart)
- UserInfo에 loginMethod, isActive, dateJoined 필드 추가
- AnonymousUserInfo 모델 신규 생성 (sessionId, expiresAt, remainingHours)
- AnonymousResponse에 expiresAt, expireHours 필드 추가
- 로그인 방식 한글 표시 헬퍼 메서드 추가
- 남은 시간 사용자 친화적 표시 메서드 추가

### 키워드 알람 기능 (keyword_models.dart, keyword_service.dart)
- KeywordInfo, AlertInfo 모델 정의
- 키워드 등록/조회/삭제 API 연동
- 알람 조회 및 읽음 처리 기능
- 모든 에러 메시지 네이버 스타일로 작성

### 인증 서비스 확장 (auth_service.dart)
- getAnonymousUserInfo 메서드 추가
- 익명 사용자 세션 정보 조회 기능

### 내정보 화면 개선 (my_page_screen.dart)
- 익명 사용자 세션 만료 시간 경고 표시
- 일반 사용자 로그인 방식 표시
- 키워드 알람 관리 섹션 추가
- 등록 키워드 수 및 읽지 않은 알람 수 표시

### 키워드 알람 관리 화면 (keyword_alerts_screen.dart)
- 탭 기반 UI (등록 키워드 / 알람)
- 키워드 등록/삭제 기능
- 알람 목록 조회 및 읽음 처리
- 빈 상태 안내 메시지
- 시간 경과 표시 (방금 전, n분 전, n시간 전, n일 전)

## 메시지 스타일
모든 사용자 대면 메시지를 네이버 스타일로 작성:
- 공손하고 정중한 어투
- 간결하고 명확한 표현
- 친근한 표현 지양