### PR TITLE
feat: 알림 및 내정보 페이지 구현 (4탭 네비게이션)

### DIFF
--- a/mobile/lib/providers/auth_provider.dart
+++ b/mobile/lib/providers/auth_provider.dart
@@ -1,0 +1,127 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../services/auth_service.dart';
+import '../models/auth_models.dart';
+
+/// 인증 상태
+/// - 로그인 여부, 익명 사용자 여부, 사용자 정보 관리
+class AuthState {
+  final bool isAuthenticated;
+  final bool isAnonymous;
+  final UserInfo? userInfo;
+  final AnonymousUserInfo? anonymousUserInfo;
+
+  const AuthState({
+    this.isAuthenticated = false,
+    this.isAnonymous = false,
+    this.userInfo,
+    this.anonymousUserInfo,
+  });
+
+  /// 일반 회원 여부 (익명이 아닌 정식 회원)
+  bool get isRegularUser => isAuthenticated && !isAnonymous;
+
+  /// 인증된 사용자 (일반 회원 또는 익명 사용자)
+  bool get hasAuth => isAuthenticated || isAnonymous;
+
+  AuthState copyWith({
+    bool? isAuthenticated,
+    bool? isAnonymous,
+    UserInfo? userInfo,
+    AnonymousUserInfo? anonymousUserInfo,
+  }) {
+    return AuthState(
+      isAuthenticated: isAuthenticated ?? this.isAuthenticated,
+      isAnonymous: isAnonymous ?? this.isAnonymous,
+      userInfo: userInfo ?? this.userInfo,
+      anonymousUserInfo: anonymousUserInfo ?? this.anonymousUserInfo,
+    );
+  }
+}
+
+/// 인증 상태 관리 노티파이어
+class AuthNotifier extends Notifier<AuthState> {
+  final AuthService _authService = AuthService();
+
+  @override
+  AuthState build() {
+    // 초기 상태는 비인증
+    return const AuthState();
+  }
+
+  /// 인증 상태 확인 및 업데이트
+  /// - 앱 시작 시 또는 필요 시 호출하여 로그인 상태 복원
+  Future<void> checkAuthStatus() async {
+    try {
+      final isLoggedIn = await _authService.isLoggedIn();
+      final isAnonymousUser = await _authService.isAnonymous();
+
+      if (isLoggedIn) {
+        // 일반 회원 로그인
+        try {
+          final userInfo = await _authService.getUserInfo();
+          state = AuthState(
+            isAuthenticated: true,
+            isAnonymous: false,
+            userInfo: userInfo,
+          );
+        } catch (e) {
+          // 사용자 정보 조회 실패 시 로그아웃 처리
+          await logout();
+        }
+      } else if (isAnonymousUser) {
+        // 익명 사용자
+        try {
+          final anonymousInfo = await _authService.getAnonymousUserInfo();
+          state = AuthState(
+            isAuthenticated: false,
+            isAnonymous: true,
+            anonymousUserInfo: anonymousInfo,
+          );
+        } catch (e) {
+          // 익명 사용자 정보 조회 실패 시 비인증 상태로
+          state = const AuthState();
+        }
+      } else {
+        // 비인증 상태
+        state = const AuthState();
+      }
+    } catch (e) {
+      // 오류 발생 시 비인증 상태로
+      state = const AuthState();
+    }
+  }
+
+  /// 로그인 성공 후 상태 업데이트
+  Future<void> updateAfterLogin(UserInfo userInfo) async {
+    state = AuthState(
+      isAuthenticated: true,
+      isAnonymous: false,
+      userInfo: userInfo,
+    );
+  }
+
+  /// 익명 로그인 성공 후 상태 업데이트
+  Future<void> updateAfterAnonymousLogin(AnonymousUserInfo anonymousInfo) async {
+    state = AuthState(
+      isAuthenticated: false,
+      isAnonymous: true,
+      anonymousUserInfo: anonymousInfo,
+    );
+  }
+
+  /// 로그아웃
+  Future<void> logout() async {
+    await _authService.logout();
+    state = const AuthState();
+  }
+
+  /// 리소스 정리
+  void dispose() {
+    _authService.dispose();
+  }
+}
+
+/// AuthProvider 선언
+final authProvider = NotifierProvider<AuthNotifier, AuthState>(
+  () => AuthNotifier(),
+);

--- a/mobile/lib/screens/notification_screen.dart
+++ b/mobile/lib/screens/notification_screen.dart
@@ -38,9 +38,16 @@ class _NotificationScreenState extends State<NotificationScreen>
     final keyword = _keywordController.text.trim();
     if (keyword.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('키워드를 입력해 주세요'),
-          duration: Duration(seconds: 2),
+        SnackBar(
+          content: const Text('키워드를 입력해 주세요'),
+          duration: const Duration(seconds: 2),
+          action: SnackBarAction(
+            label: 'X',
+            textColor: Colors.white,
+            onPressed: () {
+              ScaffoldMessenger.of(context).hideCurrentSnackBar();
+            },
+          ),
         ),
       );
       return;
@@ -48,9 +55,16 @@ class _NotificationScreenState extends State<NotificationScreen>
 
     if (_keywords.length >= 20) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('키워드는 최대 20개까지 등록할 수 있습니다'),
-          duration: Duration(seconds: 2),
+        SnackBar(
+          content: const Text('키워드는 최대 20개까지 등록할 수 있습니다'),
+          duration: const Duration(seconds: 2),
+          action: SnackBarAction(
+            label: 'X',
+            textColor: Colors.white,
+            onPressed: () {
+              ScaffoldMessenger.of(context).hideCurrentSnackBar();
+            },
+          ),
         ),
       );
       return;
@@ -70,6 +84,13 @@ class _NotificationScreenState extends State<NotificationScreen>
         content: Text("'$keyword' 키워드가 추가되었습니다"),
         duration: const Duration(seconds: 2),
         backgroundColor: Colors.green,
+        action: SnackBarAction(
+          label: 'X',
+          textColor: Colors.white,
+          onPressed: () {
+            ScaffoldMessenger.of(context).hideCurrentSnackBar();
+          },
+        ),
       ),
     );
   }
@@ -85,6 +106,13 @@ class _NotificationScreenState extends State<NotificationScreen>
       SnackBar(
         content: Text("'$keyword' 키워드가 삭제되었습니다"),
         duration: const Duration(seconds: 2),
+        action: SnackBarAction(
+          label: 'X',
+          textColor: Colors.white,
+          onPressed: () {
+            ScaffoldMessenger.of(context).hideCurrentSnackBar();
+          },
+        ),
       ),
     );
   }
@@ -103,6 +131,13 @@ class _NotificationScreenState extends State<NotificationScreen>
         content: Text("'$keyword' 알림이 ${isActive ? '활성화' : '비활성화'}되었습니다"),
         duration: const Duration(seconds: 2),
         backgroundColor: isActive ? Colors.green : Colors.orange,
+        action: SnackBarAction(
+          label: 'X',
+          textColor: Colors.white,
+          onPressed: () {
+            ScaffoldMessenger.of(context).hideCurrentSnackBar();
+          },
+        ),
       ),
     );
   }
@@ -368,16 +403,13 @@ class _NotificationScreenState extends State<NotificationScreen>
           SizedBox(width: 12.w),
 
           // 삭제 버튼
-          GestureDetector(
-            onTap: () => _removeKeyword(index),
-            child: Container(
-              padding: EdgeInsets.all(4.w),
-              child: Icon(
-                Icons.close,
-                color: Colors.red,
-                size: 20.sp,
-              ),
+          IconButton(
+            icon: Icon(
+              Icons.delete_outline,
+              color: Colors.red,
+              size: 20.sp,
             ),
+            onPressed: () => _removeKeyword(index),
           ),
         ],
       ),

--- a/mobile/lib/screens/notification_screen.dart
+++ b/mobile/lib/screens/notification_screen.dart
@@ -358,10 +358,18 @@ class _NotificationScreenState extends State<NotificationScreen>
           Switch(
             value: item.isActive,
             onChanged: (_) => _toggleKeyword(index),
-            activeColor: Theme.of(context).primaryColor,
-            activeTrackColor: Theme.of(context).primaryColor.withValues(alpha: 0.5),
-            inactiveThumbColor: Colors.white,
-            inactiveTrackColor: Colors.grey.shade400,
+            thumbColor: WidgetStateProperty.resolveWith((states) {
+              if (states.contains(WidgetState.selected)) {
+                return Colors.white;
+              }
+              return Colors.white;
+            }),
+            trackColor: WidgetStateProperty.resolveWith((states) {
+              if (states.contains(WidgetState.selected)) {
+                return Theme.of(context).primaryColor;
+              }
+              return Colors.grey.shade400;
+            }),
             materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
           ),
 

--- a/mobile/lib/screens/notification_screen.dart
+++ b/mobile/lib/screens/notification_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import '../services/keyword_service.dart';
 import '../models/keyword_models.dart';
@@ -226,6 +227,48 @@ class _NotificationScreenState extends State<NotificationScreen>
         ),
       );
     }
+  }
+
+  /// 키워드 알림 토글
+  void _toggleKeyword(int index) {
+    final old = _keywords[index];
+    final newIsActive = !old.isActive;
+
+    setState(() {
+      // KeywordInfo는 final 필드라서 새 객체를 생성하여 교체
+      _keywords[index] = KeywordInfo(
+        id: old.id,
+        keyword: old.keyword,
+        isActive: newIsActive,
+        createdAt: old.createdAt,
+      );
+    });
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text("'${old.keyword}' 알림이 ${newIsActive ? '활성화' : '비활성화'}되었습니다"),
+        duration: const Duration(seconds: 2),
+        backgroundColor: newIsActive ? Colors.green : Colors.orange,
+        behavior: SnackBarBehavior.floating,
+        action: SnackBarAction(
+          label: '닫기',
+          textColor: Colors.white70,
+          onPressed: () {
+            ScaffoldMessenger.of(context).hideCurrentSnackBar();
+          },
+        ),
+      ),
+    );
+
+    // TODO: API 연동 시 추가
+    // try {
+    //   await _keywordService.toggleKeyword(old.id, newIsActive);
+    // } catch (e) {
+    //   // 실패 시 롤백
+    //   setState(() {
+    //     _keywords[index] = old;
+    //   });
+    // }
   }
 
   @override
@@ -491,6 +534,18 @@ class _NotificationScreenState extends State<NotificationScreen>
           ),
 
           const Spacer(),
+
+          // 토글 스위치 (iOS 스타일로 일관된 크기 유지)
+          Transform.scale(
+            scale: 0.8,
+            child: CupertinoSwitch(
+              value: item.isActive,
+              onChanged: (_) => _toggleKeyword(index),
+              activeTrackColor: Theme.of(context).primaryColor,
+            ),
+          ),
+
+          SizedBox(width: 12.w),
 
           // 삭제 버튼
           IconButton(

--- a/mobile/lib/screens/notification_screen.dart
+++ b/mobile/lib/screens/notification_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 /// 체험단 알림 화면
@@ -361,7 +360,7 @@ class _NotificationScreenState extends State<NotificationScreen>
             child: CupertinoSwitch(
               value: item.isActive,
               onChanged: (_) => _toggleKeyword(index),
-              activeColor: Theme.of(context).primaryColor,
+              activeTrackColor: Theme.of(context).primaryColor,
             ),
           ),
 

--- a/mobile/lib/screens/notification_screen.dart
+++ b/mobile/lib/screens/notification_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 /// 체험단 알림 화면
@@ -354,35 +355,29 @@ class _NotificationScreenState extends State<NotificationScreen>
 
           const Spacer(),
 
-          // 토글 스위치
-          Switch(
-            value: item.isActive,
-            onChanged: (_) => _toggleKeyword(index),
-            thumbColor: WidgetStateProperty.resolveWith((states) {
-              if (states.contains(WidgetState.selected)) {
-                return Colors.white;
-              }
-              return Colors.white;
-            }),
-            trackColor: WidgetStateProperty.resolveWith((states) {
-              if (states.contains(WidgetState.selected)) {
-                return Theme.of(context).primaryColor;
-              }
-              return Colors.grey.shade400;
-            }),
-            materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          // 토글 스위치 (iOS 스타일로 일관된 크기 유지)
+          Transform.scale(
+            scale: 0.8,
+            child: CupertinoSwitch(
+              value: item.isActive,
+              onChanged: (_) => _toggleKeyword(index),
+              activeColor: Theme.of(context).primaryColor,
+            ),
           ),
 
-          SizedBox(width: 8.w),
+          SizedBox(width: 12.w),
 
           // 삭제 버튼
-          IconButton(
-            icon: Icon(
-              Icons.delete_outline,
-              color: Colors.red,
-              size: 20.sp,
+          GestureDetector(
+            onTap: () => _removeKeyword(index),
+            child: Container(
+              padding: EdgeInsets.all(4.w),
+              child: Icon(
+                Icons.close,
+                color: Colors.red,
+                size: 20.sp,
+              ),
             ),
-            onPressed: () => _removeKeyword(index),
           ),
         ],
       ),

--- a/mobile/lib/screens/notification_screen.dart
+++ b/mobile/lib/screens/notification_screen.dart
@@ -40,10 +40,11 @@ class _NotificationScreenState extends State<NotificationScreen>
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: const Text('키워드를 입력해 주세요'),
-          duration: const Duration(seconds: 2),
+          duration: const Duration(seconds: 3),
+          behavior: SnackBarBehavior.floating,
           action: SnackBarAction(
-            label: 'X',
-            textColor: Colors.white,
+            label: '닫기',
+            textColor: Colors.white70,
             onPressed: () {
               ScaffoldMessenger.of(context).hideCurrentSnackBar();
             },
@@ -57,10 +58,11 @@ class _NotificationScreenState extends State<NotificationScreen>
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: const Text('키워드는 최대 20개까지 등록할 수 있습니다'),
-          duration: const Duration(seconds: 2),
+          duration: const Duration(seconds: 3),
+          behavior: SnackBarBehavior.floating,
           action: SnackBarAction(
-            label: 'X',
-            textColor: Colors.white,
+            label: '닫기',
+            textColor: Colors.white70,
             onPressed: () {
               ScaffoldMessenger.of(context).hideCurrentSnackBar();
             },
@@ -84,9 +86,10 @@ class _NotificationScreenState extends State<NotificationScreen>
         content: Text("'$keyword' 키워드가 추가되었습니다"),
         duration: const Duration(seconds: 2),
         backgroundColor: Colors.green,
+        behavior: SnackBarBehavior.floating,
         action: SnackBarAction(
-          label: 'X',
-          textColor: Colors.white,
+          label: '닫기',
+          textColor: Colors.white70,
           onPressed: () {
             ScaffoldMessenger.of(context).hideCurrentSnackBar();
           },
@@ -106,9 +109,10 @@ class _NotificationScreenState extends State<NotificationScreen>
       SnackBar(
         content: Text("'$keyword' 키워드가 삭제되었습니다"),
         duration: const Duration(seconds: 2),
+        behavior: SnackBarBehavior.floating,
         action: SnackBarAction(
-          label: 'X',
-          textColor: Colors.white,
+          label: '닫기',
+          textColor: Colors.white70,
           onPressed: () {
             ScaffoldMessenger.of(context).hideCurrentSnackBar();
           },
@@ -131,9 +135,10 @@ class _NotificationScreenState extends State<NotificationScreen>
         content: Text("'$keyword' 알림이 ${isActive ? '활성화' : '비활성화'}되었습니다"),
         duration: const Duration(seconds: 2),
         backgroundColor: isActive ? Colors.green : Colors.orange,
+        behavior: SnackBarBehavior.floating,
         action: SnackBarAction(
-          label: 'X',
-          textColor: Colors.white,
+          label: '닫기',
+          textColor: Colors.white70,
           onPressed: () {
             ScaffoldMessenger.of(context).hideCurrentSnackBar();
           },

--- a/mobile/lib/screens/notification_screen.dart
+++ b/mobile/lib/screens/notification_screen.dart
@@ -358,7 +358,11 @@ class _NotificationScreenState extends State<NotificationScreen>
           Switch(
             value: item.isActive,
             onChanged: (_) => _toggleKeyword(index),
-            activeTrackColor: Theme.of(context).primaryColor,
+            activeColor: Theme.of(context).primaryColor,
+            activeTrackColor: Theme.of(context).primaryColor.withValues(alpha: 0.5),
+            inactiveThumbColor: Colors.white,
+            inactiveTrackColor: Colors.grey.shade400,
+            materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
           ),
 
           SizedBox(width: 8.w),

--- a/mobile/lib/screens/notification_screen.dart
+++ b/mobile/lib/screens/notification_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 /// 체험단 알림 화면

--- a/mobile/lib/screens/notification_screen.dart
+++ b/mobile/lib/screens/notification_screen.dart
@@ -1,0 +1,466 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+/// 체험단 알림 화면
+/// - 2개 탭: 키워드 관리, 알림 기록
+/// - 키워드 추가/삭제, 알림 활성화/비활성화 기능
+class NotificationScreen extends StatefulWidget {
+  const NotificationScreen({super.key});
+
+  @override
+  State<NotificationScreen> createState() => _NotificationScreenState();
+}
+
+class _NotificationScreenState extends State<NotificationScreen>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+  final TextEditingController _keywordController = TextEditingController();
+
+  // 임시 데이터 (향후 API 연동 시 제거)
+  final List<KeywordItem> _keywords = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    _keywordController.dispose();
+    super.dispose();
+  }
+
+  /// 키워드 추가
+  void _addKeyword() {
+    final keyword = _keywordController.text.trim();
+    if (keyword.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('키워드를 입력해 주세요'),
+          duration: Duration(seconds: 2),
+        ),
+      );
+      return;
+    }
+
+    if (_keywords.length >= 20) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('키워드는 최대 20개까지 등록할 수 있습니다'),
+          duration: Duration(seconds: 2),
+        ),
+      );
+      return;
+    }
+
+    setState(() {
+      _keywords.add(KeywordItem(
+        keyword: keyword,
+        isActive: true,
+        createdAt: DateTime.now(),
+      ));
+      _keywordController.clear();
+    });
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text("'$keyword' 키워드가 추가되었습니다"),
+        duration: const Duration(seconds: 2),
+        backgroundColor: Colors.green,
+      ),
+    );
+  }
+
+  /// 키워드 삭제
+  void _removeKeyword(int index) {
+    final keyword = _keywords[index].keyword;
+    setState(() {
+      _keywords.removeAt(index);
+    });
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text("'$keyword' 키워드가 삭제되었습니다"),
+        duration: const Duration(seconds: 2),
+      ),
+    );
+  }
+
+  /// 키워드 알림 토글
+  void _toggleKeyword(int index) {
+    setState(() {
+      _keywords[index].isActive = !_keywords[index].isActive;
+    });
+
+    final keyword = _keywords[index].keyword;
+    final isActive = _keywords[index].isActive;
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text("'$keyword' 알림이 ${isActive ? '활성화' : '비활성화'}되었습니다"),
+        duration: const Duration(seconds: 2),
+        backgroundColor: isActive ? Colors.green : Colors.orange,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        title: const Text('체험단 알림'),
+        backgroundColor: Colors.white,
+        elevation: 0,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: () {
+              // TODO: 새로고침 기능
+            },
+          ),
+        ],
+        bottom: TabBar(
+          controller: _tabController,
+          labelColor: Theme.of(context).primaryColor,
+          unselectedLabelColor: const Color(0xFF6C7278),
+          indicatorColor: Theme.of(context).primaryColor,
+          labelStyle: TextStyle(
+            fontSize: 14.sp,
+            fontWeight: FontWeight.w600,
+          ),
+          tabs: [
+            Tab(
+              icon: const Icon(Icons.notifications_outlined),
+              text: '키워드 관리 (${_keywords.length}/20)',
+            ),
+            const Tab(
+              icon: Icon(Icons.history),
+              text: '알림 기록 (0)',
+            ),
+          ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          _buildKeywordManagementTab(),
+          _buildNotificationHistoryTab(),
+        ],
+      ),
+    );
+  }
+
+  /// 키워드 관리 탭
+  Widget _buildKeywordManagementTab() {
+    return SingleChildScrollView(
+      padding: EdgeInsets.all(16.w),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 키워드 추가 섹션
+          Row(
+            children: [
+              Icon(
+                Icons.notifications,
+                size: 20.sp,
+                color: Theme.of(context).primaryColor,
+              ),
+              SizedBox(width: 8.w),
+              Text(
+                '키워드 추가',
+                style: TextStyle(
+                  fontSize: 16.sp,
+                  fontWeight: FontWeight.w600,
+                  color: const Color(0xFF1A1C1E),
+                ),
+              ),
+            ],
+          ),
+          SizedBox(height: 12.h),
+
+          // 입력 필드 + 추가 버튼
+          Row(
+            children: [
+              Expanded(
+                child: Container(
+                  height: 46.h,
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    borderRadius: BorderRadius.circular(10.r),
+                    border: Border.all(
+                      color: const Color(0xFFEDF1F3),
+                      width: 1,
+                    ),
+                  ),
+                  child: TextField(
+                    controller: _keywordController,
+                    style: TextStyle(
+                      fontSize: 14.sp,
+                      fontWeight: FontWeight.w500,
+                      color: const Color(0xFF1A1C1E),
+                    ),
+                    decoration: InputDecoration(
+                      hintText: '예: 아이폰, 갤럭시, 노트북',
+                      hintStyle: TextStyle(
+                        fontSize: 14.sp,
+                        fontWeight: FontWeight.w400,
+                        color: const Color(0xFF9CA3AF),
+                      ),
+                      border: InputBorder.none,
+                      contentPadding: EdgeInsets.symmetric(
+                        horizontal: 14.w,
+                        vertical: 13.h,
+                      ),
+                    ),
+                    onSubmitted: (_) => _addKeyword(),
+                  ),
+                ),
+              ),
+              SizedBox(width: 8.w),
+              ElevatedButton(
+                onPressed: _addKeyword,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Theme.of(context).primaryColor,
+                  foregroundColor: Colors.white,
+                  elevation: 0,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10.r),
+                  ),
+                  padding: EdgeInsets.symmetric(
+                    horizontal: 20.w,
+                    vertical: 13.h,
+                  ),
+                  minimumSize: Size(0, 46.h),
+                ),
+                child: Text(
+                  '추가',
+                  style: TextStyle(
+                    fontSize: 14.sp,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ),
+            ],
+          ),
+
+          SizedBox(height: 4.h),
+
+          // 글자 수 카운터
+          Align(
+            alignment: Alignment.centerRight,
+            child: Text(
+              '${_keywordController.text.length}/20',
+              style: TextStyle(
+                fontSize: 12.sp,
+                color: const Color(0xFF9CA3AF),
+              ),
+            ),
+          ),
+
+          SizedBox(height: 12.h),
+
+          // 안내 문구
+          Text(
+            '관심있는 상품의 키워드를 등록하면 관련 체험단이 올라올 때 알림을 받을 수 있습니다.',
+            style: TextStyle(
+              fontSize: 12.sp,
+              fontWeight: FontWeight.w400,
+              color: const Color(0xFF6C7278),
+              height: 1.5,
+            ),
+          ),
+
+          SizedBox(height: 24.h),
+
+          // 키워드 리스트
+          if (_keywords.isEmpty)
+            _buildEmptyState()
+          else
+            ..._keywords.asMap().entries.map((entry) {
+              final index = entry.key;
+              final item = entry.value;
+              return Padding(
+                padding: EdgeInsets.only(bottom: 12.h),
+                child: _buildKeywordCard(item, index),
+              );
+            }),
+        ],
+      ),
+    );
+  }
+
+  /// 키워드 카드
+  Widget _buildKeywordCard(KeywordItem item, int index) {
+    return Container(
+      padding: EdgeInsets.all(16.w),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12.r),
+        border: Border.all(
+          color: const Color(0xFFEDF1F3),
+          width: 1,
+        ),
+      ),
+      child: Row(
+        children: [
+          // 키워드명
+          Container(
+            padding: EdgeInsets.symmetric(
+              horizontal: 12.w,
+              vertical: 6.h,
+            ),
+            decoration: BoxDecoration(
+              color: const Color(0xFFEBF5FF),
+              borderRadius: BorderRadius.circular(6.r),
+            ),
+            child: Text(
+              item.keyword,
+              style: TextStyle(
+                fontSize: 14.sp,
+                fontWeight: FontWeight.w500,
+                color: Theme.of(context).primaryColor,
+              ),
+            ),
+          ),
+
+          SizedBox(width: 12.w),
+
+          // 상태 배지
+          Container(
+            padding: EdgeInsets.symmetric(
+              horizontal: 8.w,
+              vertical: 4.h,
+            ),
+            decoration: BoxDecoration(
+              color: item.isActive
+                  ? const Color(0xFFE6F7ED)
+                  : const Color(0xFFFFF3E6),
+              borderRadius: BorderRadius.circular(4.r),
+            ),
+            child: Text(
+              item.isActive ? '활성' : '비활성',
+              style: TextStyle(
+                fontSize: 11.sp,
+                fontWeight: FontWeight.w500,
+                color: item.isActive
+                    ? const Color(0xFF10B981)
+                    : const Color(0xFFF59E0B),
+              ),
+            ),
+          ),
+
+          const Spacer(),
+
+          // 토글 스위치
+          Switch(
+            value: item.isActive,
+            onChanged: (_) => _toggleKeyword(index),
+            activeTrackColor: Theme.of(context).primaryColor,
+          ),
+
+          SizedBox(width: 8.w),
+
+          // 삭제 버튼
+          IconButton(
+            icon: Icon(
+              Icons.delete_outline,
+              color: Colors.red,
+              size: 20.sp,
+            ),
+            onPressed: () => _removeKeyword(index),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 빈 상태 UI
+  Widget _buildEmptyState() {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          SizedBox(height: 40.h),
+          Icon(
+            Icons.notifications_none,
+            size: 64.sp,
+            color: const Color(0xFFD1D5DB),
+          ),
+          SizedBox(height: 16.h),
+          Text(
+            '등록된 키워드가 없습니다',
+            style: TextStyle(
+              fontSize: 16.sp,
+              fontWeight: FontWeight.w600,
+              color: const Color(0xFF6C7278),
+            ),
+          ),
+          SizedBox(height: 8.h),
+          Text(
+            '관심있는 상품의 키워드를 추가해보세요!\n새로운 체험단이 등록되면 알림을 보내드립니다.',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 12.sp,
+              fontWeight: FontWeight.w400,
+              color: const Color(0xFF9CA3AF),
+              height: 1.5,
+            ),
+          ),
+          SizedBox(height: 40.h),
+        ],
+      ),
+    );
+  }
+
+  /// 알림 기록 탭
+  Widget _buildNotificationHistoryTab() {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.notifications_none,
+            size: 64.sp,
+            color: const Color(0xFFD1D5DB),
+          ),
+          SizedBox(height: 16.h),
+          Text(
+            '받은 알림이 없습니다',
+            style: TextStyle(
+              fontSize: 16.sp,
+              fontWeight: FontWeight.w600,
+              color: const Color(0xFF6C7278),
+            ),
+          ),
+          SizedBox(height: 8.h),
+          Text(
+            '키워드를 등록하고 관련 체험단 알림을 받아보세요!',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 12.sp,
+              fontWeight: FontWeight.w400,
+              color: const Color(0xFF9CA3AF),
+              height: 1.5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 키워드 아이템 모델
+class KeywordItem {
+  final String keyword;
+  bool isActive;
+  final DateTime createdAt;
+
+  KeywordItem({
+    required this.keyword,
+    required this.isActive,
+    required this.createdAt,
+  });
+}

--- a/mobile/lib/screens/profile_screen.dart
+++ b/mobile/lib/screens/profile_screen.dart
@@ -1,0 +1,342 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import '../providers/auth_provider.dart';
+import 'auth/login_screen.dart';
+
+/// 내정보 화면
+/// - 비회원: 로그인 안내 표시
+/// - 회원: 프로필 정보 및 메뉴 리스트
+class ProfileScreen extends ConsumerWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final authState = ref.watch(authProvider);
+
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        title: const Text('내정보'),
+        backgroundColor: Colors.white,
+        elevation: 0,
+        automaticallyImplyLeading: false,
+      ),
+      body: authState.isRegularUser
+          ? _buildAuthenticatedContent(context, ref, authState)
+          : _buildUnauthenticatedContent(context),
+    );
+  }
+
+  /// 비회원 콘텐츠
+  Widget _buildUnauthenticatedContent(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.lock_outline,
+            size: 64.sp,
+            color: const Color(0xFFD1D5DB),
+          ),
+          SizedBox(height: 16.h),
+          Text(
+            '로그인이 필요합니다',
+            style: TextStyle(
+              fontSize: 18.sp,
+              fontWeight: FontWeight.w600,
+              color: const Color(0xFF1A1C1E),
+            ),
+          ),
+          SizedBox(height: 8.h),
+          Text(
+            '회원만 이용 가능한 기능입니다.',
+            style: TextStyle(
+              fontSize: 14.sp,
+              fontWeight: FontWeight.w400,
+              color: const Color(0xFF6C7278),
+            ),
+          ),
+          SizedBox(height: 24.h),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const LoginScreen(),
+                ),
+              );
+            },
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Theme.of(context).primaryColor,
+              foregroundColor: Colors.white,
+              elevation: 0,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10.r),
+              ),
+              padding: EdgeInsets.symmetric(
+                horizontal: 32.w,
+                vertical: 14.h,
+              ),
+            ),
+            child: Text(
+              '로그인하기',
+              style: TextStyle(
+                fontSize: 14.sp,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 회원 콘텐츠
+  Widget _buildAuthenticatedContent(
+    BuildContext context,
+    WidgetRef ref,
+    AuthState authState,
+  ) {
+    final userInfo = authState.userInfo;
+
+    return SingleChildScrollView(
+      padding: EdgeInsets.all(16.w),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 프로필 섹션
+          Container(
+            padding: EdgeInsets.all(20.w),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(12.r),
+              border: Border.all(
+                color: const Color(0xFFEDF1F3),
+                width: 1,
+              ),
+            ),
+            child: Row(
+              children: [
+                // 프로필 이미지
+                CircleAvatar(
+                  radius: 32.r,
+                  backgroundColor: Theme.of(context).primaryColor.withValues(alpha: 0.1),
+                  child: Icon(
+                    Icons.person,
+                    size: 32.sp,
+                    color: Theme.of(context).primaryColor,
+                  ),
+                ),
+                SizedBox(width: 16.w),
+                // 사용자 정보
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        userInfo?.email ?? '사용자',
+                        style: TextStyle(
+                          fontSize: 16.sp,
+                          fontWeight: FontWeight.w600,
+                          color: const Color(0xFF1A1C1E),
+                        ),
+                      ),
+                      SizedBox(height: 4.h),
+                      Text(
+                        userInfo?.email ?? '',
+                        style: TextStyle(
+                          fontSize: 12.sp,
+                          fontWeight: FontWeight.w400,
+                          color: const Color(0xFF6C7278),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          SizedBox(height: 24.h),
+
+          // 메뉴 리스트
+          Container(
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(12.r),
+              border: Border.all(
+                color: const Color(0xFFEDF1F3),
+                width: 1,
+              ),
+            ),
+            child: Column(
+              children: [
+                _buildMenuItem(
+                  icon: Icons.article_outlined,
+                  title: '내 리뷰 관리',
+                  onTap: () {
+                    // TODO: 내 리뷰 관리 화면으로 이동
+                  },
+                ),
+                _buildDivider(),
+                _buildMenuItem(
+                  icon: Icons.favorite_border,
+                  title: '찜한 장소',
+                  onTap: () {
+                    // TODO: 찜한 장소 화면으로 이동
+                  },
+                ),
+                _buildDivider(),
+                _buildMenuItem(
+                  icon: Icons.notifications_outlined,
+                  title: '알림 설정',
+                  onTap: () {
+                    // TODO: 알림 설정 화면으로 이동
+                  },
+                ),
+                _buildDivider(),
+                _buildMenuItem(
+                  icon: Icons.settings_outlined,
+                  title: '설정',
+                  onTap: () {
+                    // TODO: 설정 화면으로 이동
+                  },
+                ),
+                _buildDivider(),
+                _buildMenuItem(
+                  icon: Icons.logout,
+                  title: '로그아웃',
+                  textColor: Colors.red,
+                  onTap: () async {
+                    final confirmed = await _showLogoutDialog(context);
+                    if (confirmed == true) {
+                      await ref.read(authProvider.notifier).logout();
+                    }
+                  },
+                ),
+              ],
+            ),
+          ),
+
+          SizedBox(height: 24.h),
+
+          // 앱 정보
+          Center(
+            child: Text(
+              'ReviewMaps v1.3.2',
+              style: TextStyle(
+                fontSize: 12.sp,
+                fontWeight: FontWeight.w400,
+                color: const Color(0xFF9CA3AF),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 메뉴 아이템
+  Widget _buildMenuItem({
+    required IconData icon,
+    required String title,
+    required VoidCallback onTap,
+    Color? textColor,
+  }) {
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: 16.w,
+          vertical: 16.h,
+        ),
+        child: Row(
+          children: [
+            Icon(
+              icon,
+              size: 24.sp,
+              color: textColor ?? const Color(0xFF6C7278),
+            ),
+            SizedBox(width: 16.w),
+            Expanded(
+              child: Text(
+                title,
+                style: TextStyle(
+                  fontSize: 14.sp,
+                  fontWeight: FontWeight.w500,
+                  color: textColor ?? const Color(0xFF1A1C1E),
+                ),
+              ),
+            ),
+            Icon(
+              Icons.chevron_right,
+              size: 20.sp,
+              color: const Color(0xFF9CA3AF),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 구분선
+  Widget _buildDivider() {
+    return Divider(
+      height: 1,
+      thickness: 1,
+      color: const Color(0xFFEDF1F3),
+    );
+  }
+
+  /// 로그아웃 확인 다이얼로그
+  Future<bool?> _showLogoutDialog(BuildContext context) {
+    return showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12.r),
+        ),
+        title: Text(
+          '로그아웃',
+          style: TextStyle(
+            fontSize: 18.sp,
+            fontWeight: FontWeight.w600,
+            color: const Color(0xFF1A1C1E),
+          ),
+        ),
+        content: Text(
+          '정말 로그아웃하시겠습니까?',
+          style: TextStyle(
+            fontSize: 14.sp,
+            fontWeight: FontWeight.w400,
+            color: const Color(0xFF6C7278),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(
+              '취소',
+              style: TextStyle(
+                fontSize: 14.sp,
+                fontWeight: FontWeight.w500,
+                color: const Color(0xFF6C7278),
+              ),
+            ),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(
+              '로그아웃',
+              style: TextStyle(
+                fontSize: 14.sp,
+                fontWeight: FontWeight.w600,
+                color: Colors.red,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/widgets/auth_required_dialog.dart
+++ b/mobile/lib/widgets/auth_required_dialog.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+/// 회원 인증 필수 다이얼로그
+/// - 알림, 내정보 등 회원 전용 기능 접근 시 표시
+/// - "예" 클릭 시 로그인 화면으로 이동
+class AuthRequiredDialog extends StatelessWidget {
+  final String title;
+  final String message;
+
+  const AuthRequiredDialog({
+    super.key,
+    this.title = '로그인이 필요합니다',
+    this.message = '회원만 이용 가능한 기능입니다.\n로그인하시겠습니까?',
+  });
+
+  /// 다이얼로그 표시
+  /// - 반환값: true (로그인으로 이동), false (취소)
+  static Future<bool?> show(
+    BuildContext context, {
+    String? title,
+    String? message,
+  }) async {
+    return showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => AuthRequiredDialog(
+        title: title ?? '로그인이 필요합니다',
+        message: message ?? '회원만 이용 가능한 기능입니다.\n로그인하시겠습니까?',
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12.r),
+      ),
+      title: Text(
+        title,
+        style: TextStyle(
+          fontSize: 18.sp,
+          fontWeight: FontWeight.w600,
+          color: const Color(0xFF1A1C1E),
+        ),
+      ),
+      content: Text(
+        message,
+        style: TextStyle(
+          fontSize: 14.sp,
+          fontWeight: FontWeight.w400,
+          color: const Color(0xFF6C7278),
+          height: 1.5,
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: Text(
+            '아니요',
+            style: TextStyle(
+              fontSize: 14.sp,
+              fontWeight: FontWeight.w500,
+              color: const Color(0xFF6C7278),
+            ),
+          ),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          child: Text(
+            '예',
+            style: TextStyle(
+              fontSize: 14.sp,
+              fontWeight: FontWeight.w600,
+              color: Theme.of(context).primaryColor,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## 📋 변경사항 요약

하단 탭 네비게이션을 3개에서 4개로 확장하고, 알림 및 내정보 페이지를 구현했습니다.

## ✨ 주요 기능

### 1️⃣ 알림 페이지 (NotificationScreen)
- **키워드 관리 탭**
  - 체험단 키워드 등록/삭제 (최대 20개)
  - 키워드별 알림 활성화/비활성화 토글
  - 실시간 API 연동 (KeywordService)
  - 로딩 상태 UI 및 에러 핸들링
  - 새로고침 기능

- **알림 기록 탭**
  - 빈 상태 UI (향후 구현 예정)

### 2️⃣ 내정보 페이지 (ProfileScreen)
- **비회원**: 로그인 안내 및 버튼
- **회원**: 프로필 정보 + 메뉴
  - 내 리뷰 관리
  - 찜한 장소
  - 알림 설정
  - 설정
  - 로그아웃

### 3️⃣ 인증 시스템
- **AuthProvider**: Riverpod 기반 인증 상태 관리
- **AuthRequiredDialog**: 회원 전용 기능 접근 시 로그인 유도
- **MainScreen**: 알림/내정보 탭 접근 시 인증 체크

### 4️⃣ 하단 탭 네비게이션
- 홈 | 지도 | 알림 | 내정보 (4탭)
- IndexedStack으로 탭 상태 보존
- Lazy loading으로 성능 최적화

## 🔧 기술 구현

### API 통합
- `KeywordService.getMyKeywords()`: 키워드 목록 조회
- `KeywordService.registerKeyword()`: 키워드 등록
- `KeywordService.deleteKeyword()`: 키워드 삭제
- 토글 API는 향후 추가 예정 (현재 UI만 구현)

### UI/UX
- CupertinoSwitch로 일관된 토글 크기
- CircularProgressIndicator로 로딩 상태 표시
- SnackBar로 사용자 피드백 (성공/실패)
- 반응형 디자인 (ScreenUtil)

### 상태 관리
- Riverpod Provider 패턴
- mounted 체크로 메모리 누수 방지
- 낙관적 업데이트 (토글 시 즉시 UI 반영)

## 📝 커밋 히스토리

- feat: 알림 및 내정보 탭 추가 (4개 탭 바텀 네비게이션)
- fix: Switch 토글 thumb 크기 일관성 개선
- fix: SnackBar 디자인 개선
- feat: 키워드 알림 API 통합
- feat: 키워드 알림 토글 스위치 UI 추가

## 🧪 테스트 계획

- [ ] 알림 탭 진입 시 키워드 목록 로드 확인
- [ ] 키워드 추가/삭제 동작 확인
- [ ] 토글 스위치 UI 반영 확인
- [ ] 비회원 시 인증 다이얼로그 확인
- [ ] 회원 로그아웃 동작 확인
- [ ] 탭 전환 시 상태 보존 확인

## ⚠️ 알려진 이슈

- 토글 API 미구현 (향후 백엔드 API 추가 후 연동)
- 알림 기록 탭 미구현 (향후 추가 예정)
- 내정보 메뉴 항목 미연결 (향후 추가 예정)

## 📸 스크린샷

- 알림 페이지: 키워드 관리 탭
- 내정보 페이지: 회원/비회원 상태
- 인증 다이얼로그