### PR TITLE
fix: SNS 로그인 비동기 트랜잭션 처리 오류 수정

### DIFF
--- a/server/users/api_social.py
+++ b/server/users/api_social.py
@@ -5,6 +5,7 @@ from ninja import Router
 from ninja.errors import HttpError
 from django.contrib.auth import get_user_model
 from django.db import transaction
+from asgiref.sync import sync_to_async
 
 from .schemas import (
     KakaoLoginRequest,
@@ -88,7 +89,7 @@ async def kakao_login(request, payload: KakaoLoginRequest):
 
         return user
 
-    user = await transaction.aget(create_or_update_user)()
+    user = await sync_to_async(create_or_update_user)()
 
     # JWT 토큰 생성
     access_token = create_access_token(user.id)
@@ -164,7 +165,7 @@ async def google_login(request, payload: GoogleLoginRequest):
 
         return user
 
-    user = await transaction.aget(create_or_update_user)()
+    user = await sync_to_async(create_or_update_user)()
 
     # JWT 토큰 생성
     access_token = create_access_token(user.id)
@@ -240,7 +241,7 @@ async def apple_login(request, payload: AppleLoginRequest):
 
         return user
 
-    user = await transaction.aget(create_or_update_user)()
+    user = await sync_to_async(create_or_update_user)()
 
     # JWT 토큰 생성
     access_token = create_access_token(user.id)


### PR DESCRIPTION
## 문제 상황
Django Ninja 비동기 API에서 SNS 로그인 중 AttributeError 발생:
```
AttributeError: module 'django.db.transaction' has no attribute 'aget'
```

## 원인 분석
- `transaction.aget()` 메서드는 Django에 존재하지 않음
- 비동기 환경에서 동기 트랜잭션 함수를 호출할 때 올바른 방법 미사용

## 해결 방법
Django의 `sync_to_async`를 사용하여 동기 트랜잭션 함수를 비동기 환경에서 올바르게 호출

### 변경사항
- ✅ `asgiref.sync.sync_to_async` import 추가
- ✅ Kakao 로그인: `transaction.aget()` → `sync_to_async()` 변경
- ✅ Google 로그인: `transaction.aget()` → `sync_to_async()` 변경  
- ✅ Apple 로그인: `transaction.aget()` → `sync_to_async()` 변경

### 기술 구현
- Django 비동기 환경에서 동기 트랜잭션 함수 안전하게 호출
- `@transaction.atomic` 데코레이터가 적용된 함수를 `sync_to_async`로 래핑
- 트랜잭션 무결성 유지

## 테스트
- [ ] Kakao 로그인 API 테스트
- [ ] Google 로그인 API 테스트
- [ ] Apple 로그인 API 테스트
- [ ] 트랜잭션 롤백 시나리오 테스트

## 영향 범위
- 파일: `users/api_social.py`
- 영향: SNS 로그인 API 3개 (Kakao, Google, Apple)
- 위험도: 낮음 (Django 공식 권장 방법 적용)