### PR TITLE
feat: Kakao 로그인 구현 및 JWT 인증 디버깅

### DIFF
--- a/mobile/lib/config/config.dart
+++ b/mobile/lib/config/config.dart
@@ -63,8 +63,9 @@ class AppConfig {
   static final String NAVER_APP_SEARCH_CLIENT_SECRET_16 = _getEnv('NAVER_APP_SEARCH_CLIENT_SECRET_16');
   static final String NAVER_APP_SEARCH_CLIENT_SECRET_17 = _getEnv('NAVER_APP_SEARCH_CLIENT_SECRET_17');
 
-
-
+  // 📌 Kakao Login
+  // - Kakao SDK 초기화 시 사용되는 Native App Key
+  static final String KAKAO_NATIVE_APP_KEY = _getEnv('KAKAO_NATIVE_APP_KEY');
 
 
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -33,6 +33,7 @@ import 'package:mobile/services/remote_config_service.dart'; // Firebase Remote 
 
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 
 
 // 비동기 초기화가 필요하므로 main을 async로 선언
@@ -99,7 +100,16 @@ Future<void> main() async {
   //       - .env
   await dotenv.load(fileName: ".env");
 
-  // 7) Naver Map SDK 초기화
+  // 7) Kakao SDK 초기화
+  // - Native App Key로 Kakao SDK 초기화
+  try {
+    KakaoSdk.init(nativeAppKey: AppConfig.KAKAO_NATIVE_APP_KEY);
+    print('[Main] Kakao SDK 초기화 완료');
+  } catch (e) {
+    print('[Main] Kakao SDK 초기화 실패: $e');
+  }
+
+  // 8) Naver Map SDK 초기화
   // - clientId는 AppConfig에서 가져옴(AppConfig가 .env를 읽어 제공)
   // - onAuthFailed는 배포용에서 불필요한 콘솔 로그를 남기지 않도록 비워둠
   await FlutterNaverMap().init(

--- a/mobile/lib/models/auth_models.dart
+++ b/mobile/lib/models/auth_models.dart
@@ -34,6 +34,19 @@ class LoginRequest {
   };
 }
 
+/// Kakao 로그인 요청 데이터
+class KakaoLoginRequest {
+  final String accessToken;
+
+  KakaoLoginRequest({
+    required this.accessToken,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'access_token': accessToken,
+  };
+}
+
 /// 토큰 갱신 요청 데이터
 class RefreshTokenRequest {
   final String refreshToken;

--- a/mobile/lib/screens/auth/login_screen.dart
+++ b/mobile/lib/screens/auth/login_screen.dart
@@ -169,33 +169,68 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
 
     try {
       // 1. Kakao SDK로 로그인하여 Kakao access token 받기
+      print('[LoginScreen] ========== Kakao 로그인 시작 ==========');
+      print('[LoginScreen] 1. Kakao SDK 로그인 시작');
       final kakaoAccessToken = await KakaoLoginService.login();
+      print('[LoginScreen] 1. Kakao SDK 로그인 성공');
+      print('[LoginScreen]    - Kakao token: ${kakaoAccessToken.substring(0, 30)}...');
 
       if (!mounted) return;
 
       // 2. AuthService로 서버 로그인 (Kakao token → 서버 JWT token)
-      await _authService.kakaoLogin(kakaoAccessToken);
+      print('[LoginScreen] 2. 서버 Kakao 로그인 시작');
+      final authResponse = await _authService.kakaoLogin(kakaoAccessToken);
+      print('[LoginScreen] 2. 서버 Kakao 로그인 성공');
+      print('[LoginScreen]    - JWT access token: ${authResponse.accessToken.substring(0, 30)}...');
+      print('[LoginScreen]    - JWT refresh token: ${authResponse.refreshToken.substring(0, 30)}...');
+
+      if (!mounted) return;
+
+      // 토큰이 제대로 저장되었는지 확인
+      print('[LoginScreen] 3. 토큰 저장 확인');
+      final storedAccessToken = await _authService.getStoredAccessToken();
+      final storedRefreshToken = await _authService.getStoredRefreshToken();
+      print('[LoginScreen]    - 저장된 access token: ${storedAccessToken?.substring(0, 30) ?? 'null'}...');
+      print('[LoginScreen]    - 저장된 refresh token: ${storedRefreshToken?.substring(0, 30) ?? 'null'}...');
+
+      if (storedAccessToken == null) {
+        throw Exception('토큰 저장에 실패했습니다.\n다시 시도해 주세요.');
+      }
 
       if (!mounted) return;
 
       // 3. 사용자 정보 가져오기
+      print('[LoginScreen] 4. 사용자 정보 가져오기 시작');
       final userInfo = await _authService.getUserInfo();
+      print('[LoginScreen] 4. 사용자 정보 가져오기 성공');
+      print('[LoginScreen]    - 이메일: ${userInfo.email}');
+      print('[LoginScreen]    - 로그인 방식: ${userInfo.loginMethod}');
 
       if (!mounted) return;
 
       // 4. Riverpod authProvider 상태 업데이트
+      print('[LoginScreen] 5. authProvider 상태 업데이트 시작');
       await ref.read(authProvider.notifier).updateAfterLogin(userInfo);
+      print('[LoginScreen] 5. authProvider 상태 업데이트 완료');
 
       if (!mounted) return;
 
       // 5. 로그인 성공 - MainScreen으로 이동
+      print('[LoginScreen] 6. MainScreen으로 이동');
+      print('[LoginScreen] ========== Kakao 로그인 완료 ==========');
       Navigator.of(context).pushReplacement(
         MaterialPageRoute(
           builder: (context) => const MainScreen(),
         ),
       );
-    } catch (e) {
+    } catch (e, stackTrace) {
       if (!mounted) return;
+
+      print('[LoginScreen] ========== Kakao 로그인 에러 ==========');
+      print('[LoginScreen] 에러 타입: ${e.runtimeType}');
+      print('[LoginScreen] 에러 메시지: $e');
+      print('[LoginScreen] Stack trace: $stackTrace');
+      print('[LoginScreen] ==========================================');
 
       String errorMessage = '카카오 로그인 중 문제가 발생했습니다.\n잠시 후 다시 시도해 주세요.';
       final errorText = e.toString();
@@ -230,6 +265,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
+        backgroundColor: Colors.white,
         title: const Text('알림'),
         content: Text(message),
         actions: [

--- a/mobile/lib/screens/splash_screen.dart
+++ b/mobile/lib/screens/splash_screen.dart
@@ -2,10 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:mobile/services/app_open_ad_service.dart';
 import 'package:mobile/services/ad_service.dart';
-import 'package:mobile/services/auth_service.dart';
 import 'package:mobile/const/colors.dart';
 import 'package:mobile/screens/main_screen.dart';
-import 'package:mobile/screens/auth/login_screen.dart';
 import 'package:mobile/widgets/friendly.dart';
 import 'package:mobile/widgets/notice_dialog.dart';
 
@@ -30,7 +28,6 @@ class _SplashScreenState extends State<SplashScreen>
 
   final AppOpenAdService _appOpenAdService = AppOpenAdService();
   final AdService _adService = AdService();
-  final AuthService _authService = AuthService();
 
   @override
   void initState() {
@@ -89,23 +86,16 @@ class _SplashScreenState extends State<SplashScreen>
     _showNoticeAndNavigate();
   }
 
-  /// 로그인 상태 확인 후 적절한 화면으로 이동
+  /// 메인 화면으로 이동
+  /// 로그인은 알림/내정보 탭에서만 필요하므로 앱 시작 시 무조건 MainScreen으로 이동
   Future<void> _navigateToMain() async {
     if (!mounted) return;
 
-    // 로그인 상태 확인
-    final isLoggedIn = await _authService.isLoggedIn();
-    print('[SplashScreen] 로그인 상태 확인: ${isLoggedIn ? "로그인됨" : "로그인 안됨"}');
-
-    if (!mounted) return;
-
-    // 로그인되어 있으면 MainScreen, 아니면 LoginScreen으로 이동
-    final targetScreen = isLoggedIn ? const MainScreen() : const LoginScreen();
-    print('[SplashScreen] ${isLoggedIn ? "메인 화면" : "로그인 화면"}으로 이동');
+    print('[SplashScreen] 메인 화면으로 이동');
 
     Navigator.of(context).pushReplacement(
       PageRouteBuilder(
-        pageBuilder: (context, animation, secondaryAnimation) => targetScreen,
+        pageBuilder: (context, animation, secondaryAnimation) => const MainScreen(),
         transitionsBuilder: (context, animation, secondaryAnimation, child) {
           return FadeTransition(
             opacity: animation,

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -408,4 +408,14 @@ class AuthService {
   Future<bool> isAnonymous() async {
     return await _tokenStorage.isAnonymous();
   }
+
+  /// 저장된 Access Token 조회 (디버깅용)
+  Future<String?> getStoredAccessToken() async {
+    return await _tokenStorage.getAccessToken();
+  }
+
+  /// 저장된 Refresh Token 조회 (디버깅용)
+  Future<String?> getStoredRefreshToken() async {
+    return await _tokenStorage.getRefreshToken();
+  }
 }

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -155,7 +155,7 @@ class AuthService {
     final refreshToken = await _tokenStorage.getRefreshToken();
 
     if (refreshToken == null) {
-      throw Exception('다시 로그인해 주세요.');
+      throw Exception('로그인이 만료되었습니다.\n다시 로그인해 주세요.');
     }
 
     final request = RefreshTokenRequest(refreshToken: refreshToken);
@@ -171,9 +171,12 @@ class AuthService {
 
       _debugPrintResponse('POST', uri.toString(), response);
 
-      if (response.statusCode != 200) {
+      if (response.statusCode == 401) {
+        // 인증 만료 - 사용자 친화적 메시지
+        throw Exception('로그인이 만료되었습니다.\n다시 로그인해 주세요.');
+      } else if (response.statusCode != 200) {
         final errorBody = jsonDecode(utf8.decode(response.bodyBytes));
-        throw Exception(errorBody['detail'] ?? '다시 로그인해 주세요.');
+        throw Exception(errorBody['detail'] ?? '로그인 정보를 갱신할 수 없습니다.\n다시 로그인해 주세요.');
       }
 
       final authResponse =
@@ -237,7 +240,7 @@ class AuthService {
     final sessionToken = await _tokenStorage.getSessionToken();
 
     if (sessionToken == null) {
-      throw Exception('세션이 만료되었습니다. 다시 로그인해 주세요.');
+      throw Exception('이용 시간이 만료되었습니다.\n다시 시작해 주세요.');
     }
 
     final request = ConvertAnonymousRequest(
@@ -295,9 +298,12 @@ class AuthService {
 
       _debugPrintResponse('GET', uri.toString(), response);
 
-      if (response.statusCode != 200) {
+      if (response.statusCode == 401) {
+        // 인증 만료 - 사용자 친화적 메시지
+        throw Exception('로그인이 만료되었습니다.\n다시 로그인해 주세요.');
+      } else if (response.statusCode != 200) {
         final errorBody = jsonDecode(utf8.decode(response.bodyBytes));
-        throw Exception(errorBody['detail'] ?? '사용자 정보를 불러올 수 없습니다. 잠시 후 다시 시도해 주세요.');
+        throw Exception(errorBody['detail'] ?? '사용자 정보를 불러올 수 없습니다.\n잠시 후 다시 시도해 주세요.');
       }
 
       return UserInfo.fromJson(jsonDecode(utf8.decode(response.bodyBytes)));
@@ -315,7 +321,7 @@ class AuthService {
     final sessionToken = await _tokenStorage.getSessionToken();
 
     if (sessionToken == null) {
-      throw Exception('세션이 만료되었습니다. 다시 로그인해 주세요.');
+      throw Exception('이용 시간이 만료되었습니다.\n다시 시작해 주세요.');
     }
 
     final headers = {
@@ -333,9 +339,12 @@ class AuthService {
 
       _debugPrintResponse('GET', uri.toString(), response);
 
-      if (response.statusCode != 200) {
+      if (response.statusCode == 401) {
+        // 세션 만료 - 사용자 친화적 메시지
+        throw Exception('이용 시간이 만료되었습니다.\n다시 시작해 주세요.');
+      } else if (response.statusCode != 200) {
         final errorBody = jsonDecode(utf8.decode(response.bodyBytes));
-        throw Exception(errorBody['detail'] ?? '사용자 정보를 불러올 수 없습니다. 잠시 후 다시 시도해 주세요.');
+        throw Exception(errorBody['detail'] ?? '사용자 정보를 불러올 수 없습니다.\n잠시 후 다시 시도해 주세요.');
       }
 
       return AnonymousUserInfo.fromJson(jsonDecode(utf8.decode(response.bodyBytes)));

--- a/mobile/lib/services/sns/kakao_login_service.dart
+++ b/mobile/lib/services/sns/kakao_login_service.dart
@@ -1,4 +1,4 @@
-import 'package:kakao_flutter_sdk/kakao_flutter_sdk.dart';
+import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 import 'package:flutter/services.dart';
 
 /// Kakao 소셜 로그인 서비스

--- a/mobile/lib/services/sns/kakao_login_service.dart
+++ b/mobile/lib/services/sns/kakao_login_service.dart
@@ -1,0 +1,64 @@
+import 'package:kakao_flutter_sdk/kakao_flutter_sdk.dart';
+import 'package:flutter/services.dart';
+
+/// Kakao 소셜 로그인 서비스
+class KakaoLoginService {
+  /// Kakao 로그인 실행
+  /// - 반환값: Kakao access token
+  /// - 예외: PlatformException, KakaoException
+  static Future<String> login() async {
+    try {
+      // 카카오톡 설치 여부 확인
+      final installed = await isKakaoTalkInstalled();
+
+      OAuthToken token;
+      if (installed) {
+        // 카카오톡으로 로그인
+        try {
+          token = await UserApi.instance.loginWithKakaoTalk();
+        } catch (error) {
+          // 사용자가 카카오톡 설치 후 디바이스 권한 요청 화면에서 로그인을 취소한 경우
+          if (error is PlatformException && error.code == 'CANCELED') {
+            rethrow;
+          }
+          // 카카오톡에 연결된 카카오계정이 없는 경우, 카카오계정으로 로그인
+          token = await UserApi.instance.loginWithKakaoAccount();
+        }
+      } else {
+        // 카카오계정으로 로그인
+        token = await UserApi.instance.loginWithKakaoAccount();
+      }
+
+      return token.accessToken;
+    } catch (e) {
+      throw Exception('Kakao 로그인 실패: $e');
+    }
+  }
+
+  /// Kakao 로그아웃
+  static Future<void> logout() async {
+    try {
+      await UserApi.instance.logout();
+    } catch (e) {
+      throw Exception('Kakao 로그아웃 실패: $e');
+    }
+  }
+
+  /// Kakao 연결 해제
+  static Future<void> unlink() async {
+    try {
+      await UserApi.instance.unlink();
+    } catch (e) {
+      throw Exception('Kakao 연결 해제 실패: $e');
+    }
+  }
+
+  /// 사용자 정보 조회 (디버그용)
+  static Future<User?> getUserInfo() async {
+    try {
+      return await UserApi.instance.me();
+    } catch (e) {
+      return null;
+    }
+  }
+}

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -49,6 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.7.0"
+  asn1lib:
+    dependency: transitive
+    description:
+      name: asn1lib
+      sha256: "9a8f69025044eb466b9b60ef3bc3ac99b4dc6c158ae9c56d25eeccf5bc56d024"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.5"
   async:
     dependency: transitive
     description:
@@ -153,6 +161,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.11"
+  dio:
+    dependency: transitive
+    description:
+      name: dio
+      sha256: d90ee57923d1828ac14e492ca49440f65477f4bb1263575900be731a3dac66a9
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.9.0"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "7586e476d70caecaf1686d21eee7247ea43ef5c345eab9e0cc3583ff13378d78"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
+  encrypt:
+    dependency: transitive
+    description:
+      name: encrypt
+      sha256: "62d9aa4670cc2a8798bab89b39fc71b6dfbacf615de6cf5001fb39f7e4a996a2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.3"
   fake_async:
     dependency: transitive
     description:
@@ -552,6 +584,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.9.0"
+  kakao_flutter_sdk_auth:
+    dependency: transitive
+    description:
+      name: kakao_flutter_sdk_auth
+      sha256: "028d8803b7545cc5f41d20cda43b813683700e45c6c13aa4ca56f4b9c673305c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.9.7+3"
+  kakao_flutter_sdk_common:
+    dependency: transitive
+    description:
+      name: kakao_flutter_sdk_common
+      sha256: "1c4944cc50c363d4626e9006ab39ee496c8f5ca602b96154272b90d40544aaca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.9.7+3"
+  kakao_flutter_sdk_user:
+    dependency: "direct main"
+    description:
+      name: kakao_flutter_sdk_user
+      sha256: "5157feeafe58d677d314baa5ccdcb435fd9680c485c3b23e9ad7d97a0c93694f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.9.7+3"
   leak_tracker:
     dependency: transitive
     description:
@@ -832,6 +888,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  pointycastle:
+    dependency: transitive
+    description:
+      name: pointycastle
+      sha256: "4be0097fcf3fd3e8449e53730c631200ebc7b88016acecab2b0da2f0149222fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.9.1"
   pool:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -66,6 +66,9 @@ dependencies:
   firebase_remote_config: ^5.1.4
   firebase_messaging: ^15.1.4
 
+  # SNS 로그인
+  kakao_flutter_sdk_user: ^1.9.6
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/server/users/api_social.py
+++ b/server/users/api_social.py
@@ -5,6 +5,7 @@ from ninja import Router
 from ninja.errors import HttpError
 from django.contrib.auth import get_user_model
 from django.db import transaction
+from asgiref.sync import sync_to_async
 
 from .schemas import (
     KakaoLoginRequest,
@@ -88,7 +89,7 @@ async def kakao_login(request, payload: KakaoLoginRequest):
 
         return user
 
-    user = await transaction.aget(create_or_update_user)()
+    user = await sync_to_async(create_or_update_user)()
 
     # JWT 토큰 생성
     access_token = create_access_token(user.id)
@@ -164,7 +165,7 @@ async def google_login(request, payload: GoogleLoginRequest):
 
         return user
 
-    user = await transaction.aget(create_or_update_user)()
+    user = await sync_to_async(create_or_update_user)()
 
     # JWT 토큰 생성
     access_token = create_access_token(user.id)
@@ -240,7 +241,7 @@ async def apple_login(request, payload: AppleLoginRequest):
 
         return user
 
-    user = await transaction.aget(create_or_update_user)()
+    user = await sync_to_async(create_or_update_user)()
 
     # JWT 토큰 생성
     access_token = create_access_token(user.id)


### PR DESCRIPTION
## 📝 변경 사항

### 주요 기능
- ✅ Kakao SDK를 활용한 소셜 로그인 구현
- ✅ Riverpod authProvider 통합으로 인증 상태 관리 개선
- ✅ 앱 시작 흐름 개선 (SplashScreen → MainScreen)
- ✅ AlertDialog 배경색을 흰색으로 변경

### 디버깅 및 로깅
- 🔍 Kakao 로그인 각 단계별 상세 로그 추가
- 🔍 JWT 페이로드 디코딩 및 내용 확인
- 🔍 서버 응답 상세 로그 (상태 코드, 본문, 에러 메시지)
- 🔍 토큰 저장/조회 검증 로직 추가

### 사용자 경험 개선
- 💬 인증 관련 에러 메시지를 사용자 친화적으로 개선
- 💬 Kakao 로그인 에러 상황별 명확한 안내 메시지

## 🐛 발견된 문제 (백엔드 수정 필요)

### JWT 검증 실패 이슈
**증상**: 
- Kakao 로그인 시 JWT는 정상 발급되지만 `/auth/me` 호출 시 401 에러
- 서버 응답: `{"detail": "유효하지 않은 토큰입니다."}`

**근본 원인**:
- 동일 이메일로 email 로그인과 kakao 로그인 시 계정 충돌
- 현재 DB 스키마: `email` 필드에 `unique=True` 설정
- 같은 이메일이라도 `login_method`가 다르면 별도 계정으로 관리되어야 함

**예시**:
```
user@example.com (email 로그인) - 기존 계정 ✅
user@example.com (kakao 로그인) - 생성 실패 또는 JWT 검증 실패 ❌
```

## 🔧 백엔드 수정 필요 사항

### 1. DB 스키마 수정
```python
class User(models.Model):
    email = models.EmailField()  # unique 제약 제거
    password = models.CharField(null=True, blank=True)  # SNS 로그인은 비밀번호 없음
    login_method = models.CharField(max_length=20)
    
    class Meta:
        unique_together = [['email', 'login_method']]  # 조합이 unique
```

### 2. `/auth/kakao` 엔드포인트 수정
```python
user, created = User.objects.get_or_create(
    email=kakao_email,
    login_method='kakao',  # 명시적으로 설정
    defaults={'kakao_id': kakao_id}
)
```

### 3. JWT 생성/검증 로직 확인
- SECRET_KEY 일관성 확인
- 알고리즘(HS256) 일치 확인
- JWT 페이로드 필드명(`user_id` vs `sub`) 통일

## 📊 커밋 히스토리

1. `ae86f7c` - improve: 토큰 관련 에러 메시지 사용자 친화적으로 개선
2. `fa81f02` - feat: Riverpod authProvider 통합 및 앱 시작 흐름 개선
3. `4849c69` - feat: Kakao 로그인 기능 구현
4. `ca9610c` - fix: Kakao SDK import 및 초기화 수정
5. `06f52ba` - fix: Kakao 로그인 디버깅 로그 추가 및 AlertDialog 배경색 변경
6. `e113715` - debug: JWT 페이로드 디코딩 및 서버 응답 상세 로그 추가

## 🧪 테스트 결과

### 클라이언트 로그 분석
```
✅ Kakao SDK 로그인: 성공
✅ 서버 JWT 발급: 성공 (599분 유효)
✅ 토큰 저장: 성공
❌ 사용자 정보 조회: 401 에러 "유효하지 않은 토큰입니다."
```

### JWT 페이로드
```json
{
  "user_id": 1,
  "email": null,
  "exp": 1763604316,
  "만료시간": "599분 남음"
}
```

## 🚀 다음 단계

1. **백엔드 수정** (우선순위 높음)
   - DB 스키마 마이그레이션
   - `/auth/kakao` 엔드포인트 수정
   - JWT 생성/검증 로직 통일

2. **클라이언트 테스트**
   - 백엔드 수정 후 Kakao 로그인 재테스트
   - Google, Apple 로그인 추가 구현

3. **문서화**
   - API 문서에 SNS 로그인 스펙 추가
   - 계정 관리 정책 문서화

## 📚 관련 파일

### 신규 파일
- `lib/services/sns/kakao_login_service.dart` - Kakao 로그인 서비스
- `lib/models/auth_models.dart` - KakaoLoginRequest 추가

### 수정 파일
- `lib/main.dart` - Kakao SDK 초기화 추가
- `lib/screens/auth/login_screen.dart` - Kakao 로그인 UI/로직, AlertDialog 배경색
- `lib/services/auth_service.dart` - kakaoLogin 메서드, JWT 디코딩, 상세 로그
- `lib/providers/auth_provider.dart` - 인증 상태 관리 개선
- `lib/screens/splash_screen.dart` - 앱 시작 흐름 개선
- `pubspec.yaml` - kakao_flutter_sdk_user 의존성 추가

## ⚠️ 주의 사항

- 백엔드 수정 전까지는 Kakao 로그인이 정상 작동하지 않습니다
- 기존 email 로그인 사용자는 영향받지 않습니다
- 디버깅 로그는 추후 프로덕션 빌드에서 제거 예정입니다