### PR TITLE
fix: Django Admin login_method 및 SocialAccount 표시 추가

### DIFF
--- a/server/users/admin.py
+++ b/server/users/admin.py
@@ -1,22 +1,22 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.utils.translation import gettext_lazy as _
-from .models import User
+from .models import User, SocialAccount
 
 
 @admin.register(User)
 class UserAdmin(BaseUserAdmin):
-    """Custom User Admin - email 기반 인증"""
+    """Custom User Admin - email + login_method 기반 인증"""
 
     # 목록 페이지에서 보여질 필드
-    list_display = ('email', 'is_active', 'is_staff', 'is_superuser', 'date_joined')
-    list_filter = ('is_active', 'is_staff', 'is_superuser', 'date_joined')
-    search_fields = ('email',)
+    list_display = ('username', 'email', 'login_method', 'is_active', 'is_staff', 'is_superuser', 'date_joined')
+    list_filter = ('login_method', 'is_active', 'is_staff', 'is_superuser', 'date_joined')
+    search_fields = ('email', 'username')
     ordering = ('-date_joined',)
 
     # 사용자 상세/수정 페이지
     fieldsets = (
-        (None, {'fields': ('email', 'password')}),
+        (None, {'fields': ('username', 'email', 'login_method', 'password')}),
         (_('권한'), {
             'fields': ('is_active', 'is_staff', 'is_superuser', 'groups', 'user_permissions'),
         }),
@@ -27,8 +27,35 @@ class UserAdmin(BaseUserAdmin):
     add_fieldsets = (
         (None, {
             'classes': ('wide',),
-            'fields': ('email', 'password1', 'password2'),
+            'fields': ('email', 'login_method', 'password1', 'password2'),
         }),
     )
 
-    readonly_fields = ('date_joined', 'last_login')
+    readonly_fields = ('username', 'date_joined', 'last_login')
+
+
+@admin.register(SocialAccount)
+class SocialAccountAdmin(admin.ModelAdmin):
+    """SNS 계정 Admin"""
+
+    list_display = ('user', 'provider', 'email', 'name', 'created_at')
+    list_filter = ('provider', 'created_at')
+    search_fields = ('email', 'name', 'provider_user_id', 'user__email')
+    readonly_fields = ('created_at', 'updated_at')
+    ordering = ('-created_at',)
+
+    fieldsets = (
+        ('사용자 정보', {
+            'fields': ('user', 'provider', 'provider_user_id')
+        }),
+        ('SNS 프로필', {
+            'fields': ('email', 'name', 'profile_image')
+        }),
+        ('토큰 정보', {
+            'fields': ('access_token', 'refresh_token', 'token_expires_at'),
+            'classes': ('collapse',)
+        }),
+        ('타임스탬프', {
+            'fields': ('created_at', 'updated_at')
+        }),
+    )


### PR DESCRIPTION
## 문제
Django Admin에서 login_method 필드가 보이지 않고 SocialAccount 관리 기능이 없음

## 해결
- User Admin list_display에 username, login_method 추가
- SocialAccount Admin 등록
- 검색 및 필터 기능 강화

## 변경사항
- username, email, login_method 컬럼 표시
- login_method로 필터링 가능
- SocialAccount 전체 관리 기능