### PR TITLE
fix: createsuperuser username 중복 인자 오류 수정

### DIFF
--- a/server/users/models.py
+++ b/server/users/models.py
@@ -12,6 +12,10 @@ class UserManager(BaseUserManager):
             raise ValueError('이메일은 필수입니다.')
 
         email = self.normalize_email(email)
+        # extra_fields에서 login_method가 있으면 사용, 없으면 인자값 사용
+        login_method = extra_fields.pop('login_method', login_method)
+        # extra_fields에서 username 제거 (자동 생성하므로)
+        extra_fields.pop('username', None)
         # username을 email + login_method 조합으로 자동 생성
         username = f"{email}_{login_method}"
         user = self.model(email=email, username=username, login_method=login_method, **extra_fields)


### PR DESCRIPTION
## Summary
- create_user 메서드에서 extra_fields의 login_method, username 중복 처리 수정
- createsuperuser 명령어 실행 시 발생하던 TypeError 해결

## Changes
- `extra_fields.pop('login_method', login_method)`: 중복 인자 방지
- `extra_fields.pop('username', None)`: 자동 생성되는 username 제거

## Test
```bash
python manage.py createsuperuser --email admin@example.com
```