### PR TITLE
fix: SNS 로그인 JWT에 email 포함하도록 수정

### DIFF
--- a/server/users/api_social.py
+++ b/server/users/api_social.py
@@ -93,9 +93,9 @@ async def kakao_login(request, payload: KakaoLoginRequest):
 
     user = await sync_to_async(create_or_update_user)()
 
-    # JWT 토큰 생성
-    access_token = create_access_token(user.id)
-    refresh_token = create_refresh_token(user.id)
+    # JWT 토큰 생성 (email 포함)
+    access_token = create_access_token(user.id, user.email)
+    refresh_token = create_refresh_token(user.id, user.email)
 
     return {
         "access_token": access_token,
@@ -171,9 +171,9 @@ async def google_login(request, payload: GoogleLoginRequest):
 
     user = await sync_to_async(create_or_update_user)()
 
-    # JWT 토큰 생성
-    access_token = create_access_token(user.id)
-    refresh_token = create_refresh_token(user.id)
+    # JWT 토큰 생성 (email 포함)
+    access_token = create_access_token(user.id, user.email)
+    refresh_token = create_refresh_token(user.id, user.email)
 
     return {
         "access_token": access_token,
@@ -249,9 +249,9 @@ async def apple_login(request, payload: AppleLoginRequest):
 
     user = await sync_to_async(create_or_update_user)()
 
-    # JWT 토큰 생성
-    access_token = create_access_token(user.id)
-    refresh_token = create_refresh_token(user.id)
+    # JWT 토큰 생성 (email 포함)
+    access_token = create_access_token(user.id, user.email)
+    refresh_token = create_refresh_token(user.id, user.email)
 
     return {
         "access_token": access_token,

--- a/server/users/auth/__init__.py
+++ b/server/users/auth/__init__.py
@@ -1,6 +1,8 @@
 """
 JWT 인증 모듈
 """
-from .jwt_auth import JWTAuth, create_access_token, create_refresh_token
+from .jwt_auth import JWTAuth
+# 토큰 생성 함수는 users.utils에서 가져옴 (email 포함)
+from users.utils import create_access_token, create_refresh_token
 
 __all__ = ['JWTAuth', 'create_access_token', 'create_refresh_token']


### PR DESCRIPTION
## Summary
SNS 로그인(Kakao, Google, Apple) 시 발급되는 JWT에 email이 null로 설정되는 문제 수정

## 문제 상황
- SNS 로그인 성공 후 JWT 발급
- JWT payload에 `email: null`
- `/auth/me` 엔드포인트에서 401 에러

## 원인
- `api_social.py`가 `users/auth`의 `create_access_token(user_id)`를 사용
- `users/utils.py`의 `create_access_token(user_id, user_email)`이 아닌 함수 사용

## 해결
- `users/auth/__init__.py`에서 `users/utils`의 토큰 생성 함수 import
- SNS 로그인 API에서 `create_access_token(user.id, user.email)` 호출

## Test
```bash
python manage.py test users.tests.test_api_social users.tests.test_backends
```

✅ 18개 테스트 통과