### PR TITLE
refactor: JWT payload에서 email 제거

### DIFF
--- a/server/users/api.py
+++ b/server/users/api.py
@@ -52,8 +52,8 @@ async def signup(request, payload: UserSignupRequest):
     )
 
     # JWT 토큰 생성
-    access_token = create_access_token(user.id, user.email)
-    refresh_token = create_refresh_token(user.id, user.email)
+    access_token = create_access_token(user.id)
+    refresh_token = create_refresh_token(user.id)
 
     return {
         "access_token": access_token,
@@ -84,8 +84,8 @@ async def login(request, payload: UserLoginRequest):
         raise HttpError(403, "이용이 정지된 계정입니다.")
 
     # JWT 토큰 생성
-    access_token = create_access_token(user.id, user.email)
-    refresh_token = create_refresh_token(user.id, user.email)
+    access_token = create_access_token(user.id)
+    refresh_token = create_refresh_token(user.id)
 
     return {
         "access_token": access_token,
@@ -113,8 +113,8 @@ async def refresh_token(request, payload: TokenRefreshRequest):
         raise HttpError(401, "회원 정보를 찾을 수 없습니다.")
 
     # 새로운 토큰 생성
-    access_token = create_access_token(user.id, user.email)
-    refresh_token_new = create_refresh_token(user.id, user.email)
+    access_token = create_access_token(user.id)
+    refresh_token_new = create_refresh_token(user.id)
 
     return {
         "access_token": access_token,
@@ -180,8 +180,8 @@ async def convert_anonymous_to_user(request, payload: ConvertAnonymousRequest):
     )(user=user, anonymous_session_id=None)
 
     # JWT 토큰 생성
-    access_token = create_access_token(user.id, user.email)
-    refresh_token = create_refresh_token(user.id, user.email)
+    access_token = create_access_token(user.id)
+    refresh_token = create_refresh_token(user.id)
 
     return {
         "access_token": access_token,

--- a/server/users/api_social.py
+++ b/server/users/api_social.py
@@ -93,9 +93,9 @@ async def kakao_login(request, payload: KakaoLoginRequest):
 
     user = await sync_to_async(create_or_update_user)()
 
-    # JWT 토큰 생성 (email 포함)
-    access_token = create_access_token(user.id, user.email)
-    refresh_token = create_refresh_token(user.id, user.email)
+    # JWT 토큰 생성
+    access_token = create_access_token(user.id)
+    refresh_token = create_refresh_token(user.id)
 
     return {
         "access_token": access_token,
@@ -171,9 +171,9 @@ async def google_login(request, payload: GoogleLoginRequest):
 
     user = await sync_to_async(create_or_update_user)()
 
-    # JWT 토큰 생성 (email 포함)
-    access_token = create_access_token(user.id, user.email)
-    refresh_token = create_refresh_token(user.id, user.email)
+    # JWT 토큰 생성
+    access_token = create_access_token(user.id)
+    refresh_token = create_refresh_token(user.id)
 
     return {
         "access_token": access_token,
@@ -249,9 +249,9 @@ async def apple_login(request, payload: AppleLoginRequest):
 
     user = await sync_to_async(create_or_update_user)()
 
-    # JWT 토큰 생성 (email 포함)
-    access_token = create_access_token(user.id, user.email)
-    refresh_token = create_refresh_token(user.id, user.email)
+    # JWT 토큰 생성
+    access_token = create_access_token(user.id)
+    refresh_token = create_refresh_token(user.id)
 
     return {
         "access_token": access_token,

--- a/server/users/utils.py
+++ b/server/users/utils.py
@@ -10,13 +10,12 @@ from django.contrib.auth import get_user_model
 User = get_user_model()
 
 
-def create_access_token(user_id: int, user_email: str) -> str:
+def create_access_token(user_id: int) -> str:
     """
     Access Token 생성
 
     Args:
         user_id: 사용자 ID
-        user_email: 사용자 이메일
 
     Returns:
         JWT access token
@@ -24,7 +23,6 @@ def create_access_token(user_id: int, user_email: str) -> str:
     expire = datetime.utcnow() + timedelta(minutes=settings.JWT_ACCESS_TOKEN_EXPIRE_MINUTES)
     payload = {
         'user_id': user_id,
-        'email': user_email,
         'exp': expire,
         'iat': datetime.utcnow(),
         'type': 'access'
@@ -38,13 +36,12 @@ def create_access_token(user_id: int, user_email: str) -> str:
     return token
 
 
-def create_refresh_token(user_id: int, user_email: str) -> str:
+def create_refresh_token(user_id: int) -> str:
     """
     Refresh Token 생성
 
     Args:
         user_id: 사용자 ID
-        user_email: 사용자 이메일
 
     Returns:
         JWT refresh token
@@ -52,7 +49,6 @@ def create_refresh_token(user_id: int, user_email: str) -> str:
     expire = datetime.utcnow() + timedelta(days=settings.JWT_REFRESH_TOKEN_EXPIRE_DAYS)
     payload = {
         'user_id': user_id,
-        'email': user_email,
         'exp': expire,
         'iat': datetime.utcnow(),
         'type': 'refresh'


### PR DESCRIPTION
## Summary
JWT 토큰에서 email을 제거하여 보안 강화

## 변경 사항
- JWT payload: `{user_id, exp, iat, type}` (email 제거)
- `create_access_token(user_id)` - email 파라미터 제거
- `create_refresh_token(user_id)` - email 파라미터 제거

## 이유
- user_id로 충분히 사용자 조회 가능
- email 불필요한 노출 방지

## Test
```bash
python manage.py test users
```