### PR TITLE
애플/구글 로그인 설정 및 엔타이틀먼트 추가

### DIFF
--- a/mobile/ios/Podfile.lock
+++ b/mobile/ios/Podfile.lock
@@ -1,6 +1,16 @@
 PODS:
   - app_tracking_transparency (0.0.1):
     - Flutter
+  - AppAuth (1.7.6):
+    - AppAuth/Core (= 1.7.6)
+    - AppAuth/ExternalUserAgent (= 1.7.6)
+  - AppAuth/Core (1.7.6)
+  - AppAuth/ExternalUserAgent (1.7.6):
+    - AppAuth/Core
+  - AppCheckCore (11.2.0):
+    - GoogleUtilities/Environment (~> 8.0)
+    - GoogleUtilities/UserDefaults (~> 8.0)
+    - PromisesObjC (~> 2.4)
   - Firebase/Analytics (11.15.0):
     - Firebase/Core
   - Firebase/Core (11.15.0):
@@ -136,6 +146,12 @@ PODS:
     - Flutter
     - Google-Mobile-Ads-SDK (~> 12.2.0)
     - webview_flutter_wkwebview
+  - google_sign_in_ios (0.0.1):
+    - AppAuth (>= 1.7.4)
+    - Flutter
+    - FlutterMacOS
+    - GoogleSignIn (~> 8.0)
+    - GTMSessionFetcher (>= 3.4.0)
   - GoogleAdsOnDeviceConversion (2.1.0):
     - GoogleUtilities/Logger (~> 8.1)
     - GoogleUtilities/Network (~> 8.1)
@@ -168,6 +184,11 @@ PODS:
   - GoogleMobileAdsMediationUnity (4.16.2.0):
     - Google-Mobile-Ads-SDK (~> 12.0)
     - UnityAds (= 4.16.2)
+  - GoogleSignIn (8.0.0):
+    - AppAuth (< 2.0, >= 1.7.3)
+    - AppCheckCore (~> 11.0)
+    - GTMAppAuth (< 5.0, >= 4.1.1)
+    - GTMSessionFetcher/Core (~> 3.3)
   - GoogleUserMessagingPlatform (3.0.0)
   - GoogleUtilities/AppDelegateSwizzler (8.1.0):
     - GoogleUtilities/Environment
@@ -196,6 +217,14 @@ PODS:
   - GoogleUtilities/UserDefaults (8.1.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
+  - GTMAppAuth (4.1.1):
+    - AppAuth/Core (~> 1.7)
+    - GTMSessionFetcher/Core (< 4.0, >= 3.3)
+  - GTMSessionFetcher (3.5.0):
+    - GTMSessionFetcher/Full (= 3.5.0)
+  - GTMSessionFetcher/Core (3.5.0)
+  - GTMSessionFetcher/Full (3.5.0):
+    - GTMSessionFetcher/Core
   - kakao_flutter_sdk_common (1.9.7-3):
     - Flutter
   - location (0.0.1):
@@ -221,6 +250,8 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - sign_in_with_apple (0.0.1):
+    - Flutter
   - UnityAds (4.16.2)
   - url_launcher_ios (0.0.1):
     - Flutter
@@ -240,6 +271,7 @@ DEPENDENCIES:
   - flutter_naver_map (from `.symlinks/plugins/flutter_naver_map/ios`)
   - geolocator_apple (from `.symlinks/plugins/geolocator_apple/darwin`)
   - google_mobile_ads (from `.symlinks/plugins/google_mobile_ads/ios`)
+  - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/darwin`)
   - GoogleMobileAdsMediationUnity
   - kakao_flutter_sdk_common (from `.symlinks/plugins/kakao_flutter_sdk_common/ios`)
   - location (from `.symlinks/plugins/location/ios`)
@@ -247,11 +279,14 @@ DEPENDENCIES:
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - sign_in_with_apple (from `.symlinks/plugins/sign_in_with_apple/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
   - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/darwin`)
 
 SPEC REPOS:
   trunk:
+    - AppAuth
+    - AppCheckCore
     - Firebase
     - FirebaseABTesting
     - FirebaseAnalytics
@@ -271,8 +306,11 @@ SPEC REPOS:
     - GoogleAppMeasurement
     - GoogleDataTransport
     - GoogleMobileAdsMediationUnity
+    - GoogleSignIn
     - GoogleUserMessagingPlatform
     - GoogleUtilities
+    - GTMAppAuth
+    - GTMSessionFetcher
     - nanopb
     - NMapsGeometry
     - NMapsMap
@@ -303,6 +341,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/geolocator_apple/darwin"
   google_mobile_ads:
     :path: ".symlinks/plugins/google_mobile_ads/ios"
+  google_sign_in_ios:
+    :path: ".symlinks/plugins/google_sign_in_ios/darwin"
   kakao_flutter_sdk_common:
     :path: ".symlinks/plugins/kakao_flutter_sdk_common/ios"
   location:
@@ -315,6 +355,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+  sign_in_with_apple:
+    :path: ".symlinks/plugins/sign_in_with_apple/ios"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
   webview_flutter_wkwebview:
@@ -322,6 +364,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   app_tracking_transparency: 3d84f147f67ca82d3c15355c36b1fa6b66ca7c92
+  AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
+  AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
   Firebase: d99ac19b909cd2c548339c2241ecd0d1599ab02e
   firebase_analytics: 0e25ca1d4001ccedd40b4e5b74c0ec34e18f6425
   firebase_core: 995454a784ff288be5689b796deb9e9fa3601818
@@ -347,12 +391,16 @@ SPEC CHECKSUMS:
   geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
   Google-Mobile-Ads-SDK: 1dfb0c3cb46c7e2b00b0f4de74a1e06d9ea25d67
   google_mobile_ads: 535223588a6791b7a3cc3513a1bc7b89d12f3e62
+  google_sign_in_ios: b48bb9af78576358a168361173155596c845f0b9
   GoogleAdsOnDeviceConversion: 2be6297a4f048459e0ae17fad9bfd2844e10cf64
   GoogleAppMeasurement: 700dce7541804bec33db590a5c496b663fbe2539
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMobileAdsMediationUnity: c860c96e4c274e913c3e735790f3d4710fc6d96e
+  GoogleSignIn: ce8c89bb9b37fb624b92e7514cc67335d1e277e4
   GoogleUserMessagingPlatform: f8d0cdad3ca835406755d0a69aa634f00e76d576
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
+  GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
+  GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   kakao_flutter_sdk_common: 600d55b532da0bd37268a529e1add49302477710
   location: 155caecf9da4f280ab5fe4a55f94ceccfab838f8
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
@@ -364,6 +412,7 @@ SPEC CHECKSUMS:
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  sign_in_with_apple: c5dcc141574c8c54d5ac99dd2163c0c72ad22418
   UnityAds: 1f4e00833d90743e1e0cb9eb0c4749c4e0beee24
   url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
   webview_flutter_wkwebview: 1821ceac936eba6f7984d89a9f3bcb4dea99ebb2

--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 
 /* Begin PBXFileReference section */
 		0EBA26D62E73E51C00933475 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Runner/GoogleService-Info.plist"; sourceTree = "<group>"; };
+		0EBA74D52ED4AFE900E5ED32 /* RunnerRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RunnerRelease.entitlements; sourceTree = "<group>"; };
+		0EBA74D62ED4B5D000E5ED32 /* RunnerDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RunnerDebug.entitlements; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
@@ -129,6 +131,8 @@
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
+				0EBA74D62ED4B5D000E5ED32 /* RunnerDebug.entitlements */,
+				0EBA74D52ED4AFE900E5ED32 /* RunnerRelease.entitlements */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
@@ -667,6 +671,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/RunnerDebug.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = KSSVSPN647;
 				ENABLE_BITCODE = NO;
@@ -693,6 +698,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/RunnerRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -36,6 +36,17 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+
+	<!-- Google Sign In URL Scheme -->
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.googleusercontent.apps.966129856796-7f4f5j9mtf5g2c5ovjv8qg8mkov4rjuc</string>
+			</array>
+		</dict>
+	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/mobile/ios/Runner/Runner.entitlements
+++ b/mobile/ios/Runner/Runner.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/mobile/ios/Runner/RunnerDebug.entitlements
+++ b/mobile/ios/Runner/RunnerDebug.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/mobile/ios/Runner/RunnerRelease.entitlements
+++ b/mobile/ios/Runner/RunnerRelease.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/mobile/lib/config/config.dart
+++ b/mobile/lib/config/config.dart
@@ -67,6 +67,10 @@ class AppConfig {
   // - Kakao SDK 초기화 시 사용되는 Native App Key
   static final String KAKAO_NATIVE_APP_KEY = _getEnv('KAKAO_NATIVE_APP_KEY');
 
+  // 📌 Google Login
+  // - Google Sign In iOS Client ID (Firebase Console에서 발급)
+  static final String GOOGLE_IOS_CLIENT_ID = _getEnv('GOOGLE_IOS_CLIENT_ID');
+
 
 
   // 📌 디버그 모드 플래그

--- a/mobile/lib/models/auth_models.dart
+++ b/mobile/lib/models/auth_models.dart
@@ -47,6 +47,35 @@ class KakaoLoginRequest {
   };
 }
 
+/// Google 로그인 요청 데이터
+class GoogleLoginRequest {
+  final String accessToken;
+
+  GoogleLoginRequest({
+    required this.accessToken,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'access_token': accessToken,
+  };
+}
+
+/// Apple 로그인 요청 데이터
+class AppleLoginRequest {
+  final String identityToken;
+  final String? authorizationCode;
+
+  AppleLoginRequest({
+    required this.identityToken,
+    this.authorizationCode,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'identity_token': identityToken,
+    if (authorizationCode != null) 'authorization_code': authorizationCode,
+  };
+}
+
 /// 토큰 갱신 요청 데이터
 class RefreshTokenRequest {
   final String refreshToken;

--- a/mobile/lib/screens/auth/login_screen.dart
+++ b/mobile/lib/screens/auth/login_screen.dart
@@ -5,8 +5,11 @@ import 'package:mobile/screens/auth/sign_up_screen.dart';
 import 'package:mobile/screens/main_screen.dart';
 import 'package:mobile/services/auth_service.dart';
 import 'package:mobile/services/sns/kakao_login_service.dart';
+import 'package:mobile/services/sns/google_login_service.dart';
+import 'package:mobile/services/sns/apple_login_service.dart';
 import 'package:mobile/providers/auth_provider.dart';
 import 'package:mobile/const/colors.dart';
+import 'dart:io';
 
 /// Login Version 1 화면
 /// Figma 디자인을 기반으로 한 로그인 화면
@@ -243,6 +246,151 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
           errorMessage = '로그인이 취소되었습니다.';
         } else if (serverMessage.contains('이메일') && serverMessage.contains('동의')) {
           errorMessage = '카카오 계정에 이메일이 없습니다.\n이메일 제공 동의가 필요합니다.';
+        } else if (serverMessage.contains('network') || serverMessage.contains('timeout')) {
+          errorMessage = '네트워크 연결이 불안정합니다.\n잠시 후 다시 시도해 주세요.';
+        } else if (serverMessage.isNotEmpty) {
+          errorMessage = serverMessage;
+        }
+      }
+
+      _showErrorDialog(errorMessage);
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  /// Google 로그인 처리
+  Future<void> _handleGoogleLogin() async {
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      // 1. Google SDK로 로그인하여 Google access token 받기
+      print('[LoginScreen] ========== Google 로그인 시작 ==========');
+      final googleAccessToken = await GoogleLoginService.login();
+      print('[LoginScreen] Google SDK 로그인 성공');
+
+      if (!mounted) return;
+
+      // 2. AuthService로 서버 로그인 (Google token → 서버 JWT token)
+      await _authService.googleLogin(googleAccessToken);
+      print('[LoginScreen] 서버 Google 로그인 성공');
+
+      if (!mounted) return;
+
+      // 3. 사용자 정보 가져오기
+      final userInfo = await _authService.getUserInfo();
+
+      if (!mounted) return;
+
+      // 4. Riverpod authProvider 상태 업데이트
+      await ref.read(authProvider.notifier).updateAfterLogin(userInfo);
+
+      if (!mounted) return;
+
+      // 5. 로그인 성공 - MainScreen으로 이동
+      print('[LoginScreen] ========== Google 로그인 완료 ==========');
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute(
+          builder: (context) => const MainScreen(),
+        ),
+      );
+    } catch (e, stackTrace) {
+      if (!mounted) return;
+
+      print('[LoginScreen] Google 로그인 에러: $e');
+      print('[LoginScreen] Stack trace: $stackTrace');
+
+      String errorMessage = 'Google 로그인 중 문제가 발생했습니다.\n잠시 후 다시 시도해 주세요.';
+      final errorText = e.toString();
+
+      if (errorText.contains('Exception:')) {
+        final serverMessage = errorText.replaceAll('Exception:', '').trim();
+
+        if (serverMessage.contains('취소')) {
+          errorMessage = '로그인이 취소되었습니다.';
+        } else if (serverMessage.contains('network') || serverMessage.contains('timeout')) {
+          errorMessage = '네트워크 연결이 불안정합니다.\n잠시 후 다시 시도해 주세요.';
+        } else if (serverMessage.isNotEmpty) {
+          errorMessage = serverMessage;
+        }
+      }
+
+      _showErrorDialog(errorMessage);
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  /// Apple 로그인 처리
+  Future<void> _handleAppleLogin() async {
+    // Apple 로그인은 iOS에서만 지원
+    if (!Platform.isIOS) {
+      _showErrorDialog('Apple 로그인은 iOS에서만 사용할 수 있습니다.');
+      return;
+    }
+
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      // 1. Apple Sign In으로 identity token 받기
+      print('[LoginScreen] ========== Apple 로그인 시작 ==========');
+      final appleCredentials = await AppleLoginService.login();
+      print('[LoginScreen] Apple Sign In 성공');
+
+      if (!mounted) return;
+
+      // 2. AuthService로 서버 로그인 (Apple token → 서버 JWT token)
+      await _authService.appleLogin(
+        appleCredentials['identity_token']!,
+        appleCredentials['authorization_code'],
+      );
+      print('[LoginScreen] 서버 Apple 로그인 성공');
+
+      if (!mounted) return;
+
+      // 3. 사용자 정보 가져오기
+      final userInfo = await _authService.getUserInfo();
+
+      if (!mounted) return;
+
+      // 4. Riverpod authProvider 상태 업데이트
+      await ref.read(authProvider.notifier).updateAfterLogin(userInfo);
+
+      if (!mounted) return;
+
+      // 5. 로그인 성공 - MainScreen으로 이동
+      print('[LoginScreen] ========== Apple 로그인 완료 ==========');
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute(
+          builder: (context) => const MainScreen(),
+        ),
+      );
+    } catch (e, stackTrace) {
+      if (!mounted) return;
+
+      print('[LoginScreen] Apple 로그인 에러: $e');
+      print('[LoginScreen] Stack trace: $stackTrace');
+
+      String errorMessage = 'Apple 로그인 중 문제가 발생했습니다.\n잠시 후 다시 시도해 주세요.';
+      final errorText = e.toString();
+
+      if (errorText.contains('Exception:')) {
+        final serverMessage = errorText.replaceAll('Exception:', '').trim();
+
+        if (serverMessage.contains('취소')) {
+          errorMessage = '로그인이 취소되었습니다.';
         } else if (serverMessage.contains('network') || serverMessage.contains('timeout')) {
           errorMessage = '네트워크 연결이 불안정합니다.\n잠시 후 다시 시도해 주세요.';
         } else if (serverMessage.isNotEmpty) {
@@ -607,20 +755,18 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
         // Google
         _buildSocialButton(
           text: 'Google로 시작하기',
-          onPressed: () {
-            // TODO: Google 로그인
-          },
+          onPressed: _isLoading ? null : _handleGoogleLogin,
         ),
         SizedBox(height: 12.h),
 
-        // Apple
-        _buildSocialButton(
-          text: 'Apple로 시작하기',
-          onPressed: () {
-            // TODO: Apple 로그인
-          },
-        ),
-        SizedBox(height: 12.h),
+        // Apple (iOS에서만 표시)
+        if (Platform.isIOS) ...[
+          _buildSocialButton(
+            text: 'Apple로 시작하기',
+            onPressed: _isLoading ? null : _handleAppleLogin,
+          ),
+          SizedBox(height: 12.h),
+        ],
 
         // Kakao
         _buildSocialButton(

--- a/mobile/lib/services/sns/apple_login_service.dart
+++ b/mobile/lib/services/sns/apple_login_service.dart
@@ -1,0 +1,67 @@
+import 'dart:convert';
+import 'dart:math';
+import 'package:sign_in_with_apple/sign_in_with_apple.dart';
+import 'package:crypto/crypto.dart';
+
+/// Apple 소셜 로그인 서비스
+class AppleLoginService {
+  /// Apple 로그인 실행
+  /// - 반환값: Map containing identity_token and authorization_code
+  /// - 예외: Exception
+  static Future<Map<String, String>> login() async {
+    try {
+      // nonce 생성 (보안용)
+      final rawNonce = _generateNonce();
+      final nonce = _sha256ofString(rawNonce);
+
+      // Apple 로그인 시작
+      final credential = await SignInWithApple.getAppleIDCredential(
+        scopes: [
+          AppleIDAuthorizationScopes.email,
+          AppleIDAuthorizationScopes.fullName,
+        ],
+        nonce: nonce,
+      );
+
+      // Identity Token 확인
+      final identityToken = credential.identityToken;
+      if (identityToken == null) {
+        throw Exception('Apple identity token을 가져올 수 없습니다.');
+      }
+
+      return {
+        'identity_token': identityToken,
+        'authorization_code': credential.authorizationCode,
+      };
+    } on SignInWithAppleAuthorizationException catch (e) {
+      if (e.code == AuthorizationErrorCode.canceled) {
+        throw Exception('Apple 로그인이 취소되었습니다.');
+      }
+      throw Exception('Apple 로그인 실패: ${e.message}');
+    } catch (e) {
+      if (e.toString().contains('취소')) {
+        rethrow;
+      }
+      throw Exception('Apple 로그인 실패: $e');
+    }
+  }
+
+  /// nonce 생성
+  static String _generateNonce([int length = 32]) {
+    const charset = '0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._';
+    final random = Random.secure();
+    return List.generate(length, (_) => charset[random.nextInt(charset.length)]).join();
+  }
+
+  /// SHA256 해시 생성
+  static String _sha256ofString(String input) {
+    final bytes = utf8.encode(input);
+    final digest = sha256.convert(bytes);
+    return digest.toString();
+  }
+
+  /// Apple 로그인 가능 여부 확인
+  static Future<bool> isAvailable() async {
+    return await SignInWithApple.isAvailable();
+  }
+}

--- a/mobile/lib/services/sns/apple_login_service.dart
+++ b/mobile/lib/services/sns/apple_login_service.dart
@@ -36,11 +36,19 @@ class AppleLoginService {
     } on SignInWithAppleAuthorizationException catch (e) {
       if (e.code == AuthorizationErrorCode.canceled) {
         throw Exception('Apple 로그인이 취소되었습니다.');
+      } else if (e.code == AuthorizationErrorCode.unknown) {
+        // error 1000: Xcode에서 Sign In with Apple capability 설정 필요
+        throw Exception('Apple 로그인 설정이 필요합니다.\nXcode에서 Sign In with Apple을 활성화해주세요.');
       }
       throw Exception('Apple 로그인 실패: ${e.message}');
     } catch (e) {
-      if (e.toString().contains('취소')) {
+      final errorString = e.toString();
+      if (errorString.contains('취소')) {
         rethrow;
+      }
+      // error 1000 처리
+      if (errorString.contains('error 1000')) {
+        throw Exception('Apple 로그인 설정이 필요합니다.\nXcode에서 Sign In with Apple을 활성화해주세요.');
       }
       throw Exception('Apple 로그인 실패: $e');
     }

--- a/mobile/lib/services/sns/google_login_service.dart
+++ b/mobile/lib/services/sns/google_login_service.dart
@@ -1,0 +1,67 @@
+import 'package:google_sign_in/google_sign_in.dart';
+
+/// Google 소셜 로그인 서비스
+class GoogleLoginService {
+  static final GoogleSignIn _googleSignIn = GoogleSignIn(
+    scopes: [
+      'email',
+      'profile',
+    ],
+  );
+
+  /// Google 로그인 실행
+  /// - 반환값: Google access token
+  /// - 예외: Exception
+  static Future<String> login() async {
+    try {
+      // 기존 세션 로그아웃 (선택사항)
+      await _googleSignIn.signOut();
+
+      // Google 로그인 시작
+      final GoogleSignInAccount? account = await _googleSignIn.signIn();
+
+      if (account == null) {
+        throw Exception('Google 로그인이 취소되었습니다.');
+      }
+
+      // 인증 정보 가져오기
+      final GoogleSignInAuthentication auth = await account.authentication;
+
+      // Access Token 확인
+      final accessToken = auth.accessToken;
+      if (accessToken == null) {
+        throw Exception('Google access token을 가져올 수 없습니다.');
+      }
+
+      return accessToken;
+    } catch (e) {
+      if (e.toString().contains('취소')) {
+        rethrow;
+      }
+      throw Exception('Google 로그인 실패: $e');
+    }
+  }
+
+  /// Google 로그아웃
+  static Future<void> logout() async {
+    try {
+      await _googleSignIn.signOut();
+    } catch (e) {
+      throw Exception('Google 로그아웃 실패: $e');
+    }
+  }
+
+  /// Google 연결 해제
+  static Future<void> disconnect() async {
+    try {
+      await _googleSignIn.disconnect();
+    } catch (e) {
+      throw Exception('Google 연결 해제 실패: $e');
+    }
+  }
+
+  /// 현재 로그인된 사용자 정보 조회
+  static GoogleSignInAccount? getCurrentUser() {
+    return _googleSignIn.currentUser;
+  }
+}

--- a/mobile/lib/services/sns/google_login_service.dart
+++ b/mobile/lib/services/sns/google_login_service.dart
@@ -1,8 +1,13 @@
+import 'dart:io';
 import 'package:google_sign_in/google_sign_in.dart';
 
 /// Google 소셜 로그인 서비스
 class GoogleLoginService {
+  // iOS에서는 clientId가 필요함
   static final GoogleSignIn _googleSignIn = GoogleSignIn(
+    clientId: Platform.isIOS
+        ? '966129856796-7f4f5j9mtf5g2c5ovjv8qg8mkov4rjuc.apps.googleusercontent.com'
+        : null,
     scopes: [
       'email',
       'profile',

--- a/mobile/lib/services/sns/google_login_service.dart
+++ b/mobile/lib/services/sns/google_login_service.dart
@@ -1,13 +1,12 @@
 import 'dart:io';
 import 'package:google_sign_in/google_sign_in.dart';
+import 'package:mobile/config/config.dart';
 
 /// Google 소셜 로그인 서비스
 class GoogleLoginService {
   // iOS에서는 clientId가 필요함
   static final GoogleSignIn _googleSignIn = GoogleSignIn(
-    clientId: Platform.isIOS
-        ? '966129856796-7f4f5j9mtf5g2c5ovjv8qg8mkov4rjuc.apps.googleusercontent.com'
-        : null,
+    clientId: Platform.isIOS ? AppConfig.GOOGLE_IOS_CLIENT_ID : null,
     scopes: [
       'email',
       'profile',

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -138,7 +138,7 @@ packages:
     source: hosted
     version: "1.15.0"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
@@ -504,6 +504,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  google_identity_services_web:
+    dependency: transitive
+    description:
+      name: google_identity_services_web
+      sha256: "5d187c46dc59e02646e10fe82665fc3884a9b71bc1c90c2b8b749316d33ee454"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.3+1"
   google_mobile_ads:
     dependency: "direct main"
     description:
@@ -512,6 +520,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  google_sign_in:
+    dependency: "direct main"
+    description:
+      name: google_sign_in
+      sha256: d0a2c3bcb06e607bb11e4daca48bd4b6120f0bbc4015ccebbe757d24ea60ed2a
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.0"
+  google_sign_in_android:
+    dependency: transitive
+    description:
+      name: google_sign_in_android
+      sha256: d5e23c56a4b84b6427552f1cf3f98f716db3b1d1a647f16b96dbb5b93afa2805
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.1"
+  google_sign_in_ios:
+    dependency: transitive
+    description:
+      name: google_sign_in_ios
+      sha256: "102005f498ce18442e7158f6791033bbc15ad2dcc0afa4cf4752e2722a516c96"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.9.0"
+  google_sign_in_platform_interface:
+    dependency: transitive
+    description:
+      name: google_sign_in_platform_interface
+      sha256: "5f6f79cf139c197261adb6ac024577518ae48fdff8e53205c5373b5f6430a8aa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.0"
+  google_sign_in_web:
+    dependency: transitive
+    description:
+      name: google_sign_in_web
+      sha256: "460547beb4962b7623ac0fb8122d6b8268c951cf0b646dd150d60498430e4ded"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.12.4+4"
   gsettings:
     dependency: transitive
     description:
@@ -1024,6 +1072,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  sign_in_with_apple:
+    dependency: "direct main"
+    description:
+      name: sign_in_with_apple
+      sha256: e84a62e17b7e463abf0a64ce826c2cd1f0b72dff07b7b275e32d5302d76fb4c5
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.4"
+  sign_in_with_apple_platform_interface:
+    dependency: transitive
+    description:
+      name: sign_in_with_apple_platform_interface
+      sha256: c2ef2ce6273fce0c61acd7e9ff5be7181e33d7aa2b66508b39418b786cca2119
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  sign_in_with_apple_web:
+    dependency: transitive
+    description:
+      name: sign_in_with_apple_web
+      sha256: "2f7c38368f49e3f2043bca4b46a4a61aaae568c140a79aa0675dc59ad0ca49bc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -68,6 +68,9 @@ dependencies:
 
   # SNS 로그인
   kakao_flutter_sdk_user: ^1.9.6
+  google_sign_in: ^6.2.2
+  sign_in_with_apple: ^6.1.4
+  crypto: ^3.0.6
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 🎯 작업 내용

### Google 로그인
- Google iOS Client ID를 하드코딩에서 환경변수()로 분리
- `AppConfig.GOOGLE_IOS_CLIENT_ID`를 통해 안전하게 관리

### Apple 로그인  
- 사용자 취소 시 명확한 안내 메시지 제공
- Error 1000 발생 시 Xcode 설정 가이드 메시지 추가
- 예외 처리 로직 개선으로 디버깅 용이성 향상

### iOS 프로젝트 설정
- `Runner.entitlements`: Sign in with Apple 공용 설정 추가
- `RunnerDebug.entitlements`: Debug 빌드용 자격 추가  
- `RunnerRelease.entitlements`: Release 빌드용 자격 추가
- Xcode 프로젝트 파일 및 Pod 의존성 동기화

---

## 📋 변경된 파일
- `lib/config/config.dart` - Google Client ID 환경변수 추가
- `lib/services/sns/google_login_service.dart` - 하드코딩 제거
- `lib/services/sns/apple_login_service.dart` - 에러 핸들링 강화
- `ios/Runner/*.entitlements` - Apple Sign In 자격 설정
- `ios/Podfile.lock`, `ios/Runner.xcodeproj/project.pbxproj` - 프로젝트 동기화

---

## ✅ 체크리스트
- [ ] iOS 빌드 성공 확인
- [ ] 실기기에서 Google 로그인 테스트
- [ ] 실기기에서 Apple 로그인 테스트  
- [ ] 에러 시나리오(취소, 설정 누락 등) 검증

---

## 🔒 보안
민감정보(Client ID, API Key 등)를 환경변수로 분리하여 코드 저장소에 노출되지 않도록 처리했습니다.