### PR TITLE
로그인 화면 한글화 및 UI 개선

### DIFF
--- a/mobile/lib/screens/auth/login_screen.dart
+++ b/mobile/lib/screens/auth/login_screen.dart
@@ -110,59 +110,6 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     }
   }
 
-  /// 익명 로그인 처리
-  Future<void> _handleAnonymousLogin() async {
-    setState(() {
-      _isLoading = true;
-    });
-
-    try {
-      // 1. AuthService로 익명 로그인 수행 (세션 ID 저장)
-      await _authService.loginAnonymous();
-
-      if (!mounted) return;
-
-      // 2. 익명 사용자 정보 가져오기
-      final anonymousInfo = await _authService.getAnonymousUserInfo();
-
-      if (!mounted) return;
-
-      // 3. Riverpod authProvider 상태 업데이트
-      await ref.read(authProvider.notifier).updateAfterAnonymousLogin(anonymousInfo);
-
-      if (!mounted) return;
-
-      // 4. 익명 로그인 성공 - MainScreen으로 이동
-      Navigator.of(context).pushReplacement(
-        MaterialPageRoute(
-          builder: (context) => const MainScreen(),
-        ),
-      );
-    } catch (e) {
-      if (!mounted) return;
-
-      String errorMessage = '일시적인 오류가 발생했습니다.\n잠시 후 다시 시도해 주세요.';
-      final errorText = e.toString();
-
-      if (errorText.contains('Exception:')) {
-        final serverMessage = errorText.replaceAll('Exception:', '').trim();
-
-        if (serverMessage.contains('network') || serverMessage.contains('timeout')) {
-          errorMessage = '네트워크 연결이 불안정합니다.\n잠시 후 다시 시도해 주세요.';
-        } else {
-          errorMessage = serverMessage;
-        }
-      }
-
-      _showErrorDialog(errorMessage);
-    } finally {
-      if (mounted) {
-        setState(() {
-          _isLoading = false;
-        });
-      }
-    }
-  }
 
   /// Kakao 로그인 처리
   Future<void> _handleKakaoLogin() async {
@@ -477,27 +424,27 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                 ),
               ),
 
-              SizedBox(height: 12.h),
+              SizedBox(height: 16.h),
               
               // 로그인 버튼
               _buildLoginButton(),
 
-              SizedBox(height: 12.h),
+              SizedBox(height: 20.h),
 
               // 또는 구분선
               _buildOrDivider(),
 
-              SizedBox(height: 12.h),
+              SizedBox(height: 20.h),
 
               // 소셜 로그인 버튼들
               _buildSocialLoginButtons(),
 
-              SizedBox(height: 20.h),
+              SizedBox(height: 24.h),
 
               // 회원가입 링크
               _buildSignUpLink(),
 
-              SizedBox(height: 24.h),
+              SizedBox(height: 32.h),
             ],
           ),
         ),
@@ -716,7 +663,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     );
   }
 
-  // Or 구분선
+  // 또는 구분선
   Widget _buildOrDivider() {
     return Row(
       children: [
@@ -729,7 +676,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
         Padding(
           padding: EdgeInsets.symmetric(horizontal: 16.w),
           child: Text(
-            'Or',
+            '또는',
             style: TextStyle(
               fontSize: 12.sp,
               fontWeight: FontWeight.w400,
@@ -778,13 +725,6 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
           logoPath: 'asset/image/login/kakao.png',
           logoLeftPadding: -1,
           onPressed: _isLoading ? null : _handleKakaoLogin,
-        ),
-        SizedBox(height: 12.h),
-        
-        // 회원가입 없이 시작하기
-        _buildSocialButton(
-          text: '회원가입 없이 시작하기',
-          onPressed: _isLoading ? null : _handleAnonymousLogin,
         ),
       ],
     );
@@ -848,14 +788,14 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     );
   }
 
-  // Sign Up 링크
+  // 회원가입 링크
   Widget _buildSignUpLink() {
     return Center(
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
           Text(
-            "Don't have an account?",
+            '계정이 없으신가요?',
             style: TextStyle(
               fontSize: 12.sp,
               fontWeight: FontWeight.w500,
@@ -874,7 +814,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
               );
             },
             child: Text(
-              'Sign Up',
+              '회원가입',
               style: TextStyle(
                 fontSize: 12.sp,
                 fontWeight: FontWeight.w600,


### PR DESCRIPTION
## 🎯 작업 내용

### 로그인 화면 한글화
- **'Or'** → **'또는'**으로 변경
- **'Don't have an account?'** → **'계정이 없으신가요?'**로 변경
- **'Sign Up'** → **'회원가입'**으로 변경
- 사용자 친화적인 한글 UI로 개선

### UI 간소화
- **'회원가입 없이 시작하기' 버튼 제거**
  - 불필요한 익명 로그인 옵션 제거로 UI 단순화
  - 관련 함수(`_handleAnonymousLogin`) 삭제
- 소셜 로그인에 집중하여 사용자 경험 개선

### 레이아웃 밸런스 조정
버튼 제거에 따른 간격 재조정으로 시각적 균형 개선:
- 로그인 버튼 상단 간격: 12.h → **16.h**
- 로그인 버튼과 구분선 간격: 12.h → **20.h**
- 구분선과 소셜 로그인 간격: 12.h → **20.h**
- 소셜 로그인과 회원가입 링크 간격: 20.h → **24.h**
- 하단 여백: 24.h → **32.h**

---

## 📋 변경된 파일
- `lib/screens/auth/login_screen.dart` - 한글화, UI 간소화, 레이아웃 조정

---

## 🎨 개선 효과
- ✅ 한글 UI로 국내 사용자 접근성 향상
- ✅ 불필요한 옵션 제거로 의사결정 단순화
- ✅ 간격 조정으로 시각적으로 더 균형잡힌 레이아웃
- ✅ 소셜 로그인에 집중하여 전환율 개선 기대

---

## ✅ 테스트
- [x] Lint 오류 없음
- [x] 코드 정리 완료 (미사용 함수 제거)
- [ ] iOS/Android 실기기 테스트 필요