### PR TITLE
feat: 강제/권장 업데이트 기능 구현 (논리 버전 기반)

### DIFF
--- a/mobile/lib/config/app_version.dart
+++ b/mobile/lib/config/app_version.dart
@@ -1,0 +1,72 @@
+/// 앱 논리 버전 (Logical Version) 관리
+///
+/// 스토어 버전과 별개로 앱 내부에서 사용하는 논리적 버전입니다.
+/// 서버의 버전 정책과 비교하여 강제/권장 업데이트를 결정합니다.
+///
+/// 사용 예시:
+/// - 서버 min_version보다 낮으면 강제 업데이트
+/// - 서버 latest_version보다 낮으면 권장 업데이트
+/// - 서버 latest_version 이상이면 업데이트 안내 없음
+class AppVersion {
+  AppVersion._();
+
+  /// 현재 앱의 논리 버전
+  ///
+  /// 새 버전 배포 시 이 값을 업데이트합니다.
+  /// Semantic Versioning (major.minor.patch) 형식을 따릅니다.
+  static const String current = '2.0.0';
+
+  /// 버전 문자열을 파싱하여 비교 가능한 형태로 변환
+  ///
+  /// 예: "1.4.0" -> [1, 4, 0]
+  static List<int> parse(String version) {
+    final parts = version.split('.');
+    return parts.map((part) => int.tryParse(part) ?? 0).toList();
+  }
+
+  /// 두 버전 문자열 비교
+  ///
+  /// Returns:
+  /// - 음수: version1 < version2
+  /// - 0: version1 == version2
+  /// - 양수: version1 > version2
+  static int compare(String version1, String version2) {
+    final v1Parts = parse(version1);
+    final v2Parts = parse(version2);
+
+    // 가장 긴 버전 기준으로 비교
+    final maxLength = v1Parts.length > v2Parts.length
+        ? v1Parts.length
+        : v2Parts.length;
+
+    for (int i = 0; i < maxLength; i++) {
+      final v1 = i < v1Parts.length ? v1Parts[i] : 0;
+      final v2 = i < v2Parts.length ? v2Parts[i] : 0;
+
+      if (v1 < v2) return -1;
+      if (v1 > v2) return 1;
+    }
+
+    return 0; // 동일한 버전
+  }
+
+  /// version1이 version2보다 낮은지 확인
+  static bool isLowerThan(String version1, String version2) {
+    return compare(version1, version2) < 0;
+  }
+
+  /// version1이 version2 이상인지 확인
+  static bool isGreaterOrEqual(String version1, String version2) {
+    return compare(version1, version2) >= 0;
+  }
+
+  /// 현재 버전이 주어진 버전보다 낮은지 확인
+  static bool currentIsLowerThan(String version) {
+    return isLowerThan(current, version);
+  }
+
+  /// 현재 버전이 주어진 버전 이상인지 확인
+  static bool currentIsGreaterOrEqual(String version) {
+    return isGreaterOrEqual(current, version);
+  }
+}

--- a/mobile/lib/models/version_check_models.dart
+++ b/mobile/lib/models/version_check_models.dart
@@ -1,51 +1,102 @@
+import '../config/app_version.dart';
+
 /// 버전 체크 API 응답 모델
+///
+/// 서버에서 받은 버전 정책 정보를 담는 모델입니다.
+/// 클라이언트에서 논리 버전과 비교하여 업데이트 필요 여부를 판단합니다.
 class VersionCheckResponse {
-  /// 업데이트 필요 여부 (false=최신, true=업데이트 필요)
-  final bool needsUpdate;
-
-  /// 강제 업데이트 여부 (true=필수 업데이트)
-  final bool forceUpdate;
-
-  /// 서버의 최신 버전
+  /// 서버에서 정의한 최신 버전
   final String latestVersion;
 
-  /// 업데이트 안내 메시지
-  final String? message;
+  /// 서버에서 정의한 최소 지원 버전
+  final String minVersion;
+
+  /// 강제 업데이트 여부 (서버 정책)
+  final bool forceUpdate;
 
   /// 앱 스토어 다운로드 URL
   final String storeUrl;
 
+  /// 업데이트 안내 제목 (서버에서 제공, 없으면 기본값 사용)
+  final String? messageTitle;
+
+  /// 업데이트 안내 본문 (서버에서 제공, 없으면 기본값 사용)
+  final String? messageBody;
+
   VersionCheckResponse({
-    required this.needsUpdate,
-    required this.forceUpdate,
     required this.latestVersion,
-    this.message,
+    required this.minVersion,
+    required this.forceUpdate,
     required this.storeUrl,
+    this.messageTitle,
+    this.messageBody,
   });
 
   factory VersionCheckResponse.fromJson(Map<String, dynamic> json) {
     return VersionCheckResponse(
-      needsUpdate: json['needs_update'] as bool,
-      forceUpdate: json['force_update'] as bool,
       latestVersion: json['latest_version'] as String,
-      message: json['message'] as String?,
+      minVersion: json['min_version'] as String,
+      forceUpdate: json['force_update'] as bool,
       storeUrl: json['store_url'] as String,
+      messageTitle: json['message_title'] as String?,
+      messageBody: json['message_body'] as String?,
     );
   }
 
   Map<String, dynamic> toJson() {
     return {
-      'needs_update': needsUpdate,
-      'force_update': forceUpdate,
       'latest_version': latestVersion,
-      'message': message,
+      'min_version': minVersion,
+      'force_update': forceUpdate,
       'store_url': storeUrl,
+      'message_title': messageTitle,
+      'message_body': messageBody,
     };
+  }
+
+  /// 업데이트 필요 여부 (클라이언트에서 계산)
+  ///
+  /// 현재 앱 버전이 최신 버전보다 낮으면 업데이트 필요
+  bool get needsUpdate => AppVersion.currentIsLowerThan(latestVersion);
+
+  /// 강제 업데이트 필요 여부 (클라이언트에서 계산)
+  ///
+  /// 현재 앱 버전이 최소 지원 버전보다 낮으면 강제 업데이트 필요
+  bool get requiresForceUpdate => AppVersion.currentIsLowerThan(minVersion);
+
+  /// 업데이트 유형 결정
+  UpdateType get updateType {
+    if (requiresForceUpdate) {
+      return UpdateType.force;
+    } else if (needsUpdate) {
+      return UpdateType.recommended;
+    } else {
+      return UpdateType.none;
+    }
   }
 
   @override
   String toString() {
-    return 'VersionCheckResponse(needsUpdate: $needsUpdate, forceUpdate: $forceUpdate, '
-        'latestVersion: $latestVersion, message: $message, storeUrl: $storeUrl)';
+    return 'VersionCheckResponse('
+        'latestVersion: $latestVersion, '
+        'minVersion: $minVersion, '
+        'forceUpdate: $forceUpdate, '
+        'storeUrl: $storeUrl, '
+        'messageTitle: $messageTitle, '
+        'messageBody: $messageBody, '
+        'needsUpdate: $needsUpdate, '
+        'requiresForceUpdate: $requiresForceUpdate)';
   }
+}
+
+/// 업데이트 유형
+enum UpdateType {
+  /// 업데이트 불필요 (최신 버전 사용 중)
+  none,
+
+  /// 권장 업데이트 (사용자 선택 가능)
+  recommended,
+
+  /// 강제 업데이트 (필수)
+  force,
 }

--- a/mobile/lib/screens/main_screen.dart
+++ b/mobile/lib/screens/main_screen.dart
@@ -11,18 +11,16 @@ import 'package:mobile/providers/location_provider.dart';
 import 'package:mobile/providers/auth_provider.dart';
 import 'package:mobile/services/version_service.dart';
 import 'package:mobile/widgets/update_dialog.dart';
-
-
-// import '../widgets/exit_reward_dialog.dart';
-// import '../ads/rewarded_ad_service.dart';
+import 'package:mobile/models/version_check_models.dart';
 
 
 /// MainScreen
 /// ------------------------------------------------------
 /// 하단 탭 내비게이션 컨테이너.
 /// - 탭: 홈 / 지도 / 알림 / 내정보
-/// - 상태 보존: IndexedStack 사용 → 탭 전환 시 각 화면의 상태(스크롤, 지도 컨트롤러 등) 유지
+/// - 상태 보존: IndexedStack 사용 -> 탭 전환 시 각 화면의 상태(스크롤, 지도 컨트롤러 등) 유지
 /// - 인증 체크: 알림/내정보 탭은 회원만 접근 가능
+/// - 버전 체크: 앱 시작 시 업데이트 필요 여부 확인
 class MainScreen extends ConsumerStatefulWidget {
   const MainScreen({super.key});
 
@@ -51,9 +49,6 @@ class _MainScreenState extends ConsumerState<MainScreen> {
   @override
   void initState() {
     super.initState();
-    // 디버그 포함: 첫 프레임 이후, 홈 탭일 때 1회만 업데이트 체크
-    // 리워드 광고 미리 로드 (비활성화)
-    // RewardedAdService().loadAd();
 
     // 앱 시작 시 권한/위치 초기화 및 인증 상태 체크
     Future.microtask(() async{
@@ -63,7 +58,7 @@ class _MainScreenState extends ConsumerState<MainScreen> {
 
     _tabs = [
       const HomeScreen(),
-      null, // MapScreen은 아직 생성하지 않음 → 권한 팝업 안뜸
+      null, // MapScreen은 아직 생성하지 않음 -> 권한 팝업 안뜸
       null, // NotificationScreen도 lazy loading
       null, // ProfileScreen도 lazy loading
     ];
@@ -111,11 +106,9 @@ class _MainScreenState extends ConsumerState<MainScreen> {
         _tabs[3] = const ProfileScreen();
       }
     });
-
-    // 탭 전환 시에는 업데이트 체크 트리거 금지 (홈 초회만)
   }
 
-  /// 뒤로가기 버튼 처리 (리워드 광고 비활성화)
+  /// 뒤로가기 버튼 처리
   Future<bool> _onWillPop() async {
     // 홈 탭이 아니면 홈으로 이동
     if (_selectedIndex != 0) {
@@ -125,16 +118,6 @@ class _MainScreenState extends ConsumerState<MainScreen> {
 
     // 홈 탭에서 뒤로가기 시 바로 종료
     return true;
-
-    // 리워드 광고 다이얼로그 표시 (비활성화)
-    // final shouldExit = await ExitRewardDialog.show(
-    //   context,
-    //   onRewardEarned: () {
-    //     // 보상 지급 로직 (예: 프리미엄 정보 해제, 쿠폰 지급 등)
-    //     debugPrint('🎁 사용자가 리워드를 획득했습니다!');
-    //   },
-    // );
-    // return shouldExit ?? false;
   }
 
   @override
@@ -154,7 +137,6 @@ class _MainScreenState extends ConsumerState<MainScreen> {
         }
       },
       child: Scaffold(
-      // ✅ IndexedStack: 현재 탭만 보이되, 나머지 탭도 트리에 남아 상태 보존
       body: Column(
         children: [
           Expanded(
@@ -195,7 +177,6 @@ class _MainScreenState extends ConsumerState<MainScreen> {
         onTap: _onItemTapped,
         showUnselectedLabels: true,
 
-        // 📌 폰트 배율에 따른 동적 크기 조정
         iconSize: (isTab ? 32.0 : 24.0) * (1.0 + (MediaQuery.textScalerOf(context).textScaleFactor - 1.0) * 0.3).clamp(1.0, 1.2),
         selectedFontSize: (isTab ? 25.0 : 12.0) * (1.0 + (MediaQuery.textScalerOf(context).textScaleFactor - 1.0) * 0.5).clamp(1.0, 1.3),
         unselectedFontSize: (isTab ? 25.0 : 12.0) * (1.0 + (MediaQuery.textScalerOf(context).textScaleFactor - 1.0) * 0.5).clamp(1.0, 1.3),
@@ -206,8 +187,10 @@ class _MainScreenState extends ConsumerState<MainScreen> {
   }
 
   // ----------------------------------------------------------
-  // App Store에서 최신 버전 조회 → 새 버전이면 배너/스낵바로 안내
+  // 버전 체크 로직
   // ----------------------------------------------------------
+
+  /// 홈 탭 첫 진입 시 1회만 업데이트 체크
   void _maybeCheckUpdateOnFirstHome() {
     if (_selectedIndex != 0) return; // 홈 탭이 아닐 때 무시
     if (_didCheckUpdateOnce) return; // 세션당 1회만
@@ -217,20 +200,34 @@ class _MainScreenState extends ConsumerState<MainScreen> {
 
   /// 백엔드 API를 통한 버전 체크
   ///
-  /// - iOS와 Android 모두 지원
-  /// - 서버에서 플랫폼별 최신 버전 정보 관리
-  /// - 강제 업데이트 또는 선택적 업데이트 다이얼로그 표시
+  /// 논리 버전(Logical Version) 기반으로 업데이트 필요 여부를 판단합니다.
+  /// - current < min_version: 강제 업데이트
+  /// - current < latest_version: 권장 업데이트 (스킵 기간 고려)
+  /// - current >= latest_version: 안내 없음
   Future<void> _checkAppVersion() async {
     try {
-      final result = await _versionService.checkVersion();
-
-      // 업데이트가 필요한 경우 다이얼로그 표시
-      if (result.needsUpdate && mounted) {
-        await UpdateDialog.show(context, result);
-      }
+      await _versionService.checkAndNotify(
+        onForceUpdate: (result) {
+          if (mounted) {
+            UpdateDialog.showForceUpdate(context, result);
+          }
+        },
+        onRecommendedUpdate: (result) {
+          if (mounted) {
+            UpdateDialog.showRecommendedUpdate(context, result);
+          }
+        },
+        onLatest: () {
+          // 최신 버전 사용 중 - 아무 동작 없음
+          debugPrint('App is up to date');
+        },
+        onError: (error) {
+          // 버전 체크 실패 시 조용히 무시 (네트워크 이슈 등)
+          debugPrint('Version check failed: $error');
+        },
+      );
     } catch (e) {
-      // 버전 체크 실패 시 조용히 무시 (네트워크 이슈 등)
-      debugPrint('Version check failed: $e');
+      debugPrint('Version check error: $e');
     }
   }
 }

--- a/mobile/lib/services/version_service.dart
+++ b/mobile/lib/services/version_service.dart
@@ -1,41 +1,44 @@
 import 'dart:convert';
 import 'dart:io';
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
-import 'package:package_info_plus/package_info_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../config/config.dart';
+import '../config/app_version.dart';
 import '../models/version_check_models.dart';
 
 /// 버전 체크 서비스
 ///
 /// 백엔드 API를 호출하여 앱 업데이트 필요 여부를 확인합니다.
-/// - 현재 앱 버전과 플랫폼 정보를 서버에 전송
-/// - 서버는 최신 버전 정보와 업데이트 필요 여부를 반환
-/// - Semantic Versioning (major.minor.patch) 기반 비교
+/// - 논리 버전(Logical Version) 기반 비교
+/// - 클라이언트에서 버전 비교 로직 수행
+/// - 권장 업데이트 시 "나중에" 선택 후 일정 기간 재표시 방지
 class VersionService {
+  /// SharedPreferences 키: 권장 업데이트 스킵 시간
+  static const String _skipUntilKey = 'update_skip_until';
+
+  /// 권장 업데이트 스킵 기간 (일)
+  static const int skipDays = 3;
+
   /// 버전 체크 API 호출
   ///
   /// Returns:
-  /// - VersionCheckResponse: 업데이트 필요 여부 및 최신 버전 정보
+  /// - VersionCheckResponse: 버전 정책 정보
   ///
   /// Throws:
   /// - Exception: API 호출 실패 시
   Future<VersionCheckResponse> checkVersion() async {
     try {
-      // 1. 현재 앱 버전 정보 가져오기
-      final packageInfo = await PackageInfo.fromPlatform();
-      final currentVersion = packageInfo.version; // 예: "1.4.0"
-
-      // 2. 플랫폼 확인 (iOS 또는 Android)
+      // 1. 플랫폼 확인 (iOS 또는 Android)
       final platform = Platform.isIOS ? 'ios' : 'android';
 
-      // 3. API 엔드포인트 URL 생성
+      // 2. API 엔드포인트 URL 생성
       final url = Uri.parse('${AppConfig.ReviewMapbaseUrl}/app-config/version')
           .replace(queryParameters: {
         'platform': platform,
-        'current_version': currentVersion,
       });
 
-      // 4. API 호출
+      // 3. API 호출
       final response = await http.get(
         url,
         headers: {
@@ -44,45 +47,110 @@ class VersionService {
         },
       );
 
-      // 5. 응답 상태 코드 확인
+      // 4. 응답 상태 코드 확인
       if (response.statusCode != 200) {
         throw Exception(
           'Version check API failed with status: ${response.statusCode}',
         );
       }
 
-      // 6. JSON 파싱 및 모델 변환
+      // 5. JSON 파싱 및 모델 변환
       final Map<String, dynamic> data = jsonDecode(response.body);
       return VersionCheckResponse.fromJson(data);
     } catch (e) {
-      // 에러 발생 시 예외를 다시 던져서 호출자가 처리하도록 함
       throw Exception('Failed to check app version: $e');
     }
   }
 
-  /// 버전 체크 및 업데이트 안내 (선택적 사용)
+  /// 권장 업데이트를 표시해야 하는지 확인
   ///
-  /// 버전 체크를 수행하고 결과를 콜백으로 전달합니다.
+  /// "나중에" 선택 후 [skipDays]일 동안은 false를 반환합니다.
+  Future<bool> shouldShowRecommendedUpdate() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final skipUntilMs = prefs.getInt(_skipUntilKey);
+
+      if (skipUntilMs == null) {
+        return true; // 스킵 기록 없음 -> 표시
+      }
+
+      final skipUntil = DateTime.fromMillisecondsSinceEpoch(skipUntilMs);
+      final now = DateTime.now();
+
+      if (now.isAfter(skipUntil)) {
+        // 스킵 기간 만료 -> 기록 삭제 후 표시
+        await prefs.remove(_skipUntilKey);
+        return true;
+      }
+
+      return false; // 스킵 기간 내 -> 표시하지 않음
+    } catch (e) {
+      debugPrint('Error checking update skip status: $e');
+      return true; // 오류 시 기본적으로 표시
+    }
+  }
+
+  /// 권장 업데이트 "나중에" 선택 시 호출
+  ///
+  /// [skipDays]일 동안 권장 업데이트 다이얼로그를 표시하지 않습니다.
+  Future<void> skipRecommendedUpdate() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final skipUntil = DateTime.now().add(Duration(days: skipDays));
+      await prefs.setInt(_skipUntilKey, skipUntil.millisecondsSinceEpoch);
+      debugPrint('Update skipped until: $skipUntil');
+    } catch (e) {
+      debugPrint('Error saving update skip: $e');
+    }
+  }
+
+  /// 스킵 기록 초기화 (테스트/디버그용)
+  Future<void> clearSkipRecord() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove(_skipUntilKey);
+    } catch (e) {
+      debugPrint('Error clearing skip record: $e');
+    }
+  }
+
+  /// 버전 체크 및 업데이트 안내 (콜백 방식)
   ///
   /// Parameters:
-  /// - onUpdateNeeded: 업데이트 필요 시 호출될 콜백 (강제 업데이트 여부 포함)
-  /// - onLatest: 최신 버전일 때 호출될 콜백
-  /// - onError: 에러 발생 시 호출될 콜백
+  /// - onForceUpdate: 강제 업데이트 필요 시 호출
+  /// - onRecommendedUpdate: 권장 업데이트 필요 시 호출
+  /// - onLatest: 최신 버전일 때 호출
+  /// - onError: 에러 발생 시 호출
   Future<void> checkAndNotify({
-    required Function(VersionCheckResponse response) onUpdateNeeded,
+    required Function(VersionCheckResponse response) onForceUpdate,
+    required Function(VersionCheckResponse response) onRecommendedUpdate,
     required Function() onLatest,
     required Function(String error) onError,
   }) async {
     try {
       final result = await checkVersion();
 
-      if (result.needsUpdate) {
-        onUpdateNeeded(result);
-      } else {
-        onLatest();
+      switch (result.updateType) {
+        case UpdateType.force:
+          onForceUpdate(result);
+          break;
+        case UpdateType.recommended:
+          // 권장 업데이트는 스킵 기간 확인
+          if (await shouldShowRecommendedUpdate()) {
+            onRecommendedUpdate(result);
+          } else {
+            onLatest(); // 스킵 기간 내면 최신 버전처럼 처리
+          }
+          break;
+        case UpdateType.none:
+          onLatest();
+          break;
       }
     } catch (e) {
       onError(e.toString());
     }
   }
+
+  /// 현재 앱 버전 반환
+  String get currentVersion => AppVersion.current;
 }

--- a/mobile/lib/widgets/update_dialog.dart
+++ b/mobile/lib/widgets/update_dialog.dart
@@ -1,18 +1,25 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../models/version_check_models.dart';
+import '../services/version_service.dart';
+import '../config/app_version.dart';
 
 /// 앱 업데이트 안내 다이얼로그
 ///
-/// 서버에서 받은 버전 정보를 바탕으로 사용자에게 업데이트를 안내합니다.
+/// 네이버 스타일의 깔끔한 디자인으로 업데이트를 안내합니다.
 /// - 강제 업데이트: 닫기 버튼 없이 스토어로만 이동 가능
-/// - 선택적 업데이트: "나중에" 버튼으로 닫을 수 있음
+/// - 권장 업데이트: "나중에" 버튼으로 닫을 수 있으며, 일정 기간 재표시 방지
 class UpdateDialog extends StatelessWidget {
   final VersionCheckResponse versionInfo;
+  final bool isForceUpdate;
+  final VoidCallback? onSkip;
 
   const UpdateDialog({
     super.key,
     required this.versionInfo,
+    required this.isForceUpdate,
+    this.onSkip,
   });
 
   /// 스토어 URL 열기
@@ -41,104 +48,221 @@ class UpdateDialog extends StatelessWidget {
     }
   }
 
+  /// "나중에" 버튼 클릭 처리
+  void _handleSkip(BuildContext context) {
+    onSkip?.call();
+    Navigator.of(context).pop();
+  }
+
   @override
   Widget build(BuildContext context) {
+    // 강제 업데이트 vs 권장 업데이트에 따른 문구 결정
+    final String title = isForceUpdate
+        ? (versionInfo.messageTitle ?? '업데이트 안내')
+        : (versionInfo.messageTitle ?? '새 버전이 있어요');
+
+    final String body = isForceUpdate
+        ? (versionInfo.messageBody ?? '최신 버전으로 업데이트한 뒤 이용해 주세요.')
+        : (versionInfo.messageBody ?? '더 나은 서비스 이용을 위해 업데이트를 추천드려요.');
+
     return PopScope(
       // 강제 업데이트일 경우 뒤로가기 버튼 비활성화
-      canPop: !versionInfo.forceUpdate,
-      child: AlertDialog(
-        title: Text(
-          versionInfo.forceUpdate ? '필수 업데이트' : '업데이트 안내',
-          style: const TextStyle(
-            fontWeight: FontWeight.bold,
-          ),
+      canPop: !isForceUpdate,
+      child: Dialog(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16.r),
         ),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // 업데이트 메시지
-            Text(
-              versionInfo.message ?? '새로운 버전이 출시되었습니다.',
-              style: const TextStyle(fontSize: 14),
-            ),
-            const SizedBox(height: 16),
-            // 버전 정보
-            Container(
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: Colors.grey[100],
-                borderRadius: BorderRadius.circular(8),
+        child: Container(
+          padding: EdgeInsets.all(24.w),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // 제목
+              Text(
+                title,
+                style: TextStyle(
+                  fontSize: 18.sp,
+                  fontWeight: FontWeight.w700,
+                  color: Colors.black87,
+                ),
+                textAlign: TextAlign.center,
               ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
-                    children: [
-                      const Text(
-                        '최신 버전: ',
-                        style: TextStyle(
-                          fontSize: 13,
-                          color: Colors.black54,
-                        ),
-                      ),
-                      Text(
-                        versionInfo.latestVersion,
-                        style: const TextStyle(
-                          fontSize: 13,
-                          fontWeight: FontWeight.bold,
-                          color: Colors.blue,
-                        ),
-                      ),
-                    ],
-                  ),
-                  if (versionInfo.forceUpdate) ...[
-                    const SizedBox(height: 8),
-                    const Text(
-                      '⚠️ 계속 사용하려면 업데이트가 필요합니다',
+              SizedBox(height: 16.h),
+
+              // 본문
+              Text(
+                body,
+                style: TextStyle(
+                  fontSize: 14.sp,
+                  color: Colors.black54,
+                  height: 1.5,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              SizedBox(height: 20.h),
+
+              // 버전 정보
+              Container(
+                padding: EdgeInsets.symmetric(
+                  horizontal: 16.w,
+                  vertical: 12.h,
+                ),
+                decoration: BoxDecoration(
+                  color: Colors.grey[100],
+                  borderRadius: BorderRadius.circular(8.r),
+                ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text(
+                      '현재 버전 ${AppVersion.current}',
                       style: TextStyle(
-                        fontSize: 12,
-                        color: Colors.red,
+                        fontSize: 12.sp,
+                        color: Colors.black45,
+                      ),
+                    ),
+                    Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 8.w),
+                      child: Icon(
+                        Icons.arrow_forward,
+                        size: 14.sp,
+                        color: Colors.black45,
+                      ),
+                    ),
+                    Text(
+                      '최신 버전 ${versionInfo.latestVersion}',
+                      style: TextStyle(
+                        fontSize: 12.sp,
+                        fontWeight: FontWeight.w600,
+                        color: Theme.of(context).primaryColor,
                       ),
                     ),
                   ],
-                ],
+                ),
               ),
-            ),
-          ],
-        ),
-        actions: [
-          // 선택적 업데이트일 경우에만 "나중에" 버튼 표시
-          if (!versionInfo.forceUpdate)
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('나중에'),
-            ),
-          // 업데이트 버튼
-          ElevatedButton(
-            onPressed: () => _openStore(context),
-            style: ElevatedButton.styleFrom(
-              backgroundColor: Colors.blue,
-              foregroundColor: Colors.white,
-            ),
-            child: const Text('업데이트'),
+              SizedBox(height: 24.h),
+
+              // 버튼 영역
+              if (isForceUpdate)
+                // 강제 업데이트: 업데이트하기 버튼만 표시
+                _buildPrimaryButton(context, '업데이트하기')
+              else
+                // 권장 업데이트: 업데이트하기 + 나중에 버튼
+                Column(
+                  children: [
+                    _buildPrimaryButton(context, '업데이트하기'),
+                    SizedBox(height: 8.h),
+                    _buildSecondaryButton(context, '나중에'),
+                  ],
+                ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }
 
-  /// 다이얼로그 표시 헬퍼 함수
+  /// 주요 버튼 (업데이트하기)
+  Widget _buildPrimaryButton(BuildContext context, String text) {
+    return SizedBox(
+      width: double.infinity,
+      height: 48.h,
+      child: ElevatedButton(
+        onPressed: () => _openStore(context),
+        style: ElevatedButton.styleFrom(
+          backgroundColor: Theme.of(context).primaryColor,
+          foregroundColor: Colors.white,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8.r),
+          ),
+          elevation: 0,
+        ),
+        child: Text(
+          text,
+          style: TextStyle(
+            fontSize: 15.sp,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// 보조 버튼 (나중에)
+  Widget _buildSecondaryButton(BuildContext context, String text) {
+    return SizedBox(
+      width: double.infinity,
+      height: 48.h,
+      child: TextButton(
+        onPressed: () => _handleSkip(context),
+        style: TextButton.styleFrom(
+          foregroundColor: Colors.black54,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8.r),
+          ),
+        ),
+        child: Text(
+          text,
+          style: TextStyle(
+            fontSize: 15.sp,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// 강제 업데이트 다이얼로그 표시
   ///
-  /// 편리하게 다이얼로그를 띄울 수 있는 정적 메서드입니다.
-  static Future<void> show(
+  /// 뒤로가기, 바깥 영역 클릭으로 닫을 수 없습니다.
+  static Future<void> showForceUpdate(
     BuildContext context,
     VersionCheckResponse versionInfo,
   ) {
     return showDialog(
       context: context,
-      barrierDismissible: !versionInfo.forceUpdate, // 강제 업데이트 시 바깥 영역 클릭으로 닫기 불가
-      builder: (context) => UpdateDialog(versionInfo: versionInfo),
+      barrierDismissible: false,
+      builder: (context) => UpdateDialog(
+        versionInfo: versionInfo,
+        isForceUpdate: true,
+      ),
     );
+  }
+
+  /// 권장 업데이트 다이얼로그 표시
+  ///
+  /// "나중에" 선택 시 일정 기간 동안 다시 표시하지 않습니다.
+  static Future<void> showRecommendedUpdate(
+    BuildContext context,
+    VersionCheckResponse versionInfo,
+  ) {
+    final versionService = VersionService();
+
+    return showDialog(
+      context: context,
+      barrierDismissible: true,
+      builder: (context) => UpdateDialog(
+        versionInfo: versionInfo,
+        isForceUpdate: false,
+        onSkip: () {
+          // "나중에" 선택 시 스킵 기록 저장
+          versionService.skipRecommendedUpdate();
+        },
+      ),
+    );
+  }
+
+  /// 레거시 호환용 show 메서드
+  @Deprecated('Use showForceUpdate or showRecommendedUpdate instead')
+  static Future<void> show(
+    BuildContext context,
+    VersionCheckResponse versionInfo,
+  ) {
+    if (versionInfo.requiresForceUpdate) {
+      return showForceUpdate(context, versionInfo);
+    } else {
+      return showRecommendedUpdate(context, versionInfo);
+    }
   }
 }


### PR DESCRIPTION
## Summary

- 논리 버전(Logical Version) 기반 강제/권장 업데이트 기능 구현
- 스토어 버전 대신 앱 내부 상수 버전(2.0.0)으로 업데이트 판단
- 네이버 스타일의 깔끔한 업데이트 다이얼로그 UI
- "나중에" 선택 시 3일간 재표시 방지

## Changes

### 1. 논리 버전 관리 구조 (lib/config/app_version.dart)
- `AppVersion.current = '2.0.0'` 상수로 버전 관리
- Semantic Versioning (major.minor.patch) 기반 버전 비교 로직
- `compare()`, `isLowerThan()`, `isGreaterOrEqual()` 헬퍼 메서드

### 2. API 모델 리팩토링 (lib/models/version_check_models.dart)
- 서버 응답 필드 변경: `message_title`, `message_body` 추가
- 클라이언트에서 버전 비교 수행:
  - `current < min_version` → 강제 업데이트
  - `current < latest_version` → 권장 업데이트
  - `current >= latest_version` → 안내 없음
- `UpdateType` enum 추가 (none, recommended, force)

### 3. 업데이트 다이얼로그 UI (lib/widgets/update_dialog.dart)
- 강제 업데이트:
  - 제목: "업데이트 안내"
  - 내용: "최신 버전으로 업데이트한 뒤 이용해 주세요."
  - 버튼: "업데이트하기" (닫기 불가)
- 권장 업데이트:
  - 제목: "새 버전이 있어요"
  - 내용: "더 나은 서비스 이용을 위해 업데이트를 추천드려요."
  - 버튼: "업데이트하기 / 나중에"

### 4. 재표시 방지 로직 (lib/services/version_service.dart)
- SharedPreferences로 "나중에" 선택 시간 저장
- 3일(skipDays) 동안 권장 업데이트 다이얼로그 숨김
- `shouldShowRecommendedUpdate()`, `skipRecommendedUpdate()` 메서드

## API 요청/응답

```
GET /v1/app-config/version?platform=ios|android

Response:
{
  "latest_version": "1.4.0",
  "min_version": "1.3.0",
  "force_update": true,
  "store_url": "https://...",
  "message_title": "업데이트 안내",
  "message_body": "더 안정적인 서비스 이용을 위해 최신 버전으로 업데이트해 주세요."
}
```

## Test plan

- [ ] 강제 업데이트 테스트 (current < min_version)
- [ ] 권장 업데이트 테스트 (min_version <= current < latest_version)
- [ ] 최신 버전 테스트 (current >= latest_version → 다이얼로그 없음)
- [ ] "나중에" 선택 후 3일간 재표시 방지 확인
- [ ] 스토어 URL 열기 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)