### PR TITLE
feat(keyword-alerts): 알림 API에 위치 정보 및 거리 정렬 추가

### DIFF
--- a/server/keyword_alerts/schemas.py
+++ b/server/keyword_alerts/schemas.py
@@ -30,9 +30,15 @@ class KeywordAlertResponse(Schema):
     keyword: str
     campaign_id: int
     campaign_title: str
+    campaign_offer: Optional[str] = None
+    campaign_address: Optional[str] = None
+    campaign_lat: Optional[float] = None
+    campaign_lng: Optional[float] = None
+    campaign_img_url: Optional[str] = None
     matched_field: str
     is_read: bool
     created_at: datetime
+    distance: Optional[float] = None  # 거리 (km)
 
 
 class KeywordAlertListResponse(Schema):


### PR DESCRIPTION
## Summary
- KeywordAlertResponse 스키마에 캠페인 위치 정보 추가 (campaign_offer, address, lat/lng, img_url, distance)
- list_alerts API에 lat, lng, sort 쿼리 파라미터 추가
- Haversine formula로 사용자와 캠페인 간 거리 계산 및 거리순 정렬 지원

## Test plan
- [ ] 위치 정보 없이 알림 목록 조회 - 기존과 동일하게 동작
- [ ] lat, lng 파라미터와 함께 조회 - distance 필드에 거리 값 반환
- [ ] sort=distance로 조회 - 가까운 순으로 정렬