### PR TITLE
feat(mobile): 체험단 키워드 알림 기능 구현

### DIFF
--- a/mobile/lib/models/keyword_models.dart
+++ b/mobile/lib/models/keyword_models.dart
@@ -70,18 +70,30 @@ class AlertInfo {
   final String keyword;
   final int campaignId;
   final String campaignTitle;
+  final String? campaignOffer;
+  final String? campaignAddress;
+  final double? campaignLat;
+  final double? campaignLng;
+  final String? campaignImgUrl;
   final String matchedField;
   final bool isRead;
   final String createdAt;
+  final double? distance; // 거리 (km)
 
   AlertInfo({
     required this.id,
     required this.keyword,
     required this.campaignId,
     required this.campaignTitle,
+    this.campaignOffer,
+    this.campaignAddress,
+    this.campaignLat,
+    this.campaignLng,
+    this.campaignImgUrl,
     required this.matchedField,
     required this.isRead,
     required this.createdAt,
+    this.distance,
   });
 
   factory AlertInfo.fromJson(Map<String, dynamic> json) {
@@ -90,9 +102,21 @@ class AlertInfo {
       keyword: json['keyword'] as String,
       campaignId: json['campaign_id'] as int,
       campaignTitle: json['campaign_title'] as String,
+      campaignOffer: json['campaign_offer'] as String?,
+      campaignAddress: json['campaign_address'] as String?,
+      campaignLat: json['campaign_lat'] != null
+          ? (json['campaign_lat'] as num).toDouble()
+          : null,
+      campaignLng: json['campaign_lng'] != null
+          ? (json['campaign_lng'] as num).toDouble()
+          : null,
+      campaignImgUrl: json['campaign_img_url'] as String?,
       matchedField: json['matched_field'] as String,
       isRead: json['is_read'] as bool,
       createdAt: json['created_at'] as String,
+      distance: json['distance'] != null
+          ? (json['distance'] as num).toDouble()
+          : null,
     );
   }
 
@@ -101,10 +125,25 @@ class AlertInfo {
     'keyword': keyword,
     'campaign_id': campaignId,
     'campaign_title': campaignTitle,
+    'campaign_offer': campaignOffer,
+    'campaign_address': campaignAddress,
+    'campaign_lat': campaignLat,
+    'campaign_lng': campaignLng,
+    'campaign_img_url': campaignImgUrl,
     'matched_field': matchedField,
     'is_read': isRead,
     'created_at': createdAt,
+    'distance': distance,
   };
+
+  /// 거리 표시 문자열 (예: "1.5km", "500m")
+  String get distanceText {
+    if (distance == null) return '';
+    if (distance! < 1) {
+      return '${(distance! * 1000).round()}m';
+    }
+    return '${distance!.toStringAsFixed(1)}km';
+  }
 }
 
 /// 알람 목록 응답 데이터


### PR DESCRIPTION
## Summary
- AlertInfo 모델에 캠페인 위치 정보 추가 (lat, lng, address, distance 등)
- KeywordService에 toggleKeyword API 및 위치 기반 알림 조회 기능 추가
- NotificationScreen 알림 기록 탭 완전 구현
  - 거리순/최신순 정렬 지원
  - 알림 카드 UI (이미지, 키워드 뱃지, 거리 표시)
  - 새로고침 버튼 및 Pull-to-refresh 지원
  - 알림 읽음 처리 및 안읽은 알림 개수 뱃지

## Dependencies
- #52 서버 API 위치 정보 추가 PR이 먼저 머지되어야 함

## Test plan
- [ ] 키워드 등록/삭제 확인
- [ ] 키워드 활성화/비활성화 토글 확인
- [ ] 알림 기록 탭에서 목록 조회 확인
- [ ] 거리순/최신순 정렬 전환 확인
- [ ] 새로고침 버튼 동작 확인
- [ ] Pull-to-refresh 동작 확인
- [ ] 알림 터치 시 읽음 처리 확인