### PR TITLE
fix: keyword_alerts AppConfig 명시적 등록

### DIFF
--- a/server/config/settings.py
+++ b/server/config/settings.py
@@ -77,7 +77,7 @@ INSTALLED_APPS = [
     'users',
     'campaigns',
     'app_config',  # 앱 설정 관리
-    'keyword_alerts',  # 키워드 알람
+    'keyword_alerts.apps.KeywordAlertsConfig',  # 키워드 알람
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
signals가 등록되지 않는 문제 수정

- INSTALLED_APPS에서 'keyword_alerts' → 'keyword_alerts.apps.KeywordAlertsConfig'
- ready() 메서드에서 signals import가 실행되도록 함