### PR TITLE
feat(fcm): 모바일 FCM 푸시 알림 서비스 통합

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -30,9 +30,11 @@ import 'package:mobile/services/app_open_ad_service.dart'; // App Open Ad 서비
 import 'package:mobile/services/interstitial_ad_manager.dart'; // 전면광고 매니저
 import 'package:mobile/services/firebase_service.dart'; // Firebase 통합 서비스
 import 'package:mobile/services/remote_config_service.dart'; // Firebase Remote Config 서비스
+import 'package:mobile/services/fcm_service.dart'; // FCM 푸시 알림 서비스
 
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 
 
@@ -45,6 +47,9 @@ Future<void> main() async {
   try {
     await Firebase.initializeApp();
     print('[Main] Firebase 초기화 완료');
+
+    // FCM 백그라운드 메시지 핸들러 등록 (Firebase 초기화 직후 설정)
+    FirebaseMessaging.onBackgroundMessage(firebaseMessagingBackgroundHandler);
   } catch (e) {
     print('[Main] Firebase 초기화 실패: $e');
   }
@@ -134,7 +139,15 @@ Future<void> main() async {
     print('[Main] Firebase Remote Config 초기화 실패: $e');
   }
 
-  // 10) Flutter 앱 실행
+  // 10) FCM 푸시 알림 서비스 초기화
+  try {
+    await FcmService.instance.initialize();
+    print('[Main] FCM 서비스 초기화 완료');
+  } catch (e) {
+    print('[Main] FCM 서비스 초기화 실패: $e');
+  }
+
+  // 11) Flutter 앱 실행
   runApp(
     // ProviderScope를 추가하여 앱 전체에서 Riverpod Provider를 사용
     const ProviderScope(

--- a/mobile/lib/services/keyword_service.dart
+++ b/mobile/lib/services/keyword_service.dart
@@ -223,6 +223,65 @@ class KeywordService {
     }
   }
 
+  /// FCM 디바이스 토큰 등록
+  /// POST /v1/keyword-alerts/fcm/register
+  Future<void> registerFcmToken(String fcmToken, String deviceType) async {
+    final uri = Uri.parse('$baseUrl/fcm/register');
+    final headers = await _getAuthHeaders();
+
+    try {
+      final response = await _client
+          .post(
+            uri,
+            headers: headers,
+            body: jsonEncode({
+              'fcm_token': fcmToken,
+              'device_type': deviceType,
+            }),
+          )
+          .timeout(const Duration(seconds: 10));
+
+      _debugPrintResponse('POST', uri.toString(), response);
+
+      if (response.statusCode != 200 && response.statusCode != 201) {
+        final errorBody = jsonDecode(utf8.decode(response.bodyBytes));
+        throw Exception(errorBody['detail'] ?? 'FCM 토큰 등록에 실패했습니다.');
+      }
+
+      debugPrint('✅ FCM 토큰 등록 성공');
+    } catch (e) {
+      debugPrint('FCM 토큰 등록 오류: $e');
+      rethrow;
+    }
+  }
+
+  /// FCM 디바이스 토큰 해제
+  /// DELETE /v1/keyword-alerts/fcm/unregister
+  Future<void> unregisterFcmToken(String fcmToken) async {
+    final uri = Uri.parse('$baseUrl/fcm/unregister').replace(
+      queryParameters: {'fcm_token': fcmToken},
+    );
+    final headers = await _getAuthHeaders();
+
+    try {
+      final response = await _client
+          .delete(uri, headers: headers)
+          .timeout(const Duration(seconds: 10));
+
+      _debugPrintResponse('DELETE', uri.toString(), response);
+
+      if (response.statusCode != 200) {
+        final errorBody = jsonDecode(utf8.decode(response.bodyBytes));
+        throw Exception(errorBody['detail'] ?? 'FCM 토큰 해제에 실패했습니다.');
+      }
+
+      debugPrint('✅ FCM 토큰 해제 성공');
+    } catch (e) {
+      debugPrint('FCM 토큰 해제 오류: $e');
+      rethrow;
+    }
+  }
+
   void dispose() {
     _client.close();
   }


### PR DESCRIPTION
## Summary
- FCM 푸시 알림 서비스 클라이언트 사이드 통합
- 키워드 알람 푸시 알림을 받기 위한 FCM 토큰 관리 기능 추가
- PR #58 (서버 FCM API)와 연동되는 모바일 측 구현

## Changes
### 신규 파일
- `lib/services/fcm_service.dart`: FCM 서비스 싱글톤
  - 푸시 알림 권한 요청
  - FCM 토큰 획득 및 서버 등록
  - 토큰 갱신 감지 및 자동 재등록
  - 포그라운드/백그라운드 메시지 핸들러

### 수정 파일
- `lib/services/keyword_service.dart`: FCM API 클라이언트 메서드 추가
  - `registerFcmToken()`: POST /v1/keyword-alerts/fcm/register
  - `unregisterFcmToken()`: DELETE /v1/keyword-alerts/fcm/unregister

- `lib/main.dart`: FCM 초기화 통합
  - Firebase 초기화 직후 백그라운드 핸들러 등록
  - 앱 시작 시 FCM 서비스 초기화 (10번째 단계)

## Test Plan
- [ ] 앱 시작 시 푸시 알림 권한 요청 확인
- [ ] FCM 토큰이 서버에 정상 등록되는지 확인
- [ ] 키워드 알람 발생 시 푸시 알림 수신 확인
- [ ] 앱 포그라운드/백그라운드 상태에서 알림 처리 확인