### PR TITLE
feat(api): /me API에 프로필 이미지 및 이름 필드 추가

### DIFF
--- a/server/users/api_me.py
+++ b/server/users/api_me.py
@@ -28,23 +28,38 @@ async def get_my_info(request):
     """
     user = request.auth  # JWTAuth에서 검증된 사용자
 
-    # 연결된 소셜 계정 조회
+    # 연결된 소셜 계정 조회 (profile_image, name 포함)
     social_accounts = await SocialAccount.objects.filter(
         user=user
-    ).values('provider', 'email', 'created_at').all()
+    ).values('provider', 'email', 'profile_image', 'name', 'created_at').all()
 
     social_accounts_list = [
         SocialAccountInfo(
             provider=account['provider'],
             email=account['email'],
+            profile_image=account['profile_image'] or None,
             connected_at=account['created_at']
         )
         for account in social_accounts
     ]
 
+    # 첫 번째 소셜 계정의 프로필 이미지와 이름 사용
+    profile_image = None
+    name = None
+    for account in social_accounts:
+        if account.get('profile_image'):
+            profile_image = account['profile_image']
+            break
+    for account in social_accounts:
+        if account.get('name'):
+            name = account['name']
+            break
+
     return {
         "id": user.id,
         "email": user.email,
+        "name": name,
+        "profile_image": profile_image,
         "is_active": user.is_active,
         "date_joined": user.date_joined,
         "login_method": user.login_method,
@@ -83,23 +98,38 @@ async def update_my_info(request, payload: UpdateProfileRequest):
     # user.nickname = payload.nickname
     # await user.asave()
 
-    # 연결된 소셜 계정 조회
+    # 연결된 소셜 계정 조회 (profile_image, name 포함)
     social_accounts = await SocialAccount.objects.filter(
         user=user
-    ).values('provider', 'email', 'created_at').all()
+    ).values('provider', 'email', 'profile_image', 'name', 'created_at').all()
 
     social_accounts_list = [
         SocialAccountInfo(
             provider=account['provider'],
             email=account['email'],
+            profile_image=account['profile_image'] or None,
             connected_at=account['created_at']
         )
         for account in social_accounts
     ]
 
+    # 첫 번째 소셜 계정의 프로필 이미지와 이름 사용
+    profile_image = None
+    name = None
+    for account in social_accounts:
+        if account.get('profile_image'):
+            profile_image = account['profile_image']
+            break
+    for account in social_accounts:
+        if account.get('name'):
+            name = account['name']
+            break
+
     return {
         "id": user.id,
         "email": user.email,
+        "name": name,
+        "profile_image": profile_image,
         "is_active": user.is_active,
         "date_joined": user.date_joined,
         "login_method": user.login_method,

--- a/server/users/schemas.py
+++ b/server/users/schemas.py
@@ -87,6 +87,7 @@ class SocialAccountInfo(Schema):
     """SNS 계정 정보"""
     provider: str  # kakao, google, apple
     email: str
+    profile_image: Optional[str] = None  # 프로필 이미지 URL
     connected_at: datetime
 
 
@@ -100,4 +101,6 @@ class SNSLoginResponse(Schema):
 
 class UserDetailResponse(UserResponse):
     """사용자 상세 정보 (소셜 계정 포함)"""
+    name: Optional[str] = None  # 사용자 이름
+    profile_image: Optional[str] = None  # 프로필 이미지 URL (첫 번째 소셜 계정의 이미지)
     social_accounts: list[SocialAccountInfo] = []


### PR DESCRIPTION
## Summary
- /me API 응답에 프로필 이미지(profile_image)와 이름(name) 필드 추가
- 소셜 로그인 사용자의 프로필 정보를 클라이언트에서 표시할 수 있도록 지원

## Changes
### server/users/schemas.py
- `SocialAccountInfo`에 `profile_image` 필드 추가
- `UserDetailResponse`에 `name`, `profile_image` 필드 추가

### server/users/api_me.py
- 소셜 계정 조회 시 `profile_image`, `name` 포함
- 첫 번째 소셜 계정의 프로필 이미지와 이름을 사용자 정보로 반환

## Test Plan
- [ ] /me API 호출 시 profile_image, name 필드가 정상 반환되는지 확인
- [ ] 카카오/구글 로그인 사용자의 프로필 이미지 표시 확인
- [ ] Apple 로그인 사용자 (프로필 이미지 없음) 정상 처리 확인