### PR TITLE
feat(mobile): 내정보 화면 개선

### DIFF
--- a/mobile/lib/models/auth_models.dart
+++ b/mobile/lib/models/auth_models.dart
@@ -163,6 +163,7 @@ class UserInfo {
   final String id;
   final String email;
   final String? name;
+  final String? profileImage; // 프로필 이미지 URL
   final bool isActive;
   final String? dateJoined;
   final String loginMethod; // email, google, apple, kakao, naver
@@ -171,6 +172,7 @@ class UserInfo {
     required this.id,
     required this.email,
     this.name,
+    this.profileImage,
     required this.isActive,
     this.dateJoined,
     required this.loginMethod,
@@ -181,6 +183,7 @@ class UserInfo {
       id: json['id'].toString(), // int 또는 String을 안전하게 String으로 변환
       email: json['email'] as String,
       name: json['name'] as String?,
+      profileImage: json['profile_image'] as String?,
       isActive: json['is_active'] as bool? ?? true,
       dateJoined: json['date_joined'] as String?,
       loginMethod: json['login_method'] as String? ?? 'email',
@@ -191,6 +194,7 @@ class UserInfo {
     'id': id,
     'email': email,
     if (name != null) 'name': name,
+    if (profileImage != null) 'profile_image': profileImage,
     'is_active': isActive,
     if (dateJoined != null) 'date_joined': dateJoined,
     'login_method': loginMethod,


### PR DESCRIPTION
## Summary
- 내정보 화면 UI 개선 및 프로필 이미지 표시 기능 추가
- 불필요한 메뉴 정리 및 버전 정보 동적 로드

## Changes
### mobile/lib/models/auth_models.dart
- `UserInfo` 모델에 `profileImage` 필드 추가
- 서버 `/me` API의 `profile_image` 응답 처리

### mobile/lib/screens/profile_screen.dart
- `ConsumerWidget` → `ConsumerStatefulWidget` 변경 (비동기 버전 로드)
- 프로필 이미지 표시 (소셜 로그인 사용자의 프로필 이미지)
- 사용자 이름 표시 (이름 > 이메일 우선순위)
- 로그인 방식 뱃지 추가 (카카오/구글/애플/네이버)
- 불필요한 메뉴 삭제: 내 리뷰 관리, 찜한 장소
- 앱 버전 동적 로드 (`package_info_plus`)

## Test Plan
- [ ] 카카오 로그인 사용자: 프로필 이미지 표시 확인
- [ ] 구글 로그인 사용자: 프로필 이미지 표시 확인
- [ ] Apple 로그인 사용자: 기본 아이콘 표시 확인 (Apple은 프로필 이미지 미제공)
- [ ] 이메일 로그인 사용자: 기본 아이콘 표시 확인
- [ ] 앱 버전이 pubspec.yaml 버전과 일치하는지 확인