### PR TITLE
fix(kakao): 프로필 이미지 추출 경로 수정

### DIFF
--- a/server/users/services/kakao.py
+++ b/server/users/services/kakao.py
@@ -48,11 +48,19 @@ async def verify_kakao_token(access_token: str) -> Optional[Dict[str, Any]]:
             data = response.json()
 
             # 사용자 정보 추출
+            # 카카오 API 응답 구조:
+            # - kakao_account.profile.profile_image_url: 프로필 이미지 (640x640)
+            # - kakao_account.profile.thumbnail_image_url: 썸네일 이미지 (110x110)
+            # - kakao_account.profile.nickname: 닉네임
+            # - properties.nickname: 닉네임 (구버전 호환)
+            kakao_account = data.get('kakao_account', {})
+            profile = kakao_account.get('profile', {})
+
             user_info = {
                 'id': data.get('id'),  # Kakao 사용자 ID (필수)
-                'email': data.get('kakao_account', {}).get('email', ''),  # 이메일 (선택)
-                'name': data.get('properties', {}).get('nickname', ''),  # 닉네임
-                'profile_image': data.get('properties', {}).get('profile_image', ''),  # 프로필 이미지
+                'email': kakao_account.get('email', ''),  # 이메일
+                'name': profile.get('nickname', '') or data.get('properties', {}).get('nickname', ''),  # 닉네임
+                'profile_image': profile.get('profile_image_url', '') or profile.get('thumbnail_image_url', ''),  # 프로필 이미지
             }
 
             # 필수 필드 확인


### PR DESCRIPTION
## Summary
- 카카오 로그인 시 프로필 이미지가 저장되지 않는 버그 수정
- `properties.profile_image` → `kakao_account.profile.profile_image_url` 경로로 변경
- 카카오 API 실제 응답 구조에 맞게 수정

## 변경 내용
- `users/services/kakao.py`: 프로필 이미지 및 닉네임 추출 로직 수정

## Test plan
- [ ] 카카오 로그인 후 프로필 이미지가 DB에 저장되는지 확인
- [ ] `/me` API 호출 시 `profile_image` 필드에 URL 반환 확인
- [ ] 내정보 화면에서 프로필 이미지 표시 확인