### PR TITLE
fix(notification): 키워드 토글 시 토스트 메시지 제거

### DIFF
--- a/mobile/lib/screens/notification_screen.dart
+++ b/mobile/lib/screens/notification_screen.dart
@@ -271,11 +271,7 @@ class _NotificationScreenState extends State<NotificationScreen>
         _keywords[index] = updated;
       });
 
-      final statusText = updated.isActive ? '활성화' : '비활성화';
-      _showSnackBar(
-        "'${old.keyword}' 알림이 $statusText되었습니다",
-        isSuccess: updated.isActive,
-      );
+      // 토글 성공 시 토스트 메시지 제거 (사용자 요청)
     } catch (e) {
       if (!mounted) return;
 


### PR DESCRIPTION
## Summary
- 키워드 활성화/비활성화 토글 시 하단 토스트 메시지 제거
- 실패 시 에러 메시지는 유지

## Test plan
- [ ] 키워드 토글 시 토스트 메시지가 표시되지 않는지 확인
- [ ] 토글 실패 시 에러 메시지가 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)