### PR TITLE
feat(auth): Access Token 만료 전 자동 갱신 로직 추가

### DIFF
--- a/mobile/lib/services/token_storage_service.dart
+++ b/mobile/lib/services/token_storage_service.dart
@@ -1,10 +1,30 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+/// JWT 페이로드 디코딩 유틸리티
+Map<String, dynamic>? decodeJwtPayload(String token) {
+  try {
+    final parts = token.split('.');
+    if (parts.length != 3) return null;
+
+    final payload = parts[1];
+    // Base64 URL 디코딩
+    final normalized = base64Url.normalize(payload);
+    final decoded = utf8.decode(base64Url.decode(normalized));
+    return jsonDecode(decoded) as Map<String, dynamic>;
+  } catch (e) {
+    debugPrint('[JWT] 디코딩 실패: $e');
+    return null;
+  }
+}
 
 /// TokenStorageService
 /// ------------------------------------------------------------
 /// - SharedPreferences를 사용한 토큰 저장/로드 서비스
 /// - 인증 토큰(access_token, refresh_token) 및 익명 세션 토큰 관리
 /// - 로그아웃 시 모든 토큰 삭제
+/// - 토큰 만료 전 자동 갱신 지원
 class TokenStorageService {
   static const String _accessTokenKey = 'access_token';
   static const String _refreshTokenKey = 'refresh_token';
@@ -79,5 +99,52 @@ class TokenStorageService {
     await prefs.remove(_refreshTokenKey);
     await prefs.remove(_sessionTokenKey);
     await prefs.remove(_isAnonymousKey);
+  }
+
+  /// Access Token 만료 임박 여부 확인
+  /// - 만료 5분 전이면 true 반환
+  /// - 토큰이 없거나 디코딩 실패 시 false 반환
+  Future<bool> isAccessTokenExpiringSoon({int thresholdMinutes = 5}) async {
+    final token = await getAccessToken();
+    if (token == null) return false;
+
+    final payload = decodeJwtPayload(token);
+    final exp = payload?['exp'] as int?;
+    if (exp == null) return false;
+
+    final expDate = DateTime.fromMillisecondsSinceEpoch(exp * 1000);
+    final refreshThreshold = expDate.subtract(Duration(minutes: thresholdMinutes));
+
+    return DateTime.now().isAfter(refreshThreshold);
+  }
+
+  /// Access Token 만료 여부 확인
+  /// - 이미 만료되었으면 true 반환
+  Future<bool> isAccessTokenExpired() async {
+    final token = await getAccessToken();
+    if (token == null) return true;
+
+    final payload = decodeJwtPayload(token);
+    final exp = payload?['exp'] as int?;
+    if (exp == null) return false;
+
+    final expDate = DateTime.fromMillisecondsSinceEpoch(exp * 1000);
+    return DateTime.now().isAfter(expDate);
+  }
+
+  /// Access Token 남은 시간 (분) 조회
+  /// - 토큰이 없거나 만료되었으면 null 반환
+  Future<int?> getAccessTokenRemainingMinutes() async {
+    final token = await getAccessToken();
+    if (token == null) return null;
+
+    final payload = decodeJwtPayload(token);
+    final exp = payload?['exp'] as int?;
+    if (exp == null) return null;
+
+    final expDate = DateTime.fromMillisecondsSinceEpoch(exp * 1000);
+    final remaining = expDate.difference(DateTime.now()).inMinutes;
+
+    return remaining > 0 ? remaining : null;
   }
 }


### PR DESCRIPTION
## Summary
- TokenStorageService에 JWT 디코딩 유틸리티 및 토큰 만료 검사 메서드 추가
- AuthService에 getValidAccessToken() 메서드 추가 (만료 5분 전 자동 갱신)
- API 호출 시 자동 갱신된 토큰으로 헤더 생성하는 getValidAuthHeaders() 추가

## Changes
- `lib/services/token_storage_service.dart`: JWT 디코딩, 만료 검사 로직
- `lib/services/auth_service.dart`: 자동 토큰 갱신 로직

## Test plan
- [ ] 로그인 후 토큰 만료 시간 확인
- [ ] 토큰 만료 5분 전 API 호출 시 자동 갱신 확인
- [ ] 갱신 실패 시 적절한 에러 처리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)