### PR TITLE
refactor(keyword): 키워드 제한 하드코딩 제거

### DIFF
--- a/mobile/lib/screens/notification_screen.dart
+++ b/mobile/lib/screens/notification_screen.dart
@@ -188,10 +188,7 @@ class _NotificationScreenState extends State<NotificationScreen>
       return;
     }
 
-    if (_keywords.length >= 20) {
-      _showSnackBar('키워드는 최대 20개까지 등록할 수 있습니다');
-      return;
-    }
+    // 서버에서 키워드 제한 검증 (AppSetting 기반으로 동적 관리)
 
     setState(() {
       _isLoading = true;
@@ -215,7 +212,8 @@ class _NotificationScreenState extends State<NotificationScreen>
         _isLoading = false;
       });
 
-      _showSnackBar('키워드 추가 실패: $e', isError: true);
+      // 서버 에러 메시지 사용 (키워드 제한 초과 등)
+      _showSnackBar('$e', isError: true);
     }
   }
 


### PR DESCRIPTION
## Summary
- 클라이언트 측 키워드 20개 제한 하드코딩 제거
- 서버 AppSetting 기반 동적 제한으로 위임
- Django admin에서 키워드 제한 개수 변경 가능

## Changes
- `lib/screens/notification_screen.dart`: 클라이언트 측 제한 검사 제거, 서버 에러 메시지 사용

## Related
- Server PR #70: 알림 30일 보관 필터링 추가 (merged)

## Test plan
- [ ] 키워드 20개 등록 시 서버 에러 메시지 정상 표시 확인
- [ ] Django admin에서 제한 개수 변경 후 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)