### PR TITLE
feat(network): 에러 처리 일관성 개선 및 오프라인 지원 추가

### DIFF
--- a/mobile/lib/services/connectivity_service.dart
+++ b/mobile/lib/services/connectivity_service.dart
@@ -1,0 +1,104 @@
+import 'dart:async';
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+
+/// 네트워크 연결 상태 서비스
+/// - 인터넷 연결 상태 확인
+/// - 연결 상태 변경 스트림 제공
+class ConnectivityService {
+  static final ConnectivityService _instance = ConnectivityService._internal();
+  factory ConnectivityService() => _instance;
+  ConnectivityService._internal();
+
+  final _connectivityController = StreamController<bool>.broadcast();
+
+  /// 연결 상태 변경 스트림
+  Stream<bool> get onConnectivityChanged => _connectivityController.stream;
+
+  /// 마지막으로 확인된 연결 상태
+  bool _lastKnownState = true;
+  bool get isConnected => _lastKnownState;
+
+  /// 인터넷 연결 확인
+  /// - DNS lookup을 통해 실제 인터넷 접근 가능 여부 확인
+  Future<bool> checkConnectivity() async {
+    try {
+      // 여러 DNS 서버를 체크하여 신뢰성 향상
+      final lookupTargets = [
+        'google.com',
+        'cloudflare.com',
+        'naver.com',
+      ];
+
+      for (final target in lookupTargets) {
+        try {
+          final result = await InternetAddress.lookup(target)
+              .timeout(const Duration(seconds: 3));
+
+          if (result.isNotEmpty && result[0].rawAddress.isNotEmpty) {
+            _updateConnectivityState(true);
+            return true;
+          }
+        } catch (_) {
+          // 다음 서버 시도
+          continue;
+        }
+      }
+
+      _updateConnectivityState(false);
+      return false;
+    } catch (e) {
+      debugPrint('[ConnectivityService] 연결 확인 실패: $e');
+      _updateConnectivityState(false);
+      return false;
+    }
+  }
+
+  /// API 서버 연결 확인
+  /// - 실제 API 서버에 접근 가능한지 확인
+  Future<bool> checkApiServerConnectivity(String baseUrl) async {
+    try {
+      final uri = Uri.parse('$baseUrl/healthz');
+      final client = HttpClient()
+        ..connectionTimeout = const Duration(seconds: 5);
+
+      final request = await client.getUrl(uri);
+      final response = await request.close().timeout(const Duration(seconds: 5));
+
+      client.close();
+      return response.statusCode == 200;
+    } catch (e) {
+      debugPrint('[ConnectivityService] API 서버 연결 확인 실패: $e');
+      return false;
+    }
+  }
+
+  /// 연결 상태 업데이트
+  void _updateConnectivityState(bool isConnected) {
+    if (_lastKnownState != isConnected) {
+      _lastKnownState = isConnected;
+      _connectivityController.add(isConnected);
+      debugPrint('[ConnectivityService] 연결 상태 변경: ${isConnected ? "연결됨" : "연결 끊김"}');
+    }
+  }
+
+  /// 주기적 연결 상태 모니터링 시작
+  Timer? _monitoringTimer;
+
+  void startMonitoring({Duration interval = const Duration(seconds: 30)}) {
+    stopMonitoring();
+    _monitoringTimer = Timer.periodic(interval, (_) => checkConnectivity());
+    // 즉시 한 번 체크
+    checkConnectivity();
+  }
+
+  void stopMonitoring() {
+    _monitoringTimer?.cancel();
+    _monitoringTimer = null;
+  }
+
+  void dispose() {
+    stopMonitoring();
+    _connectivityController.close();
+  }
+}

--- a/mobile/lib/utils/network_error_handler.dart
+++ b/mobile/lib/utils/network_error_handler.dart
@@ -1,0 +1,140 @@
+import 'dart:async';
+import 'dart:io';
+
+/// 네트워크 에러 처리 유틸리티
+/// - 네이버 스타일의 사용자 친화적 한글 에러 메시지 제공
+/// - 에러 타입별 적절한 안내 메시지 반환
+class NetworkErrorHandler {
+  /// 에러를 사용자 친화적 메시지로 변환
+  static String getErrorMessage(dynamic error) {
+    // 이미 사용자 친화적 메시지인 경우 그대로 반환
+    if (error is Exception) {
+      final message = error.toString().replaceFirst('Exception: ', '');
+      if (_isUserFriendlyMessage(message)) {
+        return message;
+      }
+    }
+
+    // 네트워크 연결 오류
+    if (error is SocketException) {
+      return '인터넷 연결을 확인해 주세요.';
+    }
+
+    // 타임아웃 오류
+    if (error is TimeoutException) {
+      return '서버 응답이 늦어지고 있어요.\n잠시 후 다시 시도해 주세요.';
+    }
+
+    // SSL/TLS 핸드셰이크 오류
+    if (error is HandshakeException) {
+      return '보안 연결에 실패했습니다.\n네트워크 환경을 확인해 주세요.';
+    }
+
+    // HTTP 오류
+    if (error is HttpException) {
+      return '서버와 통신 중 오류가 발생했습니다.\n잠시 후 다시 시도해 주세요.';
+    }
+
+    // FormatException (JSON 파싱 오류 등)
+    if (error is FormatException) {
+      return '데이터를 처리하는 중 오류가 발생했습니다.';
+    }
+
+    // 문자열 에러 메시지 분석
+    final errorString = error.toString().toLowerCase();
+
+    if (errorString.contains('socketexception') ||
+        errorString.contains('network is unreachable') ||
+        errorString.contains('connection refused') ||
+        errorString.contains('no address associated') ||
+        errorString.contains('failed host lookup')) {
+      return '인터넷 연결을 확인해 주세요.';
+    }
+
+    if (errorString.contains('timeout')) {
+      return '서버 응답이 늦어지고 있어요.\n잠시 후 다시 시도해 주세요.';
+    }
+
+    if (errorString.contains('handshake') ||
+        errorString.contains('certificate')) {
+      return '보안 연결에 실패했습니다.\n네트워크 환경을 확인해 주세요.';
+    }
+
+    // 기본 메시지
+    return '일시적인 오류가 발생했습니다.\n잠시 후 다시 시도해 주세요.';
+  }
+
+  /// HTTP 상태 코드에 따른 에러 메시지
+  static String getHttpErrorMessage(int statusCode, {String? serverMessage}) {
+    // 서버에서 친화적 메시지를 제공한 경우 우선 사용
+    if (serverMessage != null && serverMessage.isNotEmpty) {
+      return serverMessage;
+    }
+
+    switch (statusCode) {
+      case 400:
+        return '요청 정보를 확인해 주세요.';
+      case 401:
+        return '로그인이 만료되었습니다.\n다시 로그인해 주세요.';
+      case 403:
+        return '접근 권한이 없습니다.';
+      case 404:
+        return '요청하신 정보를 찾을 수 없습니다.';
+      case 409:
+        return '이미 처리된 요청입니다.';
+      case 422:
+        return '입력 정보를 확인해 주세요.';
+      case 429:
+        return '요청이 너무 많습니다.\n잠시 후 다시 시도해 주세요.';
+      case 500:
+        return '서버에 일시적인 문제가 발생했습니다.\n잠시 후 다시 시도해 주세요.';
+      case 502:
+      case 503:
+      case 504:
+        return '서버 점검 중이거나 접속이 원활하지 않습니다.\n잠시 후 다시 시도해 주세요.';
+      default:
+        if (statusCode >= 500) {
+          return '서버에 문제가 발생했습니다.\n잠시 후 다시 시도해 주세요.';
+        }
+        return '요청을 처리할 수 없습니다.\n잠시 후 다시 시도해 주세요.';
+    }
+  }
+
+  /// 네트워크 연결 오류인지 확인
+  static bool isNetworkError(dynamic error) {
+    if (error is SocketException) return true;
+    if (error is TimeoutException) return true;
+
+    final errorString = error.toString().toLowerCase();
+    return errorString.contains('socketexception') ||
+        errorString.contains('network is unreachable') ||
+        errorString.contains('connection refused') ||
+        errorString.contains('no address associated') ||
+        errorString.contains('failed host lookup') ||
+        errorString.contains('timeout');
+  }
+
+  /// 재시도 가능한 오류인지 확인
+  static bool isRetryableError(dynamic error) {
+    if (error is SocketException) return true;
+    if (error is TimeoutException) return true;
+    if (error is HttpException) return true;
+
+    final errorString = error.toString().toLowerCase();
+    return errorString.contains('timeout') ||
+        errorString.contains('connection') ||
+        errorString.contains('network');
+  }
+
+  /// 사용자 친화적 메시지인지 확인
+  static bool _isUserFriendlyMessage(String message) {
+    // 한글이 포함되어 있고, 기술적 용어가 없는 경우
+    final hasKorean = RegExp(r'[가-힣]').hasMatch(message);
+    final hasTechnicalTerms = message.toLowerCase().contains('exception') ||
+        message.toLowerCase().contains('error:') ||
+        message.contains('null') ||
+        message.contains('undefined');
+
+    return hasKorean && !hasTechnicalTerms;
+  }
+}

--- a/mobile/lib/widgets/offline_banner.dart
+++ b/mobile/lib/widgets/offline_banner.dart
@@ -1,0 +1,307 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+/// 오프라인 상태 배너 위젯
+/// - 화면 상단에 고정되어 오프라인 상태를 알림
+/// - 재연결 시도 버튼 제공
+class OfflineBanner extends StatelessWidget {
+  final VoidCallback? onRetry;
+  final bool isRetrying;
+
+  const OfflineBanner({
+    super.key,
+    this.onRetry,
+    this.isRetrying = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 12.h),
+      decoration: BoxDecoration(
+        color: Colors.grey[800],
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.1),
+            blurRadius: 4,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: SafeArea(
+        bottom: false,
+        child: Row(
+          children: [
+            Icon(
+              Icons.wifi_off_rounded,
+              color: Colors.white,
+              size: 20.sp,
+            ),
+            SizedBox(width: 12.w),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    '인터넷 연결 안 됨',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 14.sp,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  SizedBox(height: 2.h),
+                  Text(
+                    'Wi-Fi 또는 데이터 연결을 확인해 주세요.',
+                    style: TextStyle(
+                      color: Colors.white70,
+                      fontSize: 12.sp,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            if (onRetry != null)
+              TextButton(
+                onPressed: isRetrying ? null : onRetry,
+                style: TextButton.styleFrom(
+                  padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 8.h),
+                  backgroundColor: Colors.white.withOpacity(0.15),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8.r),
+                  ),
+                ),
+                child: isRetrying
+                    ? SizedBox(
+                        width: 16.w,
+                        height: 16.w,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                        ),
+                      )
+                    : Text(
+                        '다시 시도',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 13.sp,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// 오프라인 전체 화면 위젯
+/// - 인터넷 연결이 필요한 화면에서 오프라인 상태일 때 표시
+class OfflineScreen extends StatelessWidget {
+  final VoidCallback? onRetry;
+  final bool isRetrying;
+  final String? title;
+  final String? message;
+
+  const OfflineScreen({
+    super.key,
+    this.onRetry,
+    this.isRetrying = false,
+    this.title,
+    this.message,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: EdgeInsets.symmetric(horizontal: 32.w),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            // 오프라인 아이콘
+            Container(
+              width: 80.w,
+              height: 80.w,
+              decoration: BoxDecoration(
+                color: Colors.grey[100],
+                shape: BoxShape.circle,
+              ),
+              child: Icon(
+                Icons.wifi_off_rounded,
+                size: 40.sp,
+                color: Colors.grey[400],
+              ),
+            ),
+            SizedBox(height: 24.h),
+
+            // 타이틀
+            Text(
+              title ?? '인터넷 연결 안 됨',
+              style: TextStyle(
+                fontSize: 18.sp,
+                fontWeight: FontWeight.w600,
+                color: Colors.grey[800],
+              ),
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(height: 12.h),
+
+            // 설명 메시지
+            Text(
+              message ?? 'Wi-Fi 또는 모바일 데이터 연결을\n확인하고 다시 시도해 주세요.',
+              style: TextStyle(
+                fontSize: 14.sp,
+                color: Colors.grey[600],
+                height: 1.5,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(height: 32.h),
+
+            // 재시도 버튼
+            if (onRetry != null)
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: isRetrying ? null : onRetry,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Theme.of(context).primaryColor,
+                    foregroundColor: Colors.white,
+                    padding: EdgeInsets.symmetric(vertical: 14.h),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12.r),
+                    ),
+                    elevation: 0,
+                  ),
+                  child: isRetrying
+                      ? SizedBox(
+                          width: 20.w,
+                          height: 20.w,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                          ),
+                        )
+                      : Text(
+                          '다시 시도',
+                          style: TextStyle(
+                            fontSize: 16.sp,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// 에러 상태 전체 화면 위젯
+/// - 일반적인 에러 발생 시 표시
+class ErrorScreen extends StatelessWidget {
+  final String? title;
+  final String? message;
+  final VoidCallback? onRetry;
+  final bool isRetrying;
+
+  const ErrorScreen({
+    super.key,
+    this.title,
+    this.message,
+    this.onRetry,
+    this.isRetrying = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: EdgeInsets.symmetric(horizontal: 32.w),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            // 에러 아이콘
+            Container(
+              width: 80.w,
+              height: 80.w,
+              decoration: BoxDecoration(
+                color: Colors.red[50],
+                shape: BoxShape.circle,
+              ),
+              child: Icon(
+                Icons.error_outline_rounded,
+                size: 40.sp,
+                color: Colors.red[300],
+              ),
+            ),
+            SizedBox(height: 24.h),
+
+            // 타이틀
+            Text(
+              title ?? '문제가 발생했어요',
+              style: TextStyle(
+                fontSize: 18.sp,
+                fontWeight: FontWeight.w600,
+                color: Colors.grey[800],
+              ),
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(height: 12.h),
+
+            // 설명 메시지
+            Text(
+              message ?? '일시적인 오류가 발생했습니다.\n잠시 후 다시 시도해 주세요.',
+              style: TextStyle(
+                fontSize: 14.sp,
+                color: Colors.grey[600],
+                height: 1.5,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(height: 32.h),
+
+            // 재시도 버튼
+            if (onRetry != null)
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: isRetrying ? null : onRetry,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Theme.of(context).primaryColor,
+                    foregroundColor: Colors.white,
+                    padding: EdgeInsets.symmetric(vertical: 14.h),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12.r),
+                    ),
+                    elevation: 0,
+                  ),
+                  child: isRetrying
+                      ? SizedBox(
+                          width: 20.w,
+                          height: 20.w,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                          ),
+                        )
+                      : Text(
+                          '다시 시도',
+                          style: TextStyle(
+                            fontSize: 16.sp,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- 네이버 스타일의 사용자 친화적 한글 에러 메시지 시스템 구축
- 네트워크 재시도 로직 개선 및 오프라인 상태 UI 지원

## Changes

### 에러 처리 개선
- `lib/utils/network_error_handler.dart`: 에러 메시지 한글화 유틸리티
  - HTTP 상태 코드별 친화적 메시지 (401: 로그인 만료, 500: 서버 문제 등)
  - 네트워크 에러 타입별 적절한 안내 (오프라인, 타임아웃, SSL 등)

### 네트워크 재시도 로직
- `lib/services/keyword_service.dart`: 지수적 백오프 재시도 (3회)
- `lib/services/campaign_service.dart`: NetworkErrorHandler 통합

### 오프라인 지원
- `lib/services/connectivity_service.dart`: 인터넷 연결 상태 확인 서비스
- `lib/widgets/offline_banner.dart`: 
  - `OfflineBanner`: 상단 배너형 오프라인 알림
  - `OfflineScreen`: 전체 화면 오프라인 안내
  - `ErrorScreen`: 일반 에러 상태 화면

## Test plan
- [ ] 네트워크 끊김 시 에러 메시지 확인
- [ ] API 호출 실패 시 재시도 동작 확인
- [ ] 오프라인 배너/화면 UI 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)