### PR TITLE
fix(api): /auth/me API에 name, profile_image 필드 추가

### DIFF
--- a/server/users/api.py
+++ b/server/users/api.py
@@ -18,6 +18,7 @@ from .schemas import (
     AnonymousSessionRequest,
     AnonymousSessionResponse,
     UserResponse,
+    UserDetailResponse,
     AnonymousUserResponse,
     ConvertAnonymousRequest,
 )
@@ -190,7 +191,7 @@ async def convert_anonymous_to_user(request, payload: ConvertAnonymousRequest):
     }
 
 
-@router.get("/me", response=Union[UserResponse, AnonymousUserResponse], summary="내 정보 조회")
+@router.get("/me", response=Union[UserDetailResponse, AnonymousUserResponse], summary="내 정보 조회")
 async def get_my_info(request):
     """
     내 정보 조회 API
@@ -211,6 +212,8 @@ async def get_my_info(request):
         return {
             "id": user.id,
             "email": user.email,
+            "name": user.name or None,
+            "profile_image": user.profile_image or None,
             "is_active": user.is_active,
             "date_joined": user.date_joined,
             "login_method": user.login_method,


### PR DESCRIPTION
## Summary
- `/v1/auth/me` 엔드포인트에서 `name`, `profile_image` 필드를 반환하도록 수정
- response 스키마를 `UserDetailResponse`로 변경

## 문제 원인
- `/v1/auth/me` (api.py)와 `/v1/users/me` (api_me.py) 두 개의 엔드포인트가 존재
- 앱에서 호출하는 `/v1/auth/me`는 `UserResponse` 스키마를 사용하여 `name`, `profile_image` 미포함
- `/v1/users/me`만 `UserDetailResponse`를 사용하여 프로필 정보 반환

## 변경사항
- `api.py`의 `/me` 엔드포인트에 `name`, `profile_image` 필드 추가
- response 스키마를 `Union[UserDetailResponse, AnonymousUserResponse]`로 변경

## Test plan
- [ ] `/v1/auth/me` API 호출 시 `name`, `profile_image` 필드 포함 확인
- [ ] 앱에서 내정보 화면에 프로필 이미지 표시 확인