### PR TITLE
feat(fcm): 푸시 알림 포그라운드 표시 및 메시지 개선

### DIFF
--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -2,7 +2,8 @@ import java.util.Properties
 import java.io.FileInputStream
 
 val dotenv = Properties()
-val dotenvFile = rootProject.file(".env")
+// .env 파일은 mobile/ 폴더에 있음 (android/의 상위 폴더)
+val dotenvFile = rootProject.file("../.env")
 if (dotenvFile.exists()) {
     dotenvFile.inputStream().use { dotenv.load(it) }
 }
@@ -27,6 +28,8 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
+        // flutter_local_notifications 패키지에 필요한 core library desugaring 활성화
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
@@ -51,6 +54,7 @@ android {
                 "NAVER_MAP_CLIENT_SECRET" to (dotenv["NAVER_MAP_CLIENT_SECRET"] ?: ""),
                 "NAVER_APP_KEY" to (dotenv["NAVER_APP_KEY"] ?: ""),
                 "NAVER_APP_SECRET" to (dotenv["NAVER_APP_SECRET"] ?: ""),
+                "KAKAO_NATIVE_APP_KEY" to (dotenv["KAKAO_NATIVE_APP_KEY"] ?: ""),
             )
         )
     }
@@ -82,6 +86,8 @@ flutter {
 }
 
 dependencies {
+    // Core library desugaring (flutter_local_notifications 필요)
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
     // Unity Ads SDK
     implementation("com.unity3d.ads:unity-ads:4.12.2")
     // Unity Ads Mediation Adapter

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -38,6 +38,13 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <!-- 카카오 로그인 리다이렉트 처리 -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="kakao${KAKAO_NATIVE_APP_KEY}" android:host="oauth" />
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
@@ -50,6 +57,17 @@
         <meta-data
             android:name="com.google.android.gms.ads.APPLICATION_ID"
             android:value="ca-app-pub-3219791135582658~5531424356"/>
+        <!-- 카카오 로그인: AuthCodeCustomTabsActivity에 리다이렉트 스킴 등록 (필수) -->
+        <activity
+            android:name="com.kakao.sdk.flutter.AuthCodeCustomTabsActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="kakao${KAKAO_NATIVE_APP_KEY}" android:host="oauth" />
+            </intent-filter>
+        </activity>
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and
@@ -71,5 +89,7 @@
             <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="https" />
         </intent>
+        <!-- 카카오톡 앱 설치 여부 확인용 -->
+        <package android:name="com.kakao.talk" />
     </queries>
 </manifest>

--- a/mobile/lib/providers/auth_provider.dart
+++ b/mobile/lib/providers/auth_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../services/auth_service.dart';
+import '../services/fcm_service.dart';
 import '../models/auth_models.dart';
 
 /// 인증 상태
@@ -98,6 +99,9 @@ class AuthNotifier extends Notifier<AuthState> {
       isAnonymous: false,
       userInfo: userInfo,
     );
+
+    // FCM 토큰 서버에 재등록 (로그인 후 푸시 알림 수신을 위해 필수)
+    await FcmService.instance.refreshToken();
   }
 
   /// 익명 로그인 성공 후 상태 업데이트
@@ -111,6 +115,8 @@ class AuthNotifier extends Notifier<AuthState> {
 
   /// 로그아웃
   Future<void> logout() async {
+    // FCM 토큰 서버에서 해제 (푸시 알림 중지)
+    await FcmService.instance.unregisterToken();
     await _authService.logout();
     state = const AuthState();
   }

--- a/mobile/lib/screens/auth/login_screen.dart
+++ b/mobile/lib/screens/auth/login_screen.dart
@@ -195,7 +195,11 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
           errorMessage = '카카오 계정에 이메일이 없습니다.\n이메일 제공 동의가 필요합니다.';
         } else if (serverMessage.contains('network') || serverMessage.contains('timeout')) {
           errorMessage = '네트워크 연결이 불안정합니다.\n잠시 후 다시 시도해 주세요.';
-        } else if (serverMessage.isNotEmpty) {
+        } else if (serverMessage.contains('REDIRECT_URI_MISMATCH')) {
+          errorMessage = '카카오 로그인 설정 오류입니다.\n잠시 후 다시 시도해 주세요.';
+        } else if (serverMessage.contains('PlatformException')) {
+          errorMessage = '카카오 로그인 중 문제가 발생했습니다.\n잠시 후 다시 시도해 주세요.';
+        } else if (serverMessage.isNotEmpty && !serverMessage.contains('Exception')) {
           errorMessage = serverMessage;
         }
       }

--- a/mobile/lib/screens/notification_screen.dart
+++ b/mobile/lib/screens/notification_screen.dart
@@ -488,7 +488,7 @@ class _NotificationScreenState extends State<NotificationScreen>
                       color: const Color(0xFF1A1C1E),
                     ),
                     decoration: InputDecoration(
-                      hintText: '예: 아이폰, 갤럭시, 노트북',
+                      hintText: '예: 강남, 맛집, 카페, 뷰티',
                       hintStyle: TextStyle(
                         fontSize: 14.sp,
                         fontWeight: FontWeight.w400,
@@ -558,7 +558,7 @@ class _NotificationScreenState extends State<NotificationScreen>
 
           // 안내 문구
           Text(
-            '관심있는 상품의 키워드를 등록하면 관련 체험단이 올라올 때 알림을 받을 수 있습니다.',
+            '관심있는 키워드를 등록하면 관련 체험단이 올라올 때 알림을 받을 수 있습니다.\n※ 키워드 등록 이후에 새로 등록된 캠페인에 대해서만 알림을 받습니다.',
             style: TextStyle(
               fontSize: 12.sp,
               fontWeight: FontWeight.w400,

--- a/mobile/lib/services/fcm_service.dart
+++ b/mobile/lib/services/fcm_service.dart
@@ -37,24 +37,42 @@ class FcmService {
         return;
       }
 
-      // 2. FCM 토큰 획득
+      // 2. iOS의 경우 APNS 토큰 대기
+      if (Platform.isIOS) {
+        String? apnsToken = await _messaging.getAPNSToken();
+        if (apnsToken == null) {
+          // APNS 토큰이 없으면 잠시 대기 후 재시도
+          debugPrint('⏳ APNS 토큰 대기 중...');
+          await Future.delayed(const Duration(seconds: 3));
+          apnsToken = await _messaging.getAPNSToken();
+        }
+        if (apnsToken != null) {
+          debugPrint('🍎 APNS 토큰 획득: ${apnsToken.substring(0, 20)}...');
+        } else {
+          debugPrint('⚠️ APNS 토큰을 받지 못했습니다 (시뮬레이터에서는 정상)');
+        }
+      }
+
+      // 3. FCM 토큰 획득
       _currentToken = await _messaging.getToken();
       if (_currentToken != null) {
         debugPrint('🔑 FCM 토큰 획득: ${_currentToken!.substring(0, 20)}...');
         await _registerTokenToServer(_currentToken!);
+      } else {
+        debugPrint('⚠️ FCM 토큰을 받지 못했습니다');
       }
 
-      // 3. 토큰 갱신 리스너 설정
+      // 4. 토큰 갱신 리스너 설정
       _messaging.onTokenRefresh.listen((newToken) async {
         debugPrint('🔄 FCM 토큰 갱신됨');
         _currentToken = newToken;
         await _registerTokenToServer(newToken);
       });
 
-      // 4. 포그라운드 메시지 핸들러 설정
+      // 5. 포그라운드 메시지 핸들러 설정
       FirebaseMessaging.onMessage.listen(_handleForegroundMessage);
 
-      // 5. 백그라운드에서 앱 열림 시 메시지 핸들러
+      // 6. 백그라운드에서 앱 열림 시 메시지 핸들러
       FirebaseMessaging.onMessageOpenedApp.listen(_handleMessageOpenedApp);
 
       _isInitialized = true;

--- a/mobile/lib/services/keyword_service.dart
+++ b/mobile/lib/services/keyword_service.dart
@@ -237,6 +237,32 @@ class KeywordService {
     });
   }
 
+  /// 알람 삭제
+  /// DELETE /v1/keyword-alerts/alerts/{alert_id}
+  Future<void> deleteAlert(int alertId) async {
+    final uri = Uri.parse('$baseUrl/alerts/$alertId');
+    final headers = await _getAuthHeaders();
+
+    return _withRetry(() async {
+      try {
+        final response = await _client
+            .delete(uri, headers: headers)
+            .timeout(const Duration(seconds: 10));
+
+        _debugPrintResponse('DELETE', uri.toString(), response);
+
+        if (response.statusCode != 200) {
+          _handleHttpError(response, '알람을 삭제할 수 없습니다.');
+        }
+      } catch (e) {
+        if (e is Exception && e.toString().contains('Exception:')) {
+          rethrow;
+        }
+        throw Exception(NetworkErrorHandler.getErrorMessage(e));
+      }
+    });
+  }
+
   /// 알람 읽음 처리
   /// POST /v1/keyword-alerts/alerts/read
   Future<void> markAlertsAsRead(List<int> alertIds) async {

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -382,6 +382,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: ef41ae901e7529e52934feba19ed82827b11baa67336829564aeab3129460610
+      url: "https://pub.dev"
+    source: hosted
+    version: "18.0.1"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: "8f685642876742c941b29c32030f6f4f6dacd0e4eaecb3efbb187d6a3812ca01"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "6c5b83c86bf819cdb177a9247a3722067dd8cc6313827ce7c77a4b238a26fd52"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.0"
   flutter_naver_map:
     dependency: "direct main"
     description:
@@ -1205,6 +1229,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.11"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.1"
   typed_data:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -65,6 +65,7 @@ dependencies:
   firebase_performance: ^0.10.1+1
   firebase_remote_config: ^5.1.4
   firebase_messaging: ^15.1.4
+  flutter_local_notifications: ^18.0.1
 
   # SNS 로그인
   kakao_flutter_sdk_user: ^1.9.6

--- a/server/keyword_alerts/signals.py
+++ b/server/keyword_alerts/signals.py
@@ -78,8 +78,8 @@ def send_push_notifications_for_alerts(alerts: list[KeywordAlert], campaign):
     print(f"[Signal] FCM 푸시 전송 대상: {len(tokens)}개 디바이스", flush=True)
 
     # 푸시 알림 전송
-    title = "새로운 캠페인 알림"
-    body = f"관심 키워드와 매칭되는 캠페인: {campaign.company[:50] if campaign.company else '새 캠페인'}"
+    title = "새로운 체험단 알림"
+    body = "관심 키워드와 매칭되는 캠페인이 등록되었습니다. 앱에서 확인해보세요."
     data = {
         "type": "keyword_alert",
         "campaign_id": str(campaign.id),


### PR DESCRIPTION
## Summary
- 앱이 포그라운드 상태일 때도 푸시 알림이 알림창에 표시되도록 개선
- 로그인/로그아웃 시 FCM 토큰 자동 등록/해제 처리
- 푸시 알림 메시지 포맷 개선

## Changes

### Mobile
- `flutter_local_notifications` 패키지 추가
- Android core library desugaring 설정 (Java 8+ API 지원)
- `FcmService`: 포그라운드 알림 표시 로직 구현
- `AuthProvider`: 로그인 시 FCM 토큰 재등록, 로그아웃 시 토큰 해제
- 카카오 로그인 Android intent-filter 설정

### Server
- 푸시 알림 메시지 변경:
  - 제목: "새로운 체험단 알림"
  - 내용: "관심 키워드와 매칭되는 캠페인이 등록되었습니다. 앱에서 확인해보세요."

## Test plan
- [x] Firebase Console에서 테스트 메시지 발송 확인
- [x] 앱 포그라운드 상태에서 알림 표시 확인
- [x] 앱 백그라운드/종료 상태에서 알림 표시 확인