### PR TITLE
feat: 알림 기록 슬라이드 삭제 및 UX 개선

### DIFF
--- a/mobile/lib/screens/notification_screen.dart
+++ b/mobile/lib/screens/notification_screen.dart
@@ -945,6 +945,7 @@ class _NotificationScreenState extends State<NotificationScreen>
         }
       },
       child: Container(
+        width: double.infinity, // 가로 전체 영역 터치 가능
         padding: EdgeInsets.symmetric(vertical: 12.h),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/mobile/lib/screens/notification_screen.dart
+++ b/mobile/lib/screens/notification_screen.dart
@@ -812,12 +812,16 @@ class _NotificationScreenState extends State<NotificationScreen>
         ),
         // 알림 목록 (슬라이드 삭제 기능)
         Expanded(
-          child: ListView.builder(
+          child: ListView.separated(
             padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 12.h),
             itemCount: _alerts.length,
+            separatorBuilder: (context, index) => Divider(
+              height: 1,
+              thickness: 1,
+              color: Colors.grey.shade300,
+            ),
             itemBuilder: (context, index) {
               final alert = _alerts[index];
-              final bool showDivider = index > 0;
 
               return Dismissible(
                 key: Key('alert_${alert.id}'),
@@ -859,14 +863,7 @@ class _NotificationScreenState extends State<NotificationScreen>
                 background: Container(
                   alignment: Alignment.centerRight,
                   padding: EdgeInsets.only(right: 20.w),
-                  decoration: BoxDecoration(
-                    color: Colors.red,
-                    border: showDivider
-                        ? Border(
-                            top: BorderSide(color: Colors.grey.shade300, width: 1),
-                          )
-                        : null,
-                  ),
+                  color: Colors.red,
                   child: Icon(
                     Icons.delete,
                     color: Colors.white,
@@ -874,13 +871,7 @@ class _NotificationScreenState extends State<NotificationScreen>
                   ),
                 ),
                 child: Container(
-                  decoration: showDivider
-                      ? BoxDecoration(
-                          border: Border(
-                            top: BorderSide(color: Colors.grey.shade300, width: 1),
-                          ),
-                        )
-                      : null,
+                  color: Colors.white,
                   child: _buildAlertCard(alert),
                 ),
               );

--- a/mobile/lib/screens/notification_screen.dart
+++ b/mobile/lib/screens/notification_screen.dart
@@ -831,6 +831,7 @@ class _NotificationScreenState extends State<NotificationScreen>
                   return await showDialog<bool>(
                     context: context,
                     builder: (context) => AlertDialog(
+                      backgroundColor: Colors.white,
                       title: const Text('알림 삭제'),
                       content: Text(
                         "'${alert.keyword}' 알림을 삭제하시겠습니까?",
@@ -922,6 +923,7 @@ class _NotificationScreenState extends State<NotificationScreen>
           await showDialog(
             context: context,
             builder: (context) => AlertDialog(
+              backgroundColor: Colors.white,
               title: const Text('알림'),
               content: const Text('삭제된 체험단이거나, 유효하지 않은 체험단입니다.'),
               actions: [

--- a/mobile/lib/screens/profile_screen.dart
+++ b/mobile/lib/screens/profile_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
-import 'package:package_info_plus/package_info_plus.dart';
+import '../config/app_version.dart';
 import '../providers/auth_provider.dart';
 import 'auth/login_screen.dart';
 import 'notification_screen.dart';
@@ -222,7 +222,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
           // 앱 정보 (논리 버전 사용)
           Center(
             child: Text(
-              '리뷰맵 v2.0.0',
+              '리뷰맵 v${AppVersion.current}',
               style: TextStyle(
                 fontSize: 12.sp,
                 fontWeight: FontWeight.w400,

--- a/mobile/lib/screens/profile_screen.dart
+++ b/mobile/lib/screens/profile_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import '../providers/auth_provider.dart';
 import 'auth/login_screen.dart';
+import 'notification_screen.dart';
 
 /// 내정보 화면
 /// - 비회원: 로그인 안내 표시
@@ -16,27 +17,6 @@ class ProfileScreen extends ConsumerStatefulWidget {
 }
 
 class _ProfileScreenState extends ConsumerState<ProfileScreen> {
-  String _appVersion = '';
-
-  @override
-  void initState() {
-    super.initState();
-    _loadAppVersion();
-  }
-
-  /// 앱 버전 정보 로드
-  Future<void> _loadAppVersion() async {
-    try {
-      final packageInfo = await PackageInfo.fromPlatform();
-      if (mounted) {
-        setState(() {
-          _appVersion = packageInfo.version;
-        });
-      }
-    } catch (e) {
-      debugPrint('앱 버전 로드 실패: $e');
-    }
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -205,18 +185,23 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
                   icon: Icons.notifications_outlined,
                   title: '알림 설정',
                   onTap: () {
-                    // TODO: 알림 설정 화면으로 이동
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (context) => const NotificationScreen(),
+                      ),
+                    );
                   },
                 ),
                 _buildDivider(),
-                _buildMenuItem(
-                  icon: Icons.settings_outlined,
-                  title: '설정',
-                  onTap: () {
-                    // TODO: 설정 화면으로 이동
-                  },
-                ),
-                _buildDivider(),
+                // 설정 메뉴 (향후 사용 예정)
+                // _buildMenuItem(
+                //   icon: Icons.settings_outlined,
+                //   title: '설정',
+                //   onTap: () {
+                //     // TODO: 설정 화면으로 이동
+                //   },
+                // ),
+                // _buildDivider(),
                 _buildMenuItem(
                   icon: Icons.logout,
                   title: '로그아웃',
@@ -234,12 +219,10 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
 
           SizedBox(height: 24.h),
 
-          // 앱 정보 (동적 버전)
+          // 앱 정보 (논리 버전 사용)
           Center(
             child: Text(
-              _appVersion.isNotEmpty
-                  ? 'ReviewMaps v$_appVersion'
-                  : 'ReviewMaps',
+              '리뷰맵 v2.0.0',
               style: TextStyle(
                 fontSize: 12.sp,
                 fontWeight: FontWeight.w400,


### PR DESCRIPTION
## 📋 변경사항 요약

### 알림 기록 기능 개선
- ✅ 왼쪽 슬라이드로 알림 삭제 기능 추가
- ✅ 삭제 확인 다이얼로그 표시
- ✅ 강제 삭제 지원 (서버 API 실패해도 로컬에서 삭제)
- ✅ 구분선 레이아웃 개선 (ListView.separated 사용)
- ✅ 터치 영역을 가로 전체로 확대

### UX 개선
- ✅ '정렬:' 텍스트 제거
- ✅ 삭제된 캠페인 클릭 시 안내 팝업 표시
- ✅ 삭제된 캠페인의 읽지 않음 표시 제거
- ✅ 알림 팝업 배경색 흰색으로 통일
- ✅ 기술적 에러 메시지 숨김 처리

### 내정보 화면 개선
- ✅ 알림 설정 메뉴 → 알림설정 페이지로 이동
- ✅ 설정 메뉴 주석 처리 (향후 사용 예정)
- ✅ 앱 버전 표시: 리뷰맵 v2.0.0 (AppVersion.current 사용)

## 🎯 주요 기능

### 1. 알림 슬라이드 삭제
- Dismissible 위젯으로 슬라이드 삭제 UI 구현
- 빨간색 배경과 휴지통 아이콘 표시

### 2. 강제 삭제 지원
- UI에서 먼저 삭제 → 사용자 즉시 확인
- 서버 API는 백그라운드에서 시도
- 네트워크 오류나 토큰 만료 시에도 삭제 가능

### 3. 삭제된 캠페인 처리
- 클릭 시 '삭제된 체험단이거나, 유효하지 않은 체험단입니다' 팝업
- NEW 뱃지는 유지, 읽지 않음 빨간 동그라미만 제거

## 📝 커밋 내역
- feat: 알림 기록 슬라이드 삭제 기능 추가
- fix: 알림 기록 리스트 구분선 및 레이아웃 개선
- improve: 알림 기록 UX 개선
- improve: 알림 카드 터치 영역을 가로 전체로 확대
- style: 알림 팝업 배경색을 흰색으로 변경
- fix: 알림 삭제를 항상 성공하도록 개선
- feat: 내정보 화면 개선
- refactor: AppVersion.current를 사용하여 앱 버전 표시

## 🧪 테스트 필요
- [ ] 알림 슬라이드 삭제 동작 확인
- [ ] 삭제 후 새로고침 시 삭제 유지 확인
- [ ] 삭제된 캠페인 클릭 시 팝업 확인
- [ ] 내정보 > 알림 설정 네비게이션 확인
- [ ] 앱 버전 표시 확인 (리뷰맵 v2.0.0)