### PR TITLE
fix: remote_config_service에 debugPrint import 추가

### DIFF
--- a/mobile/lib/services/remote_config_service.dart
+++ b/mobile/lib/services/remote_config_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:firebase_remote_config/firebase_remote_config.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 


### PR DESCRIPTION
debugPrint 사용을 위한 flutter/foundation.dart import 추가

Fixes linter error: 'debugPrint' method not defined