### PR TITLE
feat: 회원 탈퇴 API 구현 (Apple App Store 정책 준수)

### DIFF
--- a/server/users/schemas.py
+++ b/server/users/schemas.py
@@ -104,3 +104,9 @@ class UserDetailResponse(UserResponse):
     name: Optional[str] = None  # 사용자 이름
     profile_image: Optional[str] = None  # 프로필 이미지 URL (첫 번째 소셜 계정의 이미지)
     social_accounts: list[SocialAccountInfo] = []
+
+
+class MessageResponse(Schema):
+    """일반 메시지 응답"""
+    message: str
+    success: bool = True


### PR DESCRIPTION
## Summary
- Apple App Store 정책 준수를 위한 계정 삭제 API 구현
- DELETE /v1/auth/me 엔드포인트 추가

## Changes

### Server API
- **DELETE /v1/auth/me**: 회원 탈퇴 엔드포인트
  - JWT 인증 필수
  - Soft delete 방식 (is_active = False)
  - 연결된 SNS 계정 삭제
  - 탈퇴 사유 로깅 지원 (선택)

### Schema
- `MessageResponse`: 일반 메시지 응답
- `DeleteAccountRequest`: 탈퇴 요청 (reason 필드)

## Test Plan
- [ ] API 엔드포인트 테스트
- [ ] 탈퇴 후 로그인 불가 확인
- [ ] SNS 계정 삭제 확인