### PR TITLE
feat: 회원 탈퇴 기능 Mobile UI 구현 (Apple App Store 정책 준수)

### DIFF
--- a/mobile/lib/providers/auth_provider.dart
+++ b/mobile/lib/providers/auth_provider.dart
@@ -121,6 +121,14 @@ class AuthNotifier extends Notifier<AuthState> {
     state = const AuthState();
   }
 
+  /// 회원 탈퇴
+  Future<void> deleteAccount({String? reason}) async {
+    // FCM 토큰 서버에서 해제 (푸시 알림 중지)
+    await FcmService.instance.unregisterToken();
+    await _authService.deleteAccount(reason: reason);
+    state = const AuthState();
+  }
+
   /// 리소스 정리
   void dispose() {
     _authService.dispose();

--- a/mobile/lib/screens/profile_screen.dart
+++ b/mobile/lib/screens/profile_screen.dart
@@ -230,6 +230,27 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
               ),
             ),
           ),
+
+          SizedBox(height: 16.h),
+
+          // 회원 탈퇴 버튼
+          Center(
+            child: TextButton(
+              onPressed: () => _showDeleteAccountBottomSheet(context),
+              child: Text(
+                '회원 탈퇴',
+                style: TextStyle(
+                  fontSize: 12.sp,
+                  fontWeight: FontWeight.w400,
+                  color: const Color(0xFF9CA3AF),
+                  decoration: TextDecoration.underline,
+                  decorationColor: const Color(0xFF9CA3AF),
+                ),
+              ),
+            ),
+          ),
+
+          SizedBox(height: 16.h),
         ],
       ),
     );
@@ -410,6 +431,236 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  /// 회원 탈퇴 바텀시트 (요즘 스타일)
+  void _showDeleteAccountBottomSheet(BuildContext context) {
+    final reasonController = TextEditingController();
+    bool isLoading = false;
+
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) => StatefulBuilder(
+        builder: (context, setState) => Container(
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.vertical(
+              top: Radius.circular(20.r),
+            ),
+          ),
+          padding: EdgeInsets.only(
+            bottom: MediaQuery.of(context).viewInsets.bottom,
+          ),
+          child: SafeArea(
+            child: Padding(
+              padding: EdgeInsets.all(24.w),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // 핸들 바
+                  Center(
+                    child: Container(
+                      width: 40.w,
+                      height: 4.h,
+                      decoration: BoxDecoration(
+                        color: const Color(0xFFE5E7EB),
+                        borderRadius: BorderRadius.circular(2.r),
+                      ),
+                    ),
+                  ),
+                  SizedBox(height: 24.h),
+
+                  // 타이틀
+                  Text(
+                    '정말 탈퇴하시겠어요?',
+                    style: TextStyle(
+                      fontSize: 20.sp,
+                      fontWeight: FontWeight.w700,
+                      color: const Color(0xFF1A1C1E),
+                    ),
+                  ),
+                  SizedBox(height: 12.h),
+
+                  // 안내 문구
+                  Text(
+                    '탈퇴하시면 모든 데이터가 삭제되며,\n복구할 수 없습니다.',
+                    style: TextStyle(
+                      fontSize: 14.sp,
+                      fontWeight: FontWeight.w400,
+                      color: const Color(0xFF6C7278),
+                      height: 1.5,
+                    ),
+                  ),
+                  SizedBox(height: 24.h),
+
+                  // 탈퇴 사유 입력 (선택)
+                  Text(
+                    '탈퇴 사유 (선택)',
+                    style: TextStyle(
+                      fontSize: 14.sp,
+                      fontWeight: FontWeight.w500,
+                      color: const Color(0xFF1A1C1E),
+                    ),
+                  ),
+                  SizedBox(height: 8.h),
+                  TextField(
+                    controller: reasonController,
+                    maxLines: 3,
+                    maxLength: 200,
+                    decoration: InputDecoration(
+                      hintText: '서비스 개선을 위해 탈퇴 사유를 알려주세요',
+                      hintStyle: TextStyle(
+                        fontSize: 14.sp,
+                        color: const Color(0xFF9CA3AF),
+                      ),
+                      filled: true,
+                      fillColor: const Color(0xFFF9FAFB),
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12.r),
+                        borderSide: const BorderSide(
+                          color: Color(0xFFE5E7EB),
+                        ),
+                      ),
+                      enabledBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12.r),
+                        borderSide: const BorderSide(
+                          color: Color(0xFFE5E7EB),
+                        ),
+                      ),
+                      focusedBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12.r),
+                        borderSide: BorderSide(
+                          color: Theme.of(context).primaryColor,
+                        ),
+                      ),
+                      contentPadding: EdgeInsets.all(16.w),
+                    ),
+                  ),
+                  SizedBox(height: 24.h),
+
+                  // 버튼들
+                  Row(
+                    children: [
+                      // 취소 버튼
+                      Expanded(
+                        child: OutlinedButton(
+                          onPressed: isLoading
+                              ? null
+                              : () => Navigator.of(context).pop(),
+                          style: OutlinedButton.styleFrom(
+                            foregroundColor: const Color(0xFF6C7278),
+                            side: const BorderSide(
+                              color: Color(0xFFE5E7EB),
+                            ),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(12.r),
+                            ),
+                            padding: EdgeInsets.symmetric(vertical: 16.h),
+                          ),
+                          child: Text(
+                            '취소',
+                            style: TextStyle(
+                              fontSize: 16.sp,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ),
+                      ),
+                      SizedBox(width: 12.w),
+                      // 탈퇴 버튼
+                      Expanded(
+                        child: ElevatedButton(
+                          onPressed: isLoading
+                              ? null
+                              : () async {
+                                  setState(() => isLoading = true);
+
+                                  try {
+                                    await ref
+                                        .read(authProvider.notifier)
+                                        .deleteAccount(
+                                          reason: reasonController.text.isEmpty
+                                              ? null
+                                              : reasonController.text,
+                                        );
+
+                                    if (context.mounted) {
+                                      Navigator.of(context).pop();
+                                      ScaffoldMessenger.of(context).showSnackBar(
+                                        SnackBar(
+                                          content: const Text(
+                                            '회원 탈퇴가 완료되었습니다.\n그동안 이용해 주셔서 감사합니다.',
+                                          ),
+                                          backgroundColor: Colors.green,
+                                          behavior: SnackBarBehavior.floating,
+                                          shape: RoundedRectangleBorder(
+                                            borderRadius:
+                                                BorderRadius.circular(10.r),
+                                          ),
+                                        ),
+                                      );
+                                    }
+                                  } catch (e) {
+                                    setState(() => isLoading = false);
+                                    if (context.mounted) {
+                                      ScaffoldMessenger.of(context).showSnackBar(
+                                        SnackBar(
+                                          content: Text(
+                                            e.toString().replaceAll(
+                                                'Exception: ', ''),
+                                          ),
+                                          backgroundColor: Colors.red,
+                                          behavior: SnackBarBehavior.floating,
+                                          shape: RoundedRectangleBorder(
+                                            borderRadius:
+                                                BorderRadius.circular(10.r),
+                                          ),
+                                        ),
+                                      );
+                                    }
+                                  }
+                                },
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Colors.red,
+                            foregroundColor: Colors.white,
+                            elevation: 0,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(12.r),
+                            ),
+                            padding: EdgeInsets.symmetric(vertical: 16.h),
+                          ),
+                          child: isLoading
+                              ? SizedBox(
+                                  width: 20.w,
+                                  height: 20.w,
+                                  child: const CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                    valueColor: AlwaysStoppedAnimation<Color>(
+                                      Colors.white,
+                                    ),
+                                  ),
+                                )
+                              : Text(
+                                  '탈퇴하기',
+                                  style: TextStyle(
+                                    fontSize: 16.sp,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Apple App Store 정책 준수를 위한 앱 내 계정 삭제 UI 구현
- 내정보 화면에서 회원 탈퇴 기능 접근 가능

## Changes

### AuthService
- `deleteAccount()` 메서드 추가
- DELETE /v1/auth/me API 호출
- 탈퇴 사유 전달 지원

### AuthProvider  
- `deleteAccount()` 메서드 추가
- FCM 토큰 해제 후 탈퇴 처리

### ProfileScreen
- 회원 탈퇴 버튼 추가 (앱 버전 하단, 밑줄 텍스트)
- 모던 스타일 바텀시트 UI
  - 드래그 핸들 바
  - 탈퇴 경고 안내
  - 탈퇴 사유 입력 (선택, 최대 200자)
  - 취소/탈퇴 버튼
- 로딩 상태 표시
- 성공/에러 스낵바 피드백

## Screenshots
탈퇴 바텀시트 UI:
- 핸들 바 + 타이틀 + 안내문구
- 탈퇴 사유 입력 필드
- 취소(아웃라인) / 탈퇴(빨간색) 버튼

## Test Plan
- [ ] 내정보 화면에서 탈퇴 버튼 표시 확인
- [ ] 바텀시트 UI 동작 확인
- [ ] 탈퇴 API 호출 및 성공 처리
- [ ] 탈퇴 후 로그아웃 상태 전환