### PR TITLE
비밀번호 재설정 및 변경 API 구현

### DIFF
--- a/server/users/schemas.py
+++ b/server/users/schemas.py
@@ -137,3 +137,41 @@ class EmailVerifyCodeResponse(Schema):
     """이메일 인증코드 확인 응답"""
     verified: bool
     verification_token: str
+
+
+# ===== 비밀번호 재설정 스키마 =====
+
+class PasswordResetRequest(Schema):
+    """비밀번호 재설정 요청 (인증코드 발송)"""
+    email: str
+
+
+class PasswordResetResponse(Schema):
+    """비밀번호 재설정 응답"""
+    message: str
+    expires_in: int
+
+
+class PasswordResetVerifyRequest(Schema):
+    """비밀번호 재설정 인증코드 확인"""
+    email: str
+    code: str
+
+
+class PasswordResetVerifyResponse(Schema):
+    """비밀번호 재설정 인증코드 확인 응답"""
+    verified: bool
+    reset_token: str
+
+
+class PasswordResetConfirmRequest(Schema):
+    """비밀번호 재설정 확정 (새 비밀번호 설정)"""
+    email: str
+    reset_token: str
+    new_password: str
+
+
+class PasswordChangeRequest(Schema):
+    """비밀번호 변경 요청 (로그인한 사용자)"""
+    current_password: str
+    new_password: str


### PR DESCRIPTION
## 🔐 구현 기능

### 1. 비밀번호 재설정 (이메일 인증)
- `POST /v1/auth/password/reset-request`: 인증코드 이메일 발송
- `POST /v1/auth/password/reset-verify`: 인증코드 확인 및 reset_token 발급
- `POST /v1/auth/password/reset-confirm`: 새 비밀번호 설정

### 2. 비밀번호 변경 (로그인 사용자)
- `POST /v1/auth/password/change`: 현재 비밀번호 확인 후 변경

## 📋 구현 상세

### 보안 기능
- ✅ 기존 EmailVerification 모델 재활용
- ✅ 6자리 랜덤 인증코드 생성
- ✅ 60분 유효기간
- ✅ 5회 실패 시 재요청 필요
- ✅ 재발송 쿨다운 60초 (2회부터)
- ✅ reset_token으로 이중 검증
- ✅ 인증 후 토큰 삭제 (재사용 방지)

### 제약사항
- email 로그인 사용자만 지원 (SNS 로그인 제외)
- 비밀번호 8자 이상 필수
- 새 비밀번호는 현재 비밀번호와 달라야 함

## 🔄 API 플로우

### 비밀번호 찾기
1. 사용자가 이메일 입력 → reset-request
2. 이메일로 6자리 코드 수신
3. 코드 입력 → reset-verify → reset_token 획득
4. 새 비밀번호 입력 → reset-confirm

### 비밀번호 변경 (로그인 상태)
1. 현재 비밀번호 + 새 비밀번호 입력 → change

## ✅ 테스트
- Python 문법 검증 완료
- 기존 이메일 인증 시스템과 통합

## 📦 변경 파일
- `users/schemas.py`: 6개 스키마 추가
- `users/api.py`: 4개 API 엔드포인트 추가