### PR TITLE
feat: 비밀번호 찾기 구현 및 설정 화면 추가

### DIFF
--- a/mobile/lib/screens/auth/login_screen.dart
+++ b/mobile/lib/screens/auth/login_screen.dart
@@ -376,7 +376,12 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                 alignment: Alignment.centerRight,
                 child: TextButton(
                   onPressed: () {
-                    // TODO: 비밀번호 찾기 처리
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => const PasswordResetScreen(),
+                      ),
+                    );
                   },
                   child: Text(
                     '비밀번호를 잊으셨나요?',

--- a/mobile/lib/screens/profile_screen.dart
+++ b/mobile/lib/screens/profile_screen.dart
@@ -5,6 +5,7 @@ import '../config/app_version.dart';
 import '../providers/auth_provider.dart';
 import 'auth/login_screen.dart';
 import 'notification_screen.dart';
+import 'settings_screen.dart';
 
 /// 내정보 화면
 /// - 비회원: 로그인 안내 표시
@@ -193,15 +194,18 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
                   },
                 ),
                 _buildDivider(),
-                // 설정 메뉴 (향후 사용 예정)
-                // _buildMenuItem(
-                //   icon: Icons.settings_outlined,
-                //   title: '설정',
-                //   onTap: () {
-                //     // TODO: 설정 화면으로 이동
-                //   },
-                // ),
-                // _buildDivider(),
+                _buildMenuItem(
+                  icon: Icons.settings_outlined,
+                  title: '설정',
+                  onTap: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (context) => const SettingsScreen(),
+                      ),
+                    );
+                  },
+                ),
+                _buildDivider(),
                 _buildMenuItem(
                   icon: Icons.logout,
                   title: '로그아웃',
@@ -227,25 +231,6 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
                 fontSize: 12.sp,
                 fontWeight: FontWeight.w400,
                 color: const Color(0xFF9CA3AF),
-              ),
-            ),
-          ),
-
-          SizedBox(height: 16.h),
-
-          // 회원 탈퇴 버튼
-          Center(
-            child: TextButton(
-              onPressed: () => _showDeleteAccountBottomSheet(context),
-              child: Text(
-                '회원 탈퇴',
-                style: TextStyle(
-                  fontSize: 12.sp,
-                  fontWeight: FontWeight.w400,
-                  color: const Color(0xFF9CA3AF),
-                  decoration: TextDecoration.underline,
-                  decorationColor: const Color(0xFF9CA3AF),
-                ),
               ),
             ),
           ),
@@ -432,236 +417,6 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
             ),
           ),
         ],
-      ),
-    );
-  }
-
-  /// 회원 탈퇴 바텀시트 (요즘 스타일)
-  void _showDeleteAccountBottomSheet(BuildContext context) {
-    final reasonController = TextEditingController();
-    bool isLoading = false;
-
-    showModalBottomSheet(
-      context: context,
-      isScrollControlled: true,
-      backgroundColor: Colors.transparent,
-      builder: (context) => StatefulBuilder(
-        builder: (context, setState) => Container(
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.vertical(
-              top: Radius.circular(20.r),
-            ),
-          ),
-          padding: EdgeInsets.only(
-            bottom: MediaQuery.of(context).viewInsets.bottom,
-          ),
-          child: SafeArea(
-            child: Padding(
-              padding: EdgeInsets.all(24.w),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // 핸들 바
-                  Center(
-                    child: Container(
-                      width: 40.w,
-                      height: 4.h,
-                      decoration: BoxDecoration(
-                        color: const Color(0xFFE5E7EB),
-                        borderRadius: BorderRadius.circular(2.r),
-                      ),
-                    ),
-                  ),
-                  SizedBox(height: 24.h),
-
-                  // 타이틀
-                  Text(
-                    '정말 탈퇴하시겠어요?',
-                    style: TextStyle(
-                      fontSize: 20.sp,
-                      fontWeight: FontWeight.w700,
-                      color: const Color(0xFF1A1C1E),
-                    ),
-                  ),
-                  SizedBox(height: 12.h),
-
-                  // 안내 문구
-                  Text(
-                    '탈퇴하시면 모든 데이터가 삭제되며,\n복구할 수 없습니다.',
-                    style: TextStyle(
-                      fontSize: 14.sp,
-                      fontWeight: FontWeight.w400,
-                      color: const Color(0xFF6C7278),
-                      height: 1.5,
-                    ),
-                  ),
-                  SizedBox(height: 24.h),
-
-                  // 탈퇴 사유 입력 (선택)
-                  Text(
-                    '탈퇴 사유 (선택)',
-                    style: TextStyle(
-                      fontSize: 14.sp,
-                      fontWeight: FontWeight.w500,
-                      color: const Color(0xFF1A1C1E),
-                    ),
-                  ),
-                  SizedBox(height: 8.h),
-                  TextField(
-                    controller: reasonController,
-                    maxLines: 3,
-                    maxLength: 200,
-                    decoration: InputDecoration(
-                      hintText: '서비스 개선을 위해 탈퇴 사유를 알려주세요',
-                      hintStyle: TextStyle(
-                        fontSize: 14.sp,
-                        color: const Color(0xFF9CA3AF),
-                      ),
-                      filled: true,
-                      fillColor: const Color(0xFFF9FAFB),
-                      border: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12.r),
-                        borderSide: const BorderSide(
-                          color: Color(0xFFE5E7EB),
-                        ),
-                      ),
-                      enabledBorder: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12.r),
-                        borderSide: const BorderSide(
-                          color: Color(0xFFE5E7EB),
-                        ),
-                      ),
-                      focusedBorder: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12.r),
-                        borderSide: BorderSide(
-                          color: Theme.of(context).primaryColor,
-                        ),
-                      ),
-                      contentPadding: EdgeInsets.all(16.w),
-                    ),
-                  ),
-                  SizedBox(height: 24.h),
-
-                  // 버튼들
-                  Row(
-                    children: [
-                      // 취소 버튼
-                      Expanded(
-                        child: OutlinedButton(
-                          onPressed: isLoading
-                              ? null
-                              : () => Navigator.of(context).pop(),
-                          style: OutlinedButton.styleFrom(
-                            foregroundColor: const Color(0xFF6C7278),
-                            side: const BorderSide(
-                              color: Color(0xFFE5E7EB),
-                            ),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(12.r),
-                            ),
-                            padding: EdgeInsets.symmetric(vertical: 16.h),
-                          ),
-                          child: Text(
-                            '취소',
-                            style: TextStyle(
-                              fontSize: 16.sp,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
-                        ),
-                      ),
-                      SizedBox(width: 12.w),
-                      // 탈퇴 버튼
-                      Expanded(
-                        child: ElevatedButton(
-                          onPressed: isLoading
-                              ? null
-                              : () async {
-                                  setState(() => isLoading = true);
-
-                                  try {
-                                    await ref
-                                        .read(authProvider.notifier)
-                                        .deleteAccount(
-                                          reason: reasonController.text.isEmpty
-                                              ? null
-                                              : reasonController.text,
-                                        );
-
-                                    if (context.mounted) {
-                                      Navigator.of(context).pop();
-                                      ScaffoldMessenger.of(context).showSnackBar(
-                                        SnackBar(
-                                          content: const Text(
-                                            '회원 탈퇴가 완료되었습니다.\n그동안 이용해 주셔서 감사합니다.',
-                                          ),
-                                          backgroundColor: Colors.green,
-                                          behavior: SnackBarBehavior.floating,
-                                          shape: RoundedRectangleBorder(
-                                            borderRadius:
-                                                BorderRadius.circular(10.r),
-                                          ),
-                                        ),
-                                      );
-                                    }
-                                  } catch (e) {
-                                    setState(() => isLoading = false);
-                                    if (context.mounted) {
-                                      ScaffoldMessenger.of(context).showSnackBar(
-                                        SnackBar(
-                                          content: Text(
-                                            e.toString().replaceAll(
-                                                'Exception: ', ''),
-                                          ),
-                                          backgroundColor: Colors.red,
-                                          behavior: SnackBarBehavior.floating,
-                                          shape: RoundedRectangleBorder(
-                                            borderRadius:
-                                                BorderRadius.circular(10.r),
-                                          ),
-                                        ),
-                                      );
-                                    }
-                                  }
-                                },
-                          style: ElevatedButton.styleFrom(
-                            backgroundColor: Colors.red,
-                            foregroundColor: Colors.white,
-                            elevation: 0,
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(12.r),
-                            ),
-                            padding: EdgeInsets.symmetric(vertical: 16.h),
-                          ),
-                          child: isLoading
-                              ? SizedBox(
-                                  width: 20.w,
-                                  height: 20.w,
-                                  child: const CircularProgressIndicator(
-                                    strokeWidth: 2,
-                                    valueColor: AlwaysStoppedAnimation<Color>(
-                                      Colors.white,
-                                    ),
-                                  ),
-                                )
-                              : Text(
-                                  '탈퇴하기',
-                                  style: TextStyle(
-                                    fontSize: 16.sp,
-                                    fontWeight: FontWeight.w600,
-                                  ),
-                                ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
       ),
     );
   }

--- a/mobile/lib/screens/settings_screen.dart
+++ b/mobile/lib/screens/settings_screen.dart
@@ -1,0 +1,364 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import '../providers/auth_provider.dart';
+
+/// 설정 화면
+/// - 회원 탈퇴 등 설정 관련 기능 제공
+class SettingsScreen extends ConsumerStatefulWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  ConsumerState<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends ConsumerState<SettingsScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        title: const Text('설정'),
+        backgroundColor: Colors.white,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: SingleChildScrollView(
+        padding: EdgeInsets.all(16.w),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(height: 8.h),
+
+            // 계정 섹션
+            _buildSectionTitle('계정'),
+            SizedBox(height: 8.h),
+            Container(
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(12.r),
+                border: Border.all(
+                  color: const Color(0xFFEDF1F3),
+                  width: 1,
+                ),
+              ),
+              child: Column(
+                children: [
+                  _buildMenuItem(
+                    icon: Icons.person_remove_outlined,
+                    title: '회원 탈퇴',
+                    textColor: Colors.red,
+                    onTap: () => _showDeleteAccountBottomSheet(context),
+                  ),
+                ],
+              ),
+            ),
+
+            SizedBox(height: 24.h),
+
+            // 향후 추가될 설정 섹션 예시
+            // _buildSectionTitle('알림'),
+            // _buildSectionTitle('테마'),
+            // 등등...
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 섹션 타이틀
+  Widget _buildSectionTitle(String title) {
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: 4.w),
+      child: Text(
+        title,
+        style: TextStyle(
+          fontSize: 14.sp,
+          fontWeight: FontWeight.w600,
+          color: const Color(0xFF6C7278),
+        ),
+      ),
+    );
+  }
+
+  /// 메뉴 아이템
+  Widget _buildMenuItem({
+    required IconData icon,
+    required String title,
+    required VoidCallback onTap,
+    Color? textColor,
+  }) {
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: 16.w,
+          vertical: 16.h,
+        ),
+        child: Row(
+          children: [
+            Icon(
+              icon,
+              size: 24.sp,
+              color: textColor ?? const Color(0xFF6C7278),
+            ),
+            SizedBox(width: 16.w),
+            Expanded(
+              child: Text(
+                title,
+                style: TextStyle(
+                  fontSize: 14.sp,
+                  fontWeight: FontWeight.w500,
+                  color: textColor ?? const Color(0xFF1A1C1E),
+                ),
+              ),
+            ),
+            Icon(
+              Icons.chevron_right,
+              size: 20.sp,
+              color: const Color(0xFF9CA3AF),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 회원 탈퇴 바텀시트
+  void _showDeleteAccountBottomSheet(BuildContext context) {
+    final reasonController = TextEditingController();
+    bool isLoading = false;
+
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) => StatefulBuilder(
+        builder: (context, setState) => Container(
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.vertical(
+              top: Radius.circular(20.r),
+            ),
+          ),
+          padding: EdgeInsets.only(
+            bottom: MediaQuery.of(context).viewInsets.bottom,
+          ),
+          child: SafeArea(
+            child: Padding(
+              padding: EdgeInsets.all(24.w),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // 핸들 바
+                  Center(
+                    child: Container(
+                      width: 40.w,
+                      height: 4.h,
+                      decoration: BoxDecoration(
+                        color: const Color(0xFFE5E7EB),
+                        borderRadius: BorderRadius.circular(2.r),
+                      ),
+                    ),
+                  ),
+                  SizedBox(height: 24.h),
+
+                  // 타이틀
+                  Text(
+                    '정말 탈퇴하시겠어요?',
+                    style: TextStyle(
+                      fontSize: 20.sp,
+                      fontWeight: FontWeight.w700,
+                      color: const Color(0xFF1A1C1E),
+                    ),
+                  ),
+                  SizedBox(height: 12.h),
+
+                  // 안내 문구
+                  Text(
+                    '탈퇴하시면 모든 데이터가 삭제되며,\n복구할 수 없습니다.',
+                    style: TextStyle(
+                      fontSize: 14.sp,
+                      fontWeight: FontWeight.w400,
+                      color: const Color(0xFF6C7278),
+                      height: 1.5,
+                    ),
+                  ),
+                  SizedBox(height: 24.h),
+
+                  // 탈퇴 사유 입력 (선택)
+                  Text(
+                    '탈퇴 사유 (선택)',
+                    style: TextStyle(
+                      fontSize: 14.sp,
+                      fontWeight: FontWeight.w500,
+                      color: const Color(0xFF1A1C1E),
+                    ),
+                  ),
+                  SizedBox(height: 8.h),
+                  TextField(
+                    controller: reasonController,
+                    maxLines: 3,
+                    maxLength: 200,
+                    decoration: InputDecoration(
+                      hintText: '서비스 개선을 위해 탈퇴 사유를 알려주세요',
+                      hintStyle: TextStyle(
+                        fontSize: 14.sp,
+                        color: const Color(0xFF9CA3AF),
+                      ),
+                      filled: true,
+                      fillColor: const Color(0xFFF9FAFB),
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12.r),
+                        borderSide: const BorderSide(
+                          color: Color(0xFFE5E7EB),
+                        ),
+                      ),
+                      enabledBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12.r),
+                        borderSide: const BorderSide(
+                          color: Color(0xFFE5E7EB),
+                        ),
+                      ),
+                      focusedBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12.r),
+                        borderSide: BorderSide(
+                          color: Theme.of(context).primaryColor,
+                        ),
+                      ),
+                      contentPadding: EdgeInsets.all(16.w),
+                    ),
+                  ),
+                  SizedBox(height: 24.h),
+
+                  // 버튼들
+                  Row(
+                    children: [
+                      // 취소 버튼
+                      Expanded(
+                        child: OutlinedButton(
+                          onPressed: isLoading
+                              ? null
+                              : () => Navigator.of(context).pop(),
+                          style: OutlinedButton.styleFrom(
+                            foregroundColor: const Color(0xFF6C7278),
+                            side: const BorderSide(
+                              color: Color(0xFFE5E7EB),
+                            ),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(12.r),
+                            ),
+                            padding: EdgeInsets.symmetric(vertical: 16.h),
+                          ),
+                          child: Text(
+                            '취소',
+                            style: TextStyle(
+                              fontSize: 16.sp,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ),
+                      ),
+                      SizedBox(width: 12.w),
+                      // 탈퇴 버튼
+                      Expanded(
+                        child: ElevatedButton(
+                          onPressed: isLoading
+                              ? null
+                              : () async {
+                                  setState(() => isLoading = true);
+
+                                  try {
+                                    await ref
+                                        .read(authProvider.notifier)
+                                        .deleteAccount(
+                                          reason: reasonController.text.isEmpty
+                                              ? null
+                                              : reasonController.text,
+                                        );
+
+                                    if (context.mounted) {
+                                      // 바텀시트 닫기
+                                      Navigator.of(context).pop();
+                                      // 설정 화면 닫기
+                                      Navigator.of(context).pop();
+                                      
+                                      ScaffoldMessenger.of(context).showSnackBar(
+                                        SnackBar(
+                                          content: const Text(
+                                            '회원 탈퇴가 완료되었습니다.\n그동안 이용해 주셔서 감사합니다.',
+                                          ),
+                                          backgroundColor: Colors.green,
+                                          behavior: SnackBarBehavior.floating,
+                                          shape: RoundedRectangleBorder(
+                                            borderRadius:
+                                                BorderRadius.circular(10.r),
+                                          ),
+                                        ),
+                                      );
+                                    }
+                                  } catch (e) {
+                                    setState(() => isLoading = false);
+                                    if (context.mounted) {
+                                      ScaffoldMessenger.of(context).showSnackBar(
+                                        SnackBar(
+                                          content: Text(
+                                            e.toString().replaceAll(
+                                                'Exception: ', ''),
+                                          ),
+                                          backgroundColor: Colors.red,
+                                          behavior: SnackBarBehavior.floating,
+                                          shape: RoundedRectangleBorder(
+                                            borderRadius:
+                                                BorderRadius.circular(10.r),
+                                          ),
+                                        ),
+                                      );
+                                    }
+                                  }
+                                },
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Colors.red,
+                            foregroundColor: Colors.white,
+                            elevation: 0,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(12.r),
+                            ),
+                            padding: EdgeInsets.symmetric(vertical: 16.h),
+                          ),
+                          child: isLoading
+                              ? SizedBox(
+                                  width: 20.w,
+                                  height: 20.w,
+                                  child: const CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                    valueColor: AlwaysStoppedAnimation<Color>(
+                                      Colors.white,
+                                    ),
+                                  ),
+                                )
+                              : Text(
+                                  '탈퇴하기',
+                                  style: TextStyle(
+                                    fontSize: 16.sp,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## 변경사항

### 1. 비밀번호 찾기 구현
- login_screen.dart의 TODO 처리 완료
- '비밀번호를 잊으셨나요?' 버튼 클릭 시 PasswordResetScreen으로 이동

### 2. 설정 화면 추가
- settings_screen.dart 신규 생성
- 회원탈퇴 기능을 설정 화면으로 이동
- 향후 추가 설정 항목을 위한 구조 마련

### 3. 프로필 화면 개선
- 설정 메뉴 활성화
- 회원탈퇴를 프로필에서 설정으로 이동
- 더 나은 UX를 위한 메뉴 구조 개선

## 테스트
- [ ] 비밀번호 찾기 버튼 클릭 시 정상 이동 확인
- [ ] 설정 화면 정상 진입 확인
- [ ] 회원탈퇴 기능 정상 작동 확인
- [ ] 로그아웃 기능 정상 작동 확인