### PR TITLE
feat: FCM 알림 탭 시 캠페인 링크 처리 구현

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -37,6 +37,8 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 
+/// 글로벌 네비게이터 키 (FCM 알림 탭 등에서 사용)
+final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
 // 비동기 초기화가 필요하므로 main을 async로 선언
 Future<void> main() async {
@@ -157,6 +159,9 @@ class MyApp extends StatelessWidget {
       // builder 내부에서 MaterialApp을 구성하고, child를 home으로 넘겨 성능/재빌드 최소화
       builder: (context, child) {
         return MaterialApp(
+          // 글로벌 네비게이터 키 설정
+          navigatorKey: navigatorKey,
+          
           // 릴리즈에서 디버그 배너 제거
           debugShowCheckedModeBanner: false,
           title: 'Review Schedule',

--- a/mobile/lib/screens/settings_screen.dart
+++ b/mobile/lib/screens/settings_screen.dart
@@ -252,12 +252,12 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                             shape: RoundedRectangleBorder(
                               borderRadius: BorderRadius.circular(12.r),
                             ),
-                            padding: EdgeInsets.symmetric(vertical: 16.h),
+                            padding: EdgeInsets.symmetric(vertical: 12.h),
                           ),
                           child: Text(
                             '취소',
                             style: TextStyle(
-                              fontSize: 16.sp,
+                              fontSize: 15.sp,
                               fontWeight: FontWeight.w600,
                             ),
                           ),
@@ -328,12 +328,12 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                             shape: RoundedRectangleBorder(
                               borderRadius: BorderRadius.circular(12.r),
                             ),
-                            padding: EdgeInsets.symmetric(vertical: 16.h),
+                            padding: EdgeInsets.symmetric(vertical: 12.h),
                           ),
                           child: isLoading
                               ? SizedBox(
-                                  width: 20.w,
-                                  height: 20.w,
+                                  width: 18.w,
+                                  height: 18.w,
                                   child: const CircularProgressIndicator(
                                     strokeWidth: 2,
                                     valueColor: AlwaysStoppedAnimation<Color>(
@@ -344,7 +344,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                               : Text(
                                   '탈퇴하기',
                                   style: TextStyle(
-                                    fontSize: 16.sp,
+                                    fontSize: 15.sp,
                                     fontWeight: FontWeight.w600,
                                   ),
                                 ),


### PR DESCRIPTION
## 변경사항

### 1. FCM 알림 처리 구현
- 알림 탭 시 캠페인 ID로 조회 후 링크 처리
- 캠페인 삭제/오류 시: **"체험단이 삭제되었거나 올바르지 않은 주소입니다"** 다이얼로그 표시 (네이버 스타일)
- 캠페인 존재 시: 외부 브라우저로 링크 열기

### 2. CampaignService API 추가
- `fetchCampaignById(int campaignId)`: 단일 캠페인 조회
- 404 또는 에러 발생 시 null 반환

### 3. 글로벌 네비게이터 추가
- main.dart에 `navigatorKey` 추가
- FCM 핸들러에서 컨텍스트 없이 네비게이션 가능

### 4. UI 개선
- settings_screen.dart 회원 탈퇴 버튼 크기 축소
  - padding: 16h → 12h
  - fontSize: 16sp → 15sp

## 기술 상세

### 알림 처리 플로우
1. 알림 탭 → payload에서 campaign_id 추출
2. CampaignService.fetchCampaignById() 호출
3. 결과에 따른 분기:
   - null 또는 contentLink 없음: 삭제 안내 다이얼로그
   - contentLink 있음: url_launcher로 외부 브라우저 실행

### 네이버 스타일 에러 메시지
- 간결하고 친절한 안내 문구
- 확인 버튼 하나로 단순화

## 테스트 체크리스트
- [ ] 포그라운드 알림 탭 → 정상 링크 오픈
- [ ] 백그라운드 알림 탭 → 정상 링크 오픈
- [ ] 삭제된 캠페인 알림 탭 → 안내 다이얼로그 표시
- [ ] 네트워크 에러 시 → 안내 다이얼로그 표시
- [ ] 회원 탈퇴 UI 버튼 크기 확인