### PR TITLE
feat: Django Prometheus 메트릭 수집 설정 추가

### DIFF
--- a/server/config/settings.py
+++ b/server/config/settings.py
@@ -63,6 +63,7 @@ else:
 # Application definition
 
 INSTALLED_APPS = [
+    'django_prometheus',  # Prometheus 메트릭 - 맨 위에 위치
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -81,6 +82,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'django_prometheus.middleware.PrometheusBeforeMiddleware',  # Prometheus - 맨 위 (요청 시작 측정)
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',  # WhiteNoise - static 파일 서빙
     'corsheaders.middleware.CorsMiddleware',  # CORS - 최상단 가까이 위치
@@ -91,6 +93,7 @@ MIDDLEWARE = [
     'core.middleware.rate_limit.RateLimitMiddleware',  # Rate Limiting - 인증 후 실행
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django_prometheus.middleware.PrometheusAfterMiddleware',  # Prometheus - 맨 아래 (요청 종료 측정)
 ]
 
 ROOT_URLCONF = 'config.urls'
@@ -128,7 +131,7 @@ if 'test' in sys.argv:
 else:
     DATABASES = {
         'default': {
-            'ENGINE': 'django.db.backends.postgresql',
+            'ENGINE': 'django_prometheus.db.backends.postgresql',  # Prometheus 메트릭 수집 지원
             'NAME': os.getenv('POSTGRES_DB', 'test'),
             'USER': os.getenv('POSTGRES_USER', 'test'),
             'PASSWORD': os.getenv('POSTGRES_PASSWORD', 'test1234'),

--- a/server/config/urls.py
+++ b/server/config/urls.py
@@ -15,7 +15,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 from ninja import NinjaAPI
 from campaigns.api import router as campaigns_router
 from campaigns.category_api import router as categories_router
@@ -44,6 +44,8 @@ api.add_router("/app-config", app_config_router)  # /v1/app-config/* 로 접근
 api.add_router("", health_router)  # /v1/healthz로 접근
 
 urlpatterns = [
+    # Prometheus 메트릭 엔드포인트 (/metrics)
+    path('', include('django_prometheus.urls')),
     path('admin/', admin.site.urls),
     path('v1/', api.urls),  # /v1/campaigns, /v1/categories, /v1/healthz로 접근
 ]

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -4,6 +4,13 @@ set -euo pipefail
 # 환경 변수 기본값 설정
 WORKERS=${WORKERS:-2}
 PORT=${PORT:-8000}
+export PROMETHEUS_MULTIPROC_DIR=${PROMETHEUS_MULTIPROC_DIR:-/tmp/metrics}
+
+# Prometheus 멀티프로세스 디렉토리 설정 (Gunicorn 사용 시 필수)
+echo "Setting up Prometheus multiprocess directory: ${PROMETHEUS_MULTIPROC_DIR}"
+mkdir -p "${PROMETHEUS_MULTIPROC_DIR}"
+rm -rf "${PROMETHEUS_MULTIPROC_DIR}"/*  # 시작 시 기존 메트릭 파일 정리
+chmod 777 "${PROMETHEUS_MULTIPROC_DIR}"
 
 # Django 마이그레이션 실행
 echo "Running Django migrations..."

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "django>=5.2.8",
     "django-cors-headers>=4.9.0",
     "django-ninja>=1.5.0",
+    "django-prometheus>=2.4.1",
     "dotenv>=0.9.9",
     "firebase-admin>=6.5.0",
     "gunicorn>=23.0.0",

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -302,6 +302,19 @@ wheels = [
 ]
 
 [[package]]
+name = "django-prometheus"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "prometheus-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/f4/cb39ddd2a41e07a274c4e162c076e906ae232d63b66bbabdea0300878877/django_prometheus-2.4.1.tar.gz", hash = "sha256:073628243d2a6de6a8a8c20e5b512872dfb85d66e1b60b28bcf1eca0155dad95", size = 24464, upload-time = "2025-06-25T15:45:37.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/50/9c5e022fa92574e5d20606687f15a2aa255e10512a17d11a8216fa117f72/django_prometheus-2.4.1-py2.py3-none-any.whl", hash = "sha256:7fe5af7f7c9ad9cd8a429fe0f3f1bf651f0e244f77162147869eab7ec09cc5e7", size = 29541, upload-time = "2025-06-25T15:45:35.433Z" },
+]
+
+[[package]]
 name = "dotenv"
 version = "0.9.9"
 source = { registry = "https://pypi.org/simple" }
@@ -676,6 +689,15 @@ wheels = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/53/3edb5d68ecf6b38fcbcc1ad28391117d2a322d9a1a3eff04bfdb184d8c3b/prometheus_client-0.23.1.tar.gz", hash = "sha256:6ae8f9081eaaaf153a2e959d2e6c4f4fb57b12ef76c8c7980202f1e57b48b2ce", size = 80481, upload-time = "2025-09-18T20:47:25.043Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/db/14bafcb4af2139e046d03fd00dea7873e48eafe18b7d2797e73d6681f210/prometheus_client-0.23.1-py3-none-any.whl", hash = "sha256:dd1913e6e76b59cfe44e7a4b83e01afc9873c1bdfd2ed8739f1e76aeca115f99", size = 61145, upload-time = "2025-09-18T20:47:23.875Z" },
+]
+
+[[package]]
 name = "proto-plus"
 version = "1.26.1"
 source = { registry = "https://pypi.org/simple" }
@@ -968,6 +990,7 @@ dependencies = [
     { name = "django" },
     { name = "django-cors-headers" },
     { name = "django-ninja" },
+    { name = "django-prometheus" },
     { name = "dotenv" },
     { name = "firebase-admin" },
     { name = "gunicorn" },
@@ -992,6 +1015,7 @@ requires-dist = [
     { name = "django", specifier = ">=5.2.8" },
     { name = "django-cors-headers", specifier = ">=4.9.0" },
     { name = "django-ninja", specifier = ">=1.5.0" },
+    { name = "django-prometheus", specifier = ">=2.4.1" },
     { name = "dotenv", specifier = ">=0.9.9" },
     { name = "firebase-admin", specifier = ">=6.5.0" },
     { name = "gunicorn", specifier = ">=23.0.0" },


### PR DESCRIPTION
## Summary
- Grafana 모니터링을 위한 Django Prometheus 메트릭 엔드포인트(`/metrics`) 추가
- django-prometheus 2.4.1 패키지 설치 및 설정
- 멀티프로세스(Gunicorn) 환경 지원

## Changes
- `config/settings.py`: INSTALLED_APPS, MIDDLEWARE, DATABASE ENGINE 설정
- `config/urls.py`: `/metrics` 엔드포인트 추가
- `entrypoint.sh`: PROMETHEUS_MULTIPROC_DIR 설정 추가
- `pyproject.toml`, `uv.lock`: django-prometheus 의존성 추가

## Test Plan
- [x] `python manage.py check` - 설정 검증 통과
- [x] `/metrics` 엔드포인트 접근 테스트 완료
- [x] Prometheus 메트릭 형식 확인

## 수집되는 메트릭
| 메트릭 | 설명 |
|--------|------|
| `django_http_*` | HTTP 요청/응답 시간, 상태코드 |
| `django_db_*` | DB 연결 및 쿼리 메트릭 |
| `django_model_*` | 모델 CRUD 작업 카운터 |
| `django_migrations_*` | 마이그레이션 상태 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)