### PR TITLE
fix: firebase_service.py logging import 오류 수정

### DIFF
--- a/server/keyword_alerts/firebase_service.py
+++ b/server/keyword_alerts/firebase_service.py
@@ -1,10 +1,10 @@
 """
-import logging
 Firebase Admin SDK 초기화 및 FCM 푸시 전송 서비스
 
 환경변수:
     FIREBASE_CREDENTIALS: Firebase Admin SDK 서비스 계정 JSON (문자열)
 """
+import logging
 import json
 import os
 from typing import Optional


### PR DESCRIPTION
## Summary
- Admin에서 Campaign 추가 시 발생하는 `NameError: name 'logging' is not defined` 오류 수정

## Problem
```python
# 수정 전 (잘못된 코드)
"""
import logging  # ← docstring 안에 위치하여 실행 안됨
Firebase Admin SDK 초기화...
"""
```

## Solution
```python
# 수정 후
"""
Firebase Admin SDK 초기화...
"""
import logging  # ← docstring 밖으로 이동
```

## Test Plan
- [x] `python manage.py check` - Django 설정 검증 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)