### PR TITLE
perf(mobile): 가까운 체험단 로딩 속도 최적화

### DIFF
--- a/mobile/lib/screens/splash_screen.dart
+++ b/mobile/lib/screens/splash_screen.dart
@@ -95,10 +95,10 @@ class _SplashScreenState extends State<SplashScreen>
     final stopwatch = Stopwatch()..start();
 
     // 1. 병렬 실행: 최소 대기 + 데이터 프리로드 + 세션 로깅
-    // 광고가 표시되는 동안 백그라운드에서 데이터를 미리 로드
+    // 광고가 표시되는 동안 백그라운드에서 추천 + 가까운 캠페인을 모두 미리 로드
     await Future.wait([
       Future.delayed(const Duration(milliseconds: 1500)), // 1.5초로 단축
-      CampaignCacheManager.instance.preloadRecommended(limit: 20), // 추천 캠페인 프리로드
+      CampaignCacheManager.instance.preloadAll(recommendedLimit: 20, nearestLimit: 10), // 추천 + 가까운 캠페인 병렬 프리로드
       _adService.logSessionStart(),
     ]);
 


### PR DESCRIPTION
## Summary
- 스플래시 화면에서 가까운 체험단 데이터를 백그라운드로 프리로드
- HomeScreen에서 캐시된 데이터 즉시 표시로 UI 블로킹 방지

## Changes

### CampaignCacheManager
- `preloadNearest()`: 위치 권한 있는 경우 백그라운드 프리로드
- `preloadAll()`: 추천 + 가까운 캠페인 병렬 프리로드
- 마지막 알려진 위치 우선 사용으로 빠른 응답

### SplashScreen
- `preloadAll()` 호출로 추천 + 가까운 캠페인 동시 프리로드

### HomeScreen
- 캐시된 가까운 체험단 데이터 즉시 표시
- 캐시 히트 시 API 호출 스킵

## Test Plan
- [ ] 앱 시작 시 가까운 체험단 즉시 표시 확인
- [ ] 위치 권한 없을 때 정상 동작 확인
- [ ] 새로고침 시 데이터 갱신 확인