### PR TITLE
chore(server): entrypoint.sh에 makemigrations 자동화 추가

### DIFF
--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -12,7 +12,10 @@ mkdir -p "${PROMETHEUS_MULTIPROC_DIR}"
 rm -rf "${PROMETHEUS_MULTIPROC_DIR}"/*  # 시작 시 기존 메트릭 파일 정리
 chmod 777 "${PROMETHEUS_MULTIPROC_DIR}"
 
-# Django 마이그레이션 실행
+# Django 마이그레이션 생성 및 실행
+echo "Creating Django migrations (if any)..."
+/app/.venv/bin/python manage.py makemigrations --noinput
+
 echo "Running Django migrations..."
 /app/.venv/bin/python manage.py migrate --noinput
 


### PR DESCRIPTION
## Summary
- Pod 시작 시 Django 마이그레이션 파일을 자동 생성하도록 개선
- `makemigrations --noinput` 명령어 추가
- 수동으로 shell 접속하여 마이그레이션 생성 불필요

## Test plan
- [ ] K8s pod 재시작 시 마이그레이션 자동 생성 확인
- [ ] 기존 마이그레이션 없을 때 정상 동작 확인