### PR TITLE
feat(campaigns): 캠페인 마감 필터를 오늘 날짜 기준으로 개선

### DIFF
--- a/server/campaigns/tests/test_api.py
+++ b/server/campaigns/tests/test_api.py
@@ -1,9 +1,10 @@
 from django.test import TestCase
 from django.utils import timezone
-from ninja.testing import TestClient
+from ninja.testing import TestAsyncClient
 from decimal import Decimal
 from campaigns.models import Category, Campaign
 from campaigns.api import router
+from asgiref.sync import async_to_sync
 
 
 class CampaignAPITest(TestCase):
@@ -46,11 +47,15 @@ class CampaignAPITest(TestCase):
             apply_deadline=timezone.now() - timezone.timedelta(days=1)
         )
 
-        self.client = TestClient(router)
+        self.client = TestAsyncClient(router)
+
+    def _get(self, path):
+        """비동기 GET 요청을 동기로 실행"""
+        return async_to_sync(self.client.get)(path)
 
     def test_list_campaigns_basic(self):
         """기본 캠페인 목록 조회 테스트"""
-        response = self.client.get("/campaigns")
+        response = self._get("/")
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -61,7 +66,7 @@ class CampaignAPITest(TestCase):
 
     def test_list_campaigns_excludes_expired(self):
         """만료된 캠페인 제외 테스트"""
-        response = self.client.get("/campaigns")
+        response = self._get("/")
         data = response.json()
 
         # 만료된 캠페인은 제외되어야 함
@@ -70,7 +75,7 @@ class CampaignAPITest(TestCase):
 
     def test_list_campaigns_with_category_filter(self):
         """카테고리 필터 테스트"""
-        response = self.client.get(f"/campaigns?category_id={self.category.id}")
+        response = self._get(f"/?category_id={self.category.id}")
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -80,7 +85,7 @@ class CampaignAPITest(TestCase):
 
     def test_list_campaigns_with_platform_filter(self):
         """플랫폼 필터 테스트"""
-        response = self.client.get("/campaigns?platform=네이버")
+        response = self._get("/?platform=네이버")
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -89,7 +94,7 @@ class CampaignAPITest(TestCase):
 
     def test_list_campaigns_with_company_search(self):
         """업체명 검색 테스트"""
-        response = self.client.get("/campaigns?company=강남")
+        response = self._get("/?company=강남")
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -97,7 +102,7 @@ class CampaignAPITest(TestCase):
 
     def test_list_campaigns_with_offer_search(self):
         """오퍼 검색 테스트"""
-        response = self.client.get("/campaigns?offer=10,000")
+        response = self._get("/?offer=10,000")
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -105,7 +110,7 @@ class CampaignAPITest(TestCase):
 
     def test_list_campaigns_sort_by_promotion_level(self):
         """프로모션 레벨 정렬 테스트"""
-        response = self.client.get("/campaigns?sort=-promotion_level")
+        response = self._get("/?sort=-promotion_level")
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -119,7 +124,7 @@ class CampaignAPITest(TestCase):
 
     def test_list_campaigns_with_pagination(self):
         """페이지네이션 테스트"""
-        response = self.client.get("/campaigns?limit=1&offset=0")
+        response = self._get("/?limit=1&offset=0")
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -128,15 +133,15 @@ class CampaignAPITest(TestCase):
 
     def test_list_campaigns_distance_sort_requires_location(self):
         """거리 정렬 시 위치 파라미터 필수 테스트"""
-        response = self.client.get("/campaigns?sort=distance")
+        response = self._get("/?sort=distance")
         # lat, lng 없으면 400 에러
         self.assertEqual(response.status_code, 400)
 
     def test_list_campaigns_distance_sort_with_location(self):
         """거리 정렬 테스트"""
         # 강남 위치
-        response = self.client.get(
-            "/campaigns?sort=distance&lat=37.497952&lng=127.027619"
+        response = self._get(
+            "/?sort=distance&lat=37.497952&lng=127.027619"
         )
         self.assertEqual(response.status_code, 200)
 
@@ -148,7 +153,7 @@ class CampaignAPITest(TestCase):
 
     def test_get_campaign_by_id(self):
         """캠페인 상세 조회 테스트"""
-        response = self.client.get(f"/campaigns/{self.campaign1.id}")
+        response = self._get(f"/{self.campaign1.id}")
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -158,14 +163,14 @@ class CampaignAPITest(TestCase):
 
     def test_get_campaign_not_found(self):
         """존재하지 않는 캠페인 조회 테스트"""
-        response = self.client.get("/campaigns/999999")
+        response = self._get("/999999")
         self.assertEqual(response.status_code, 404)
 
     def test_list_campaigns_with_bounding_box(self):
         """바운딩 박스 필터 테스트"""
         # 강남 지역 바운딩 박스
-        response = self.client.get(
-            "/campaigns?sw_lat=37.4&sw_lng=127.0&ne_lat=37.6&ne_lng=127.1"
+        response = self._get(
+            "/?sw_lat=37.4&sw_lng=127.0&ne_lat=37.6&ne_lng=127.1"
         )
         self.assertEqual(response.status_code, 200)
 

--- a/server/core/middleware/__init__.py
+++ b/server/core/middleware/__init__.py
@@ -2,3 +2,5 @@
 Core Middleware Package
 """
 
+
+

--- a/server/core/middleware/rate_limit.py
+++ b/server/core/middleware/rate_limit.py
@@ -163,3 +163,5 @@ class RateLimitMiddleware(MiddlewareMixin):
 
         return None
 
+
+


### PR DESCRIPTION
## Summary
- 마감 필터를 `timezone.now()` → 오늘 00:00:00 기준으로 변경하여 당일까지 캠페인 표시
- 캠페인 상세 API는 마감 여부 상관없이 조회 가능 (링크 공유 대응)
- `is_expired` 필드 추가로 클라이언트에서 마감 여부 확인 가능

## Changes
| 변경 사항 | 설명 |
|----------|------|
| `campaigns/api.py` | `get_active_campaign_filter()` 함수 추가, 오늘 자정 기준 마감 필터 |
| `campaigns/schemas.py` | `is_expired` 필드 및 resolver 추가 |
| `campaigns/tests/test_api.py` | 비동기 테스트 클라이언트로 수정 |

## Test plan
- [x] 캠페인 목록 API 테스트 통과
- [x] 마감된 캠페인 제외 테스트 통과
- [x] 캠페인 상세 조회 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)