### PR TITLE
fix: D-Day 마감일 필터링 및 키워드 알림 매칭 개선

### DIFF
--- a/mobile/lib/widgets/deadline_chips.dart
+++ b/mobile/lib/widgets/deadline_chips.dart
@@ -124,10 +124,14 @@ class DeadlineChips extends StatelessWidget {
 
   int? _calculateDDay(DateTime deadline) {
     final now = DateTime.now();
-    final difference = deadline.difference(now).inDays;
+    // 날짜만 비교 (시간 무시) - 정확한 D-Day 계산을 위해
+    // deadline이 오늘이면 D-0, 내일이면 D-1, 어제면 null (마감됨)
+    final deadlineDate = DateTime(deadline.year, deadline.month, deadline.day);
+    final nowDate = DateTime(now.year, now.month, now.day);
+    final difference = deadlineDate.difference(nowDate).inDays;
     return difference >= 0 ? difference : null;
   }
-  
+
   /// 태블릿 여부 확인
   bool _isTablet(BuildContext context) {
     return MediaQuery.of(context).size.shortestSide >= 600;
@@ -190,10 +194,14 @@ class DeadlineChip extends StatelessWidget {
 
   int? _calculateDDay(DateTime deadline) {
     final now = DateTime.now();
-    final difference = deadline.difference(now).inDays;
+    // 날짜만 비교 (시간 무시) - 정확한 D-Day 계산을 위해
+    // deadline이 오늘이면 D-0, 내일이면 D-1, 어제면 null (마감됨)
+    final deadlineDate = DateTime(deadline.year, deadline.month, deadline.day);
+    final nowDate = DateTime(now.year, now.month, now.day);
+    final difference = deadlineDate.difference(nowDate).inDays;
     return difference >= 0 ? difference : null;
   }
-  
+
   /// 태블릿 여부 확인
   bool _isTablet(BuildContext context) {
     return MediaQuery.of(context).size.shortestSide >= 600;

--- a/server/campaigns/api.py
+++ b/server/campaigns/api.py
@@ -18,16 +18,21 @@ def get_active_campaign_filter():
     마감되지 않은 캠페인 필터 조건 반환 (Asia/Seoul 기준)
 
     - apply_deadline이 NULL이면 무기한이므로 표시
-    - apply_deadline >= 오늘 날짜 00:00:00 이면 표시 (당일까지 보임)
-    - apply_deadline < 오늘 날짜 00:00:00 이면 숨김
+    - apply_deadline >= 오늘 날짜 00:00:00 (KST) 이면 표시 (당일까지 보임)
+    - apply_deadline < 오늘 날짜 00:00:00 (KST) 이면 숨김
 
     예시: 마감일이 12/20이고 오늘이 12/20이면 → 보임
           마감일이 12/20이고 오늘이 12/21이면 → 안 보임
-    """
-    # 오늘 날짜의 시작 (00:00:00) - Asia/Seoul 타임존 적용
-    today_start = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
 
-    return models.Q(apply_deadline__isnull=True) | models.Q(apply_deadline__gte=today_start)
+    주의: timezone.now()는 UTC 기준이므로, 로컬 타임존(Asia/Seoul)으로 변환 후
+          오늘 시작 시간을 계산해야 정확한 필터링이 가능
+    """
+    # 로컬 타임존(Asia/Seoul) 기준 현재 시간
+    now_local = timezone.localtime(timezone.now())
+    # 오늘 날짜의 시작 (00:00:00 KST)
+    today_start_local = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    return models.Q(apply_deadline__isnull=True) | models.Q(apply_deadline__gte=today_start_local)
 
 
 def calculate_distance(lat1: Decimal, lng1: Decimal, lat2: Decimal, lng2: Decimal) -> float:

--- a/server/campaigns/schemas.py
+++ b/server/campaigns/schemas.py
@@ -50,14 +50,20 @@ class CampaignOut(Schema):
         캠페인 마감 여부 계산 (오늘 날짜 기준, 당일까지는 유효)
 
         - apply_deadline이 NULL이면 None (무기한)
-        - apply_deadline < 오늘 00:00:00 이면 True (마감됨)
-        - apply_deadline >= 오늘 00:00:00 이면 False (유효)
+        - apply_deadline < 오늘 00:00:00 (KST) 이면 True (마감됨)
+        - apply_deadline >= 오늘 00:00:00 (KST) 이면 False (유효)
+
+        주의: timezone.now()는 UTC 기준이므로, 로컬 타임존(Asia/Seoul)으로 변환 후
+              오늘 시작 시간을 계산해야 정확한 마감 여부 판단이 가능
         """
         if obj.apply_deadline is None:
             return None  # 무기한
 
-        today_start = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
-        return obj.apply_deadline < today_start
+        # 로컬 타임존(Asia/Seoul) 기준 현재 시간
+        now_local = timezone.localtime(timezone.now())
+        # 오늘 날짜의 시작 (00:00:00 KST)
+        today_start_local = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
+        return obj.apply_deadline < today_start_local
 
 
 class CampaignListResponse(Schema):


### PR DESCRIPTION
## Summary
- D-Day 표시 버그 수정: UTC → Asia/Seoul 로컬 타임존 기준으로 변경
- 키워드 푸시 알림 누락 수정: title 필드 검색 추가

## 변경사항

### 1. D-Day 마감일 필터링 버그 수정

**문제**
- 날짜가 지난 체험단이 D-0으로 표시되는 문제
- 원인: 서버에서 UTC 기준으로 오늘 시작 시간을 계산하여 한국 시간과 최대 9시간 차이 발생

**수정**
- `campaigns/api.py`: `timezone.localtime()` 적용하여 Asia/Seoul 기준으로 필터링
- `campaigns/schemas.py`: `is_expired` 계산도 로컬 타임존 기준으로 변경
- `mobile/lib/widgets/deadline_chips.dart`: 시간 무시하고 순수 날짜 기반 D-Day 계산

### 2. 키워드 푸시 알림 누락 수정

**문제**
- "김포"를 키워드로 등록했는데 "[김포] 꾸미오가구 김포검단점" 캠페인 알림이 오지 않음
- 원인: `company`, `offer` 필드만 검색하고 `title` 필드는 검색하지 않음

**수정**
- `keyword_alerts/signals.py`: `title` 필드도 키워드 매칭 대상에 추가
- 검색 순서: company → title → offer

## Test plan
- [x] campaigns 테스트 통과 (27개 테스트 OK)
- [ ] 로컬에서 D-Day 표시 확인
- [ ] 키워드 알림 매칭 확인