### PR TITLE
feat(mobile): 푸시 알림 탭 시 알림 기록 페이지로 이동

### DIFF
--- a/mobile/lib/config/app_version.dart
+++ b/mobile/lib/config/app_version.dart
@@ -14,7 +14,7 @@ class AppVersion {
   ///
   /// 새 버전 배포 시 이 값을 업데이트합니다.
   /// Semantic Versioning (major.minor.patch) 형식을 따릅니다.
-  static const String current = '2.0.3';
+  static const String current = '2.0.4';
 
   /// 버전 문자열을 파싱하여 비교 가능한 형태로 변환
   ///

--- a/mobile/lib/screens/main_screen.dart
+++ b/mobile/lib/screens/main_screen.dart
@@ -21,7 +21,17 @@ import 'package:mobile/widgets/update_dialog.dart';
 /// - 인증 체크: 알림/내정보 탭은 회원만 접근 가능
 /// - 버전 체크: 앱 시작 시 업데이트 필요 여부 확인
 class MainScreen extends ConsumerStatefulWidget {
-  const MainScreen({super.key});
+  /// 초기 탭 인덱스 (푸시 알림 등에서 특정 탭으로 바로 이동할 때 사용)
+  final int initialTabIndex;
+
+  /// 알림 기록 탭으로 바로 이동할지 여부
+  final bool openAlertHistoryTab;
+
+  const MainScreen({
+    super.key,
+    this.initialTabIndex = 0,
+    this.openAlertHistoryTab = false,
+  });
 
   @override
   ConsumerState<MainScreen> createState() => _MainScreenState();
@@ -49,6 +59,9 @@ class _MainScreenState extends ConsumerState<MainScreen> {
   void initState() {
     super.initState();
 
+    // 초기 탭 인덱스 설정 (푸시 알림 등에서 전달받은 경우)
+    _selectedIndex = widget.initialTabIndex;
+
     // 앱 시작 시 권한/위치 초기화 및 인증 상태 체크
     Future.microtask(() async{
       await ref.read(locationProvider.notifier).update();
@@ -62,8 +75,23 @@ class _MainScreenState extends ConsumerState<MainScreen> {
       null, // ProfileScreen도 lazy loading
     ];
 
+    // 초기 탭이 알림 탭인 경우 NotificationScreen 생성
+    // 푸시 알림에서 진입한 경우 알림 기록 탭(index 1)으로 바로 이동
+    if (_selectedIndex == 2) {
+      _tabs[2] = NotificationScreen(
+        initialTabIndex: widget.openAlertHistoryTab ? 1 : 0,
+      );
+    }
+
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _maybeCheckUpdateOnFirstHome();
+
+      // 알림 기록 탭으로 바로 이동 (푸시 알림 탭 시)
+      if (widget.openAlertHistoryTab && _selectedIndex == 2) {
+        // NotificationScreen의 TabController를 알림 기록 탭(index 1)으로 이동시키기 위해
+        // GlobalKey를 사용하거나, 이벤트 버스를 사용할 수 있음
+        // 여기서는 NotificationScreen이 openAlertHistoryTab을 처리하도록 함
+      }
     });
   }
 

--- a/mobile/lib/screens/notification_screen.dart
+++ b/mobile/lib/screens/notification_screen.dart
@@ -14,7 +14,14 @@ import 'home_screen.dart'; // buildChannelIcons, platformBadgeColor
 /// - 키워드 추가/삭제, 알림 활성화/비활성화 기능
 /// - 위치 기반 거리순 정렬 지원
 class NotificationScreen extends StatefulWidget {
-  const NotificationScreen({super.key});
+  /// 초기 탭 인덱스 (0: 키워드 관리, 1: 알림 기록)
+  /// 푸시 알림에서 진입 시 알림 기록 탭으로 바로 이동
+  final int initialTabIndex;
+
+  const NotificationScreen({
+    super.key,
+    this.initialTabIndex = 0,
+  });
 
   @override
   State<NotificationScreen> createState() => _NotificationScreenState();
@@ -42,7 +49,11 @@ class _NotificationScreenState extends State<NotificationScreen>
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: 2, vsync: this);
+    _tabController = TabController(
+      length: 2,
+      vsync: this,
+      initialIndex: widget.initialTabIndex,
+    );
     _tabController.addListener(_onTabChanged);
     _loadKeywords();
     _getUserLocation();


### PR DESCRIPTION
## Summary
- 푸시 알림 탭 시 캠페인 링크 대신 알림 기록 페이지로 이동하도록 변경
- MainScreen/NotificationScreen에 초기 탭 인덱스 매개변수 추가
- 앱 버전 2.0.3 → 2.0.4 업데이트
- FcmService에서 미사용 코드 정리

## Changes
- `mobile/lib/services/fcm_service.dart`: 푸시 알림 탭 시 알림 기록 페이지로 이동
- `mobile/lib/screens/main_screen.dart`: initialTabIndex, openAlertHistoryTab 매개변수 추가
- `mobile/lib/screens/notification_screen.dart`: initialTabIndex 매개변수 추가
- `mobile/lib/config/app_version.dart`: 버전 2.0.3 → 2.0.4

## Test plan
- [ ] 앱에서 푸시 알림 수신 후 탭하면 알림 기록 페이지로 이동하는지 확인
- [ ] 알림 기록 탭에서 항목 탭하면 캠페인 링크가 열리는지 확인
- [ ] 앱 버전이 2.0.4로 표시되는지 확인