### PR TITLE
fix(admin): k8s 환경에서 개별 POSTGRES_* 환경변수로 DB 연결 지원

### DIFF
--- a/admin/config/settings.py
+++ b/admin/config/settings.py
@@ -66,9 +66,24 @@ TEMPLATES = [
 WSGI_APPLICATION = "config.wsgi.application"
 
 # Database - Same PostgreSQL as Go Fiber API
+# DATABASE_URL 우선, 없으면 개별 POSTGRES_* 환경변수로 구성 (Go server와 동일한 패턴)
+def get_database_url():
+    """Build DATABASE_URL from individual POSTGRES_* env vars if DATABASE_URL not set."""
+    if url := os.getenv("DATABASE_URL"):
+        return url
+
+    host = os.getenv("POSTGRES_SERVER", "localhost")
+    port = os.getenv("POSTGRES_PORT", "5432")
+    user = os.getenv("POSTGRES_USER", "postgres")
+    password = os.getenv("POSTGRES_PASSWORD", "")
+    dbname = os.getenv("POSTGRES_DB", "reviewmaps")
+    sslmode = os.getenv("POSTGRES_SSLMODE", "disable")
+
+    return f"postgres://{user}:{password}@{host}:{port}/{dbname}?sslmode={sslmode}"
+
 DATABASES = {
     "default": dj_database_url.config(
-        default=os.getenv("DATABASE_URL", "postgres://postgres:postgres@localhost:5432/reviewmaps"),
+        default=get_database_url(),
         conn_max_age=600,
     )
 }


### PR DESCRIPTION
## Summary
- DATABASE_URL 환경변수가 없을 때 개별 POSTGRES_* 환경변수로 DB URL 구성
- Go server의 `getDatabaseURL()` 패턴과 동일하게 구현
- k8s secret에서 개별 환경변수로 주입되는 경우 정상 동작

## Problem
Django Admin migration job이 k8s에서 localhost로 연결 시도하여 실패:
```
psycopg2.OperationalError: connection to server at "localhost" (::1), port 5432 failed
```

## Solution
`get_database_url()` 함수 추가:
- `DATABASE_URL` 있으면 그대로 사용
- 없으면 `POSTGRES_SERVER`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `POSTGRES_PORT`, `POSTGRES_SSLMODE`로 URL 구성