### PR TITLE
fix: POSTGRES_SERVER → POSTGRES_HOST로 환경변수명 통일

### DIFF
--- a/admin/config/settings.py
+++ b/admin/config/settings.py
@@ -73,7 +73,7 @@ def get_database_url():
     if url := os.getenv("DATABASE_URL"):
         return url
 
-    host = os.getenv("POSTGRES_SERVER", "localhost")
+    host = os.getenv("POSTGRES_HOST", "localhost")
     port = os.getenv("POSTGRES_PORT", "5432")
     user = os.getenv("POSTGRES_USER", "postgres")
     password = os.getenv("POSTGRES_PASSWORD", "")

--- a/server/.env.example
+++ b/server/.env.example
@@ -4,8 +4,8 @@ SERVER_ENV=development
 
 # Database - DATABASE_URL 또는 개별 환경변수 사용 가능
 DATABASE_URL=postgres://user:password@localhost:5432/reviewmaps?sslmode=disable
-# Django 스타일 개별 환경변수 (DATABASE_URL이 없을 때 사용)
-POSTGRES_SERVER=localhost
+# 개별 환경변수 (DATABASE_URL이 없을 때 사용)
+POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 POSTGRES_USER=reviewmaps
 POSTGRES_PASSWORD=your-password

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -90,15 +90,15 @@ func getEnvAsInt(key string, defaultValue int) int {
 	return defaultValue
 }
 
-// getDatabaseURL returns DATABASE_URL or builds it from individual env vars (Django compatible)
+// getDatabaseURL returns DATABASE_URL or builds it from individual env vars
 func getDatabaseURL() string {
 	// 1. DATABASE_URL이 있으면 그대로 사용
 	if url := os.Getenv("DATABASE_URL"); url != "" {
 		return url
 	}
 
-	// 2. Django 스타일 개별 환경변수로 구성
-	host := getEnv("POSTGRES_SERVER", "localhost")
+	// 2. 개별 환경변수로 구성 (k8s secret 키 이름과 일치)
+	host := getEnv("POSTGRES_HOST", "localhost")
 	port := getEnv("POSTGRES_PORT", "5432")
 	user := getEnv("POSTGRES_USER", "postgres")
 	password := getEnv("POSTGRES_PASSWORD", "")


### PR DESCRIPTION
## Summary
- k8s secret `reviewmaps-db-credentials`의 키 이름(`POSTGRES_HOST`)과 일치하도록 수정
- Go server와 Django Admin 모두 동일한 환경변수명 사용

## Changes
- `server/internal/config/config.go`: `POSTGRES_SERVER` → `POSTGRES_HOST`
- `admin/config/settings.py`: `POSTGRES_SERVER` → `POSTGRES_HOST`
- `server/.env.example`: 문서 업데이트

## Problem
Go server가 `user=root database=`로 Unix 소켓 연결 시도하여 실패
```
dial unix /tmp/.s.PGSQL.5432: connect: no such file or directory
```

## Root Cause
- 코드에서 `POSTGRES_SERVER` 읽음
- k8s secret에는 `POSTGRES_HOST` 키가 있음
- 환경변수 불일치로 기본값(localhost) 사용됨