### PR TITLE
fix(server): production에서 GORM AutoMigrate 비활성화

### DIFF
--- a/server/cmd/api/main.go
+++ b/server/cmd/api/main.go
@@ -56,9 +56,12 @@ func main() {
 		log.Fatalf("Failed to connect to database: %v", err)
 	}
 
-	// Run migrations
-	if err := database.Migrate(db); err != nil {
-		log.Fatalf("Failed to run migrations: %v", err)
+	// Run migrations only in development
+	// Production uses Django Admin migrations
+	if cfg.ServerEnv == "development" {
+		if err := database.Migrate(db); err != nil {
+			log.Fatalf("Failed to run migrations: %v", err)
+		}
 	}
 
 	// Initialize Fiber app


### PR DESCRIPTION
## Summary
- SERVER_ENV=production일 때 GORM AutoMigrate 스킵
- DB 스키마는 Django Admin migration으로 관리

## Problem
GORM AutoMigrate가 기존 Django DB의 constraint를 삭제하려다 실패:
```
ERROR: constraint "uni_users_username" of relation "users" does not exist
```

## Solution
- development 환경에서만 AutoMigrate 실행
- production은 Django Admin의 `python manage.py migrate`로 관리