### PR TITLE
fix(server): GORM AutoMigrate를 Django DB와 호환되도록 수정

### DIFF
--- a/server/cmd/api/main.go
+++ b/server/cmd/api/main.go
@@ -56,12 +56,9 @@ func main() {
 		log.Fatalf("Failed to connect to database: %v", err)
 	}
 
-	// Run migrations only in development
-	// Production uses Django Admin migrations
-	if cfg.ServerEnv == "development" {
-		if err := database.Migrate(db); err != nil {
-			log.Fatalf("Failed to run migrations: %v", err)
-		}
+	// Run migrations
+	if err := database.Migrate(db); err != nil {
+		log.Fatalf("Failed to run migrations: %v", err)
 	}
 
 	// Initialize Fiber app

--- a/server/internal/models/user.go
+++ b/server/internal/models/user.go
@@ -5,9 +5,10 @@ import (
 )
 
 // User represents the users table
+// Note: unique constraints are managed by existing Django migrations
 type User struct {
 	ID           uint       `gorm:"primaryKey" json:"id"`
-	Username     string     `gorm:"uniqueIndex;size:255;not null" json:"username"`
+	Username     string     `gorm:"size:255;not null" json:"username"`
 	Email        string     `gorm:"size:255;not null" json:"email"`
 	Password     string     `gorm:"size:255" json:"-"`
 	LoginMethod  string     `gorm:"size:20;default:email" json:"login_method"`


### PR DESCRIPTION
## Summary
- GORM AutoMigrate가 기존 Django DB 스키마와 호환되도록 수정
- Migration 책임은 Go 서버에서 담당

## Changes
1. `DisableForeignKeyConstraintWhenMigrating: true` 설정
2. AutoMigrate 에러를 경고로 처리 (서버 시작 차단하지 않음)
3. `User.Username`에서 `uniqueIndex` 제거 (Django가 관리하는 constraint)

## Problem
```
ERROR: constraint "uni_users_username" of relation "users" does not exist
```
GORM이 Django가 만든 다른 이름의 constraint를 삭제하려 시도하여 실패

## Solution
- constraint 충돌하는 모델에서 `uniqueIndex` 제거
- migration 에러는 로깅만 하고 서버 시작은 허용
- 기존 스키마와 호환성 유지