### PR TITLE
fix(server): Apple Client ID 환경변수 호환성 개선

### DIFF
--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -33,7 +33,7 @@ type Config struct {
 	// Apple
 	AppleTeamID   string
 	AppleKeyID    string
-	AppleBundleID string
+	AppleClientID string // Bundle ID for Apple Sign In (APPLE_CLIENT_ID or APPLE_BUNDLE_ID)
 
 	// SigNoz
 	SigNozEndpoint string
@@ -64,10 +64,10 @@ func Load() *Config {
 		GoogleClientIDAndroid: getEnv("GOOGLE_CLIENT_ID_ANDROID", ""),
 		GoogleClientIDWeb:     getEnv("GOOGLE_CLIENT_ID_WEB", ""),
 
-		// Apple
+		// Apple (APPLE_CLIENT_ID 우선, APPLE_BUNDLE_ID fallback - k8s secret 호환)
 		AppleTeamID:   getEnv("APPLE_TEAM_ID", ""),
 		AppleKeyID:    getEnv("APPLE_KEY_ID", ""),
-		AppleBundleID: getEnv("APPLE_BUNDLE_ID", ""),
+		AppleClientID: getEnvWithFallback("APPLE_CLIENT_ID", "APPLE_BUNDLE_ID", ""),
 
 		// SigNoz
 		SigNozEndpoint: getEnv("SIGNOZ_ENDPOINT", ""),
@@ -76,6 +76,17 @@ func Load() *Config {
 
 func getEnv(key, defaultValue string) string {
 	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+	return defaultValue
+}
+
+// getEnvWithFallback tries primary key first, then fallback key
+func getEnvWithFallback(primary, fallback, defaultValue string) string {
+	if value, exists := os.LookupEnv(primary); exists && value != "" {
+		return value
+	}
+	if value, exists := os.LookupEnv(fallback); exists && value != "" {
 		return value
 	}
 	return defaultValue

--- a/server/internal/services/auth.go
+++ b/server/internal/services/auth.go
@@ -384,7 +384,7 @@ func (s *AuthService) AppleLogin(identityToken string) (*AuthResponse, error) {
 	resultCh := make(chan verifyResult, 1)
 
 	go func() {
-		user, err := sns.VerifyAppleToken(ctx, identityToken, s.cfg.AppleBundleID)
+		user, err := sns.VerifyAppleToken(ctx, identityToken, s.cfg.AppleClientID)
 		resultCh <- verifyResult{user, err}
 	}()
 


### PR DESCRIPTION
## 요약
k8s secret과의 환경변수 호환성을 위해 Apple Client ID 설정 방식을 개선했습니다.

## 변경 사항
- `AppleBundleID` → `AppleClientID`로 필드명 변경
- `getEnvWithFallback()` 함수 추가
  - `APPLE_CLIENT_ID` 환경변수를 우선 사용
  - `APPLE_BUNDLE_ID`를 fallback으로 지원하여 하위 호환성 유지
- `auth.go`에서 변경된 필드명 적용

## 해결한 문제
k8s secret에서 `APPLE_CLIENT_ID`를 사용하지만, 기존 코드는 `APPLE_BUNDLE_ID`만 참조하여 환경변수가 정상적으로 로드되지 않는 문제가 있었습니다.

## 테스트 계획
- [ ] 로컬 환경에서 `APPLE_CLIENT_ID` 환경변수로 테스트
- [ ] 기존 `APPLE_BUNDLE_ID` 환경변수 fallback 동작 확인
- [ ] k8s 환경에서 Apple 소셜 로그인 정상 작동 검증