### PR TITLE
fix(server): Swagger URL, 로깅 강화, K8s Health Check 개선

### DIFF
--- a/server/docs/docs.go
+++ b/server/docs/docs.go
@@ -1048,6 +1048,67 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/v1/liveness": {
+            "get": {
+                "description": "Returns liveness status for k8s",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "health"
+                ],
+                "summary": "Liveness probe endpoint",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/readiness": {
+            "get": {
+                "description": "Returns readiness status including DB connection for k8s",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "health"
+                ],
+                "summary": "Readiness probe endpoint",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -1665,9 +1726,9 @@ const docTemplate = `{
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
 	Version:          "1.0.0",
-	Host:             "localhost:3000",
+	Host:             "api.review-maps.com",
 	BasePath:         "/v1",
-	Schemes:          []string{},
+	Schemes:          []string{"https"},
 	Title:            "ReviewMaps API",
 	Description:      "캠페인 추천 시스템 API",
 	InfoInstanceName: "swagger",

--- a/server/docs/swagger.json
+++ b/server/docs/swagger.json
@@ -1,4 +1,7 @@
 {
+    "schemes": [
+        "https"
+    ],
     "swagger": "2.0",
     "info": {
         "description": "캠페인 추천 시스템 API",
@@ -6,7 +9,7 @@
         "contact": {},
         "version": "1.0.0"
     },
-    "host": "localhost:3000",
+    "host": "api.review-maps.com",
     "basePath": "/v1",
     "paths": {
         "/app-config/ads": {
@@ -1039,6 +1042,67 @@
                 "responses": {
                     "204": {
                         "description": "No Content"
+                    }
+                }
+            }
+        },
+        "/v1/liveness": {
+            "get": {
+                "description": "Returns liveness status for k8s",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "health"
+                ],
+                "summary": "Liveness probe endpoint",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/readiness": {
+            "get": {
+                "description": "Returns readiness status including DB connection for k8s",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "health"
+                ],
+                "summary": "Readiness probe endpoint",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
                     }
                 }
             }

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -386,7 +386,7 @@ definitions:
       update_message:
         type: string
     type: object
-host: localhost:3000
+host: api.review-maps.com
 info:
   contact: {}
   description: 캠페인 추천 시스템 API
@@ -1042,6 +1042,48 @@ paths:
       summary: Update current user info
       tags:
       - users
+  /v1/liveness:
+    get:
+      consumes:
+      - application/json
+      description: Returns liveness status for k8s
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Liveness probe endpoint
+      tags:
+      - health
+  /v1/readiness:
+    get:
+      consumes:
+      - application/json
+      description: Returns readiness status including DB connection for k8s
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "503":
+          description: Service Unavailable
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Readiness probe endpoint
+      tags:
+      - health
+schemes:
+- https
 securityDefinitions:
   BearerAuth:
     in: header

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	// Server
 	ServerPort string
 	ServerEnv  string
+	ServerHost string // Swagger host 설정용
 
 	// Database
 	DatabaseURL string
@@ -44,6 +45,7 @@ func Load() *Config {
 		// Server
 		ServerPort: getEnv("SERVER_PORT", "3000"),
 		ServerEnv:  getEnv("SERVER_ENV", "development"),
+		ServerHost: getEnv("SERVER_HOST", "localhost:3000"),
 
 		// Database - DATABASE_URL 우선, 없으면 개별 환경변수로 구성
 		DatabaseURL: getDatabaseURL(),

--- a/server/internal/handlers/health.go
+++ b/server/internal/handlers/health.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"github.com/ggorockee/reviewmaps/server/internal/database"
 	"github.com/gofiber/fiber/v2"
 )
 
@@ -16,4 +17,52 @@ func HealthCheck(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{
 		"status": "healthy",
 	})
+}
+
+// LivenessCheck godoc
+// @Summary Liveness probe endpoint
+// @Description Returns liveness status for k8s
+// @Tags health
+// @Accept json
+// @Produce json
+// @Success 200 {object} map[string]string
+// @Router /v1/liveness [get]
+func LivenessCheck(c *fiber.Ctx) error {
+	return c.JSON(fiber.Map{
+		"status": "alive",
+	})
+}
+
+// ReadinessCheck godoc
+// @Summary Readiness probe endpoint
+// @Description Returns readiness status including DB connection for k8s
+// @Tags health
+// @Accept json
+// @Produce json
+// @Success 200 {object} map[string]string
+// @Failure 503 {object} map[string]string
+// @Router /v1/readiness [get]
+func ReadinessCheck(db *database.DB) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		// DB connection check
+		sqlDB, err := db.DB.DB()
+		if err != nil {
+			return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+				"status": "not ready",
+				"error":  "database connection error",
+			})
+		}
+
+		if err := sqlDB.Ping(); err != nil {
+			return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+				"status": "not ready",
+				"error":  "database ping failed",
+			})
+		}
+
+		return c.JSON(fiber.Map{
+			"status":   "ready",
+			"database": "connected",
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- Swagger host를 `localhost:3000`에서 `api.review-maps.com`으로 변경하고 HTTPS 스키마 추가
- Logger 미들웨어에 상세 포맷 적용하여 API 디버깅 강화
- K8s probe 엔드포인트 추가: `/v1/health`, `/v1/liveness`, `/v1/readiness` (DB 연결 확인 포함)

## Test plan
- [ ] Swagger UI에서 API 요청 시 `https://api.review-maps.com/v1/*` URL로 요청되는지 확인
- [ ] 로그 출력 형식 확인 (시간, 상태, 지연시간, IP, 메소드, 경로, 에러)
- [ ] `/v1/readiness` 엔드포인트가 DB 연결 상태를 정상 반환하는지 확인
- [ ] `/v1/liveness` 엔드포인트가 200 응답하는지 확인