### PR TITLE
fix(server): 모바일 앱 API 호환성 개선

### DIFF
--- a/server/internal/handlers/auth.go
+++ b/server/internal/handlers/auth.go
@@ -1,19 +1,26 @@
 package handlers
 
 import (
+	"strings"
+
 	"github.com/ggorockee/reviewmaps/server/internal/config"
 	"github.com/ggorockee/reviewmaps/server/internal/database"
 	"github.com/ggorockee/reviewmaps/server/internal/services"
+	"github.com/ggorockee/reviewmaps/server/pkg/auth"
 	"github.com/gofiber/fiber/v2"
 )
 
 type AuthHandler struct {
-	service *services.AuthService
+	service     *services.AuthService
+	userService *services.UserService
+	cfg         *config.Config
 }
 
 func NewAuthHandler(db *database.DB, cfg *config.Config) *AuthHandler {
 	return &AuthHandler{
-		service: services.NewAuthService(db, cfg),
+		service:     services.NewAuthService(db, cfg),
+		userService: services.NewUserService(db),
+		cfg:         cfg,
 	}
 }
 
@@ -29,6 +36,10 @@ func SetupAuthRoutes(router fiber.Router, db *database.DB, cfg *config.Config) {
 	router.Post("/kakao", h.KakaoLogin)
 	router.Post("/google", h.GoogleLogin)
 	router.Post("/apple", h.AppleLogin)
+
+	// /auth/me endpoints (mobile app compatibility)
+	router.Get("/me", h.GetMe)
+	router.Delete("/me", h.DeleteMe)
 }
 
 // SendEmailCode godoc
@@ -220,4 +231,89 @@ func (h *AuthHandler) AppleLogin(c *fiber.Ctx) error {
 	}
 
 	return c.JSON(response)
+}
+
+// GetMe godoc
+// @Summary Get current user info (auth/me compatibility)
+// @Tags auth
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Success 200 {object} models.User
+// @Router /auth/me [get]
+func (h *AuthHandler) GetMe(c *fiber.Ctx) error {
+	// Extract token from Authorization header
+	authHeader := c.Get("Authorization")
+	if authHeader == "" {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"detail": "로그인이 필요합니다.",
+		})
+	}
+
+	parts := strings.Split(authHeader, " ")
+	if len(parts) != 2 || parts[0] != "Bearer" {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"detail": "잘못된 인증 형식입니다.",
+		})
+	}
+
+	token := parts[1]
+	claims, err := auth.ValidateAccessToken(token, h.cfg.JWTSecretKey)
+	if err != nil {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"detail": "로그인이 만료되었습니다. 다시 로그인해 주세요.",
+		})
+	}
+
+	user, err := h.userService.GetByID(claims.UserID)
+	if err != nil {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"detail": "사용자를 찾을 수 없습니다.",
+		})
+	}
+
+	return c.JSON(user)
+}
+
+// DeleteMe godoc
+// @Summary Delete current user (auth/me compatibility)
+// @Tags auth
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Success 200 {object} map[string]string
+// @Router /auth/me [delete]
+func (h *AuthHandler) DeleteMe(c *fiber.Ctx) error {
+	// Extract token from Authorization header
+	authHeader := c.Get("Authorization")
+	if authHeader == "" {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"detail": "로그인이 필요합니다.",
+		})
+	}
+
+	parts := strings.Split(authHeader, " ")
+	if len(parts) != 2 || parts[0] != "Bearer" {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"detail": "잘못된 인증 형식입니다.",
+		})
+	}
+
+	token := parts[1]
+	claims, err := auth.ValidateAccessToken(token, h.cfg.JWTSecretKey)
+	if err != nil {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"detail": "로그인이 만료되었습니다. 다시 로그인해 주세요.",
+		})
+	}
+
+	if err := h.userService.Delete(claims.UserID); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"detail": "회원 탈퇴 처리 중 오류가 발생했습니다.",
+		})
+	}
+
+	return c.JSON(fiber.Map{
+		"message": "회원 탈퇴가 완료되었습니다.",
+	})
 }

--- a/server/internal/handlers/campaign.go
+++ b/server/internal/handlers/campaign.go
@@ -42,20 +42,36 @@ func SetupCampaignRoutes(router fiber.Router, db *database.DB) {
 func (h *CampaignHandler) List(c *fiber.Ctx) error {
 	page, _ := strconv.Atoi(c.Query("page", "1"))
 	limit, _ := strconv.Atoi(c.Query("limit", "20"))
+	offset, _ := strconv.Atoi(c.Query("offset", "0"))
 	categoryID, _ := strconv.Atoi(c.Query("category_id", "0"))
 	platform := c.Query("platform")
 	region := c.Query("region")
 	lat, _ := strconv.ParseFloat(c.Query("lat", "0"), 64)
 	lng, _ := strconv.ParseFloat(c.Query("lng", "0"), 64)
+	sort := c.Query("sort", "-created_at")
+	query := c.Query("q") // 검색어
+
+	// Bounding box 파라미터
+	swLat, _ := strconv.ParseFloat(c.Query("sw_lat", "0"), 64)
+	swLng, _ := strconv.ParseFloat(c.Query("sw_lng", "0"), 64)
+	neLat, _ := strconv.ParseFloat(c.Query("ne_lat", "0"), 64)
+	neLng, _ := strconv.ParseFloat(c.Query("ne_lng", "0"), 64)
 
 	filter := services.CampaignFilter{
 		Page:       page,
 		Limit:      limit,
+		Offset:     offset,
 		CategoryID: uint(categoryID),
 		Platform:   platform,
 		Region:     region,
 		Lat:        lat,
 		Lng:        lng,
+		Sort:       sort,
+		Query:      query,
+		SwLat:      swLat,
+		SwLng:      swLng,
+		NeLat:      neLat,
+		NeLng:      neLng,
 	}
 
 	response, err := h.service.List(&filter)

--- a/server/internal/services/campaign.go
+++ b/server/internal/services/campaign.go
@@ -78,32 +78,51 @@ func (s *CampaignService) List(filter *CampaignFilter) (*CampaignListResponse, e
 	// Count total
 	query.Count(&total)
 
-	// 정렬 처리
+	// 정렬 처리 (원본 Django 로직과 동일)
+	// 1순위: promotion_level 내림차순 (NULL은 0으로 처리)
+	// 2순위: pseudo_random (id % 1000) - 동일 레벨 내 균형 분포
+	// 3순위: 사용자 지정 정렬 또는 created_at
+
 	switch filter.Sort {
-	case "-created_at":
-		query = query.Order("created_at DESC")
-	case "created_at":
-		query = query.Order("created_at ASC")
 	case "distance":
 		// 거리순 정렬 (Haversine 공식 사용)
 		if filter.Lat != 0 && filter.Lng != 0 {
 			// Haversine 공식: 2 * 6371 * asin(sqrt(sin^2((lat2-lat1)/2) + cos(lat1)*cos(lat2)*sin^2((lng2-lng1)/2)))
-			// PostgreSQL에서 삼각함수 사용 (radians 변환 포함)
-			haversineOrder := fmt.Sprintf(`
+			haversineExpr := fmt.Sprintf(`
 				CASE WHEN lat IS NULL OR lng IS NULL THEN 999999
 				ELSE 2 * 6371 * asin(sqrt(
 					power(sin(radians(lat - %f) / 2), 2) +
 					cos(radians(%f)) * cos(radians(lat)) * power(sin(radians(lng - %f) / 2), 2)
 				))
-				END ASC`,
+				END`,
 				filter.Lat, filter.Lat, filter.Lng)
-			query = query.Order(haversineOrder)
+
+			// 1순위: promotion_level, 2순위: distance, 3순위: pseudo_random, 4순위: created_at
+			query = query.Order("COALESCE(promotion_level, 0) DESC").
+				Order(haversineExpr + " ASC").
+				Order("id % 1000").
+				Order("created_at DESC")
 		} else {
-			query = query.Order("promotion_level DESC, created_at DESC")
+			// lat, lng 없으면 기본 정렬
+			query = query.Order("COALESCE(promotion_level, 0) DESC").
+				Order("id % 1000").
+				Order("created_at DESC")
 		}
+	case "created_at":
+		// 1순위: promotion_level, 2순위: pseudo_random, 3순위: created_at ASC
+		query = query.Order("COALESCE(promotion_level, 0) DESC").
+			Order("id % 1000").
+			Order("created_at ASC")
+	case "-created_at":
+		// 1순위: promotion_level, 2순위: pseudo_random, 3순위: created_at DESC
+		query = query.Order("COALESCE(promotion_level, 0) DESC").
+			Order("id % 1000").
+			Order("created_at DESC")
 	default:
-		// 기본: 프로모션 레벨 우선, 최신순
-		query = query.Order("promotion_level DESC, created_at DESC")
+		// 기본: 1순위 promotion_level, 2순위 pseudo_random, 3순위 created_at DESC
+		query = query.Order("COALESCE(promotion_level, 0) DESC").
+			Order("id % 1000").
+			Order("created_at DESC")
 	}
 
 	// Pagination - offset 우선, 없으면 page 기반

--- a/server/internal/services/campaign.go
+++ b/server/internal/services/campaign.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/ggorockee/reviewmaps/server/internal/database"
@@ -18,11 +19,19 @@ func NewCampaignService(db *database.DB) *CampaignService {
 type CampaignFilter struct {
 	Page       int
 	Limit      int
+	Offset     int    // 모바일 앱 호환성
 	CategoryID uint
 	Platform   string
 	Region     string
 	Lat        float64
 	Lng        float64
+	Sort       string // 정렬 기준: -created_at, distance 등
+	Query      string // 검색어 (q 파라미터)
+	// Bounding box 파라미터 (지도 뷰포트)
+	SwLat float64
+	SwLng float64
+	NeLat float64
+	NeLng float64
 }
 
 type CampaignListResponse struct {
@@ -53,14 +62,57 @@ func (s *CampaignService) List(filter *CampaignFilter) (*CampaignListResponse, e
 		query = query.Where("region = ?", filter.Region)
 	}
 
+	// 검색어 필터 (q 파라미터)
+	if filter.Query != "" {
+		searchTerm := "%" + filter.Query + "%"
+		query = query.Where("title ILIKE ? OR company ILIKE ? OR search_text ILIKE ?",
+			searchTerm, searchTerm, searchTerm)
+	}
+
+	// Bounding box 필터 (지도 뷰포트)
+	if filter.SwLat != 0 && filter.SwLng != 0 && filter.NeLat != 0 && filter.NeLng != 0 {
+		query = query.Where("lat >= ? AND lat <= ? AND lng >= ? AND lng <= ?",
+			filter.SwLat, filter.NeLat, filter.SwLng, filter.NeLng)
+	}
+
 	// Count total
 	query.Count(&total)
 
-	// Order by promotion_level DESC, created_at DESC
-	query = query.Order("promotion_level DESC, created_at DESC")
+	// 정렬 처리
+	switch filter.Sort {
+	case "-created_at":
+		query = query.Order("created_at DESC")
+	case "created_at":
+		query = query.Order("created_at ASC")
+	case "distance":
+		// 거리순 정렬 (Haversine 공식 사용)
+		if filter.Lat != 0 && filter.Lng != 0 {
+			// Haversine 공식: 2 * 6371 * asin(sqrt(sin^2((lat2-lat1)/2) + cos(lat1)*cos(lat2)*sin^2((lng2-lng1)/2)))
+			// PostgreSQL에서 삼각함수 사용 (radians 변환 포함)
+			haversineOrder := fmt.Sprintf(`
+				CASE WHEN lat IS NULL OR lng IS NULL THEN 999999
+				ELSE 2 * 6371 * asin(sqrt(
+					power(sin(radians(lat - %f) / 2), 2) +
+					cos(radians(%f)) * cos(radians(lat)) * power(sin(radians(lng - %f) / 2), 2)
+				))
+				END ASC`,
+				filter.Lat, filter.Lat, filter.Lng)
+			query = query.Order(haversineOrder)
+		} else {
+			query = query.Order("promotion_level DESC, created_at DESC")
+		}
+	default:
+		// 기본: 프로모션 레벨 우선, 최신순
+		query = query.Order("promotion_level DESC, created_at DESC")
+	}
 
-	// Pagination
-	offset := (filter.Page - 1) * filter.Limit
+	// Pagination - offset 우선, 없으면 page 기반
+	var offset int
+	if filter.Offset > 0 {
+		offset = filter.Offset
+	} else {
+		offset = (filter.Page - 1) * filter.Limit
+	}
 	query = query.Offset(offset).Limit(filter.Limit)
 
 	if err := query.Find(&campaigns).Error; err != nil {


### PR DESCRIPTION
## Summary
- /v1/auth/me GET/DELETE 엔드포인트 추가 (모바일 앱 404 에러 해결)
- Campaign API 파라미터 확장 (offset, sort, q, sw_lat/lng, ne_lat/lng)
- 거리 정렬 Haversine 공식 적용 (기존 유클리드 근사 → 정확한 Haversine 공식)
- 검색어 필터 추가 (title, company, search_text ILIKE 검색)
- 지도 뷰포트 바운딩박스 필터 추가

## Test plan
- [ ] /v1/auth/me GET 호출 시 사용자 정보 반환 확인
- [ ] /v1/auth/me DELETE 호출 시 계정 삭제 확인
- [ ] 캠페인 목록 offset 파라미터 동작 확인
- [ ] 캠페인 sort=distance 정렬 확인 (Haversine)
- [ ] 캠페인 q 검색어 필터 확인
- [ ] 캠페인 바운딩박스 필터 확인