### PR TITLE
fix(server): 키워드 목록 API 응답 형식 수정

### DIFF
--- a/server/internal/handlers/keyword_alert.go
+++ b/server/internal/handlers/keyword_alert.go
@@ -69,7 +69,7 @@ func (h *KeywordAlertHandler) CreateKeyword(c *fiber.Ctx) error {
 // @Accept json
 // @Produce json
 // @Security BearerAuth
-// @Success 200 {array} models.Keyword
+// @Success 200 {object} map[string]interface{}
 // @Router /keyword-alerts/keywords [get]
 func (h *KeywordAlertHandler) ListKeywords(c *fiber.Ctx) error {
 	userID := c.Locals("userID").(uint)
@@ -79,7 +79,10 @@ func (h *KeywordAlertHandler) ListKeywords(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
 	}
 
-	return c.JSON(keywords)
+	// 원본 Django API 응답 형식과 동일하게 keywords 키로 감싸서 반환
+	return c.JSON(fiber.Map{
+		"keywords": keywords,
+	})
 }
 
 // DeleteKeyword godoc


### PR DESCRIPTION
## Summary
- 키워드 목록 API (GET /v1/keyword-alerts/keywords) 응답 형식을 원본 Django API와 동일하게 수정
- 배열 직접 반환 → `{keywords: [...]}` 객체로 감싸서 반환
- 모바일 앱의 KeywordListResponse.fromJson() 파싱 호환성 확보

## Test plan
- [ ] 모바일 앱에서 키워드 목록 조회 정상 동작 확인
- [ ] 기존 키워드 등록/삭제/토글 기능 정상 동작 확인