### PR TITLE
fix(server): 카테고리 및 유저 모델 Django 스키마 호환성 수정

### DIFF
--- a/server/internal/models/campaign.go
+++ b/server/internal/models/campaign.go
@@ -5,14 +5,12 @@ import (
 )
 
 // Category represents campaign categories
+// Note: Field names match Django model for DB compatibility
 type Category struct {
-	ID        uint      `gorm:"primaryKey" json:"id"`
-	Name      string    `gorm:"size:100;not null;uniqueIndex" json:"name"`
-	Slug      string    `gorm:"size:100;not null;uniqueIndex" json:"slug"`
-	SortOrder int       `gorm:"default:0" json:"sort_order"`
-	IsActive  bool      `gorm:"default:true" json:"is_active"`
-	CreatedAt time.Time `gorm:"autoCreateTime" json:"created_at"`
-	UpdatedAt time.Time `gorm:"autoUpdateTime" json:"updated_at"`
+	ID           uint      `gorm:"primaryKey" json:"id"`
+	Name         string    `gorm:"size:100;not null;uniqueIndex" json:"name"`
+	DisplayOrder int       `gorm:"column:display_order;default:99" json:"display_order"`
+	CreatedAt    time.Time `gorm:"autoCreateTime" json:"created_at"`
 
 	// Relations
 	Campaigns []Campaign `gorm:"foreignKey:CategoryID" json:"campaigns,omitempty"`

--- a/server/internal/models/user.go
+++ b/server/internal/models/user.go
@@ -6,9 +6,10 @@ import (
 
 // User represents the users table
 // Note: unique constraints are managed by existing Django migrations
+// GORM tags avoid creating new constraints that conflict with Django schema
 type User struct {
 	ID           uint       `gorm:"primaryKey" json:"id"`
-	Username     string     `gorm:"size:255;not null" json:"username"`
+	Username     string     `gorm:"size:255;not null;->" json:"username"` // -> means read-only for migrations
 	Email        string     `gorm:"size:255;not null" json:"email"`
 	Password     string     `gorm:"size:255" json:"-"`
 	LoginMethod  string     `gorm:"size:20;default:email" json:"login_method"`

--- a/server/internal/services/category.go
+++ b/server/internal/services/category.go
@@ -13,10 +13,11 @@ func NewCategoryService(db *database.DB) *CategoryService {
 	return &CategoryService{db: db}
 }
 
-// List retrieves all active categories
+// List retrieves all categories ordered by display_order
+// Note: Django model doesn't have is_active field
 func (s *CategoryService) List() ([]models.Category, error) {
 	var categories []models.Category
-	err := s.db.Where("is_active = ?", true).Order("sort_order ASC").Find(&categories).Error
+	err := s.db.Order("display_order ASC, id ASC").Find(&categories).Error
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
카테고리 API 500 에러 및 AutoMigrate 경고 수정

### 카테고리 API 500 에러 원인
- Go 모델의 `SortOrder` 필드가 Django DB의 `display_order` 컬럼과 불일치
- `is_active` 조건 사용했으나 Django 스키마에 해당 컬럼 없음

### 변경사항
1. **Category 모델** (`server/internal/models/campaign.go`)
   - `Slug`, `IsActive`, `UpdatedAt` 필드 제거 (Django에 없음)
   - `SortOrder` → `DisplayOrder` (column:display_order)

2. **CategoryService** (`server/internal/services/category.go`)
   - `is_active = true` 조건 제거
   - `sort_order` → `display_order` 정렬

3. **User 모델** (`server/internal/models/user.go`)
   - `Username` 필드에 `->` 태그 추가 (migration에서 제외)
   - Django의 `uni_users_username` constraint 충돌 방지

## Test plan
- [ ] 카테고리 목록 API 정상 응답 확인
- [ ] AutoMigrate 경고 메시지 해소 확인
- [ ] 모바일 앱에서 카테고리 로딩 확인