### PR TITLE
fix(admin): health check 미들웨어로 ALLOWED_HOSTS 우회

### DIFF
--- a/admin/config/middleware.py
+++ b/admin/config/middleware.py
@@ -1,0 +1,40 @@
+"""Custom middleware for ReviewMaps Admin."""
+
+from django.http import JsonResponse
+
+
+class HealthCheckMiddleware:
+    """
+    Middleware to handle health check endpoints before ALLOWED_HOSTS validation.
+
+    K8s probes send requests using Pod IP which may not be in ALLOWED_HOSTS.
+    This middleware intercepts health check requests early and responds directly,
+    bypassing all Django middleware including SecurityMiddleware.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        # Handle health checks before any other middleware (including ALLOWED_HOSTS check)
+        if request.path == "/health/":
+            return JsonResponse({"status": "healthy"})
+
+        if request.path == "/liveness/":
+            return JsonResponse({"status": "alive"})
+
+        if request.path == "/readiness/":
+            return self._readiness_check()
+
+        return self.get_response(request)
+
+    def _readiness_check(self):
+        """Check database connectivity for readiness probe."""
+        from django.db import connection
+
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT 1")
+            return JsonResponse({"status": "ready", "database": "connected"})
+        except Exception as e:
+            return JsonResponse({"status": "not ready", "error": str(e)}, status=503)

--- a/admin/config/settings.py
+++ b/admin/config/settings.py
@@ -36,6 +36,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "config.middleware.HealthCheckMiddleware",  # Must be first - handles k8s probes before ALLOWED_HOSTS check
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",  # Static files serving
     "django.contrib.sessions.middleware.SessionMiddleware",


### PR DESCRIPTION
## Summary
K8s probe가 Pod IP로 요청 시 `ALLOWED_HOSTS` 검증에서 400 에러 발생 문제 해결

## Root Cause
- K8s liveness/readiness probe는 Pod IP로 HTTP 요청을 보냄
- Django `SecurityMiddleware`가 `ALLOWED_HOSTS`에 Pod IP가 없으면 400 반환
- 기존 health check 엔드포인트는 미들웨어 체인 이후에 실행됨

## Solution
- `HealthCheckMiddleware`를 MIDDLEWARE 최상단에 배치
- Health check 경로 요청을 `SecurityMiddleware` 전에 가로채서 직접 응답
- `/health/`, `/liveness/`, `/readiness/` 모두 미들웨어에서 처리

## Changes
1. **config/middleware.py** (신규)
   - `HealthCheckMiddleware` 클래스 추가
   - 모든 health check 로직을 미들웨어에서 처리

2. **config/settings.py**
   - `HealthCheckMiddleware`를 MIDDLEWARE 최상단에 추가