### PR TITLE
fix(admin): CSRF_TRUSTED_ORIGINS 설정 추가

### DIFF
--- a/admin/config/settings.py
+++ b/admin/config/settings.py
@@ -16,6 +16,9 @@ SECRET_KEY = os.getenv("SECRET_KEY", "django-insecure-dev-key-change-in-producti
 DEBUG = os.getenv("DEBUG", "True").lower() == "true"
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "localhost,127.0.0.1,admin.review-maps.com").split(",")
 
+# CSRF settings for HTTPS
+CSRF_TRUSTED_ORIGINS = os.getenv("CSRF_TRUSTED_ORIGINS", "https://admin.review-maps.com").split(",")
+
 # Application definition
 INSTALLED_APPS = [
     # Unfold must be before django.contrib.admin


### PR DESCRIPTION
## Summary
HTTPS 환경에서 로그인 시 CSRF 403 에러 해결

## Root Cause
- Django는 HTTPS 환경에서 CSRF 토큰 검증 시 `Origin` 헤더 확인
- `CSRF_TRUSTED_ORIGINS` 설정이 없으면 403 Forbidden 반환

## Solution
`CSRF_TRUSTED_ORIGINS`에 `https://admin.review-maps.com` 추가

## Changes
- **config/settings.py**: `CSRF_TRUSTED_ORIGINS` 설정 추가 (환경변수로 오버라이드 가능)