### PR TITLE
fix(admin): 이메일로 로그인 가능하도록 인증 백엔드 추가

### DIFF
--- a/admin/config/settings.py
+++ b/admin/config/settings.py
@@ -98,6 +98,12 @@ DATABASES = {
 # Custom User Model
 AUTH_USER_MODEL = "users.User"
 
+# Authentication backends - allow email login
+AUTHENTICATION_BACKENDS = [
+    "users.backends.EmailBackend",
+    "django.contrib.auth.backends.ModelBackend",
+]
+
 # Password validation
 AUTH_PASSWORD_VALIDATORS = [
     {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},

--- a/admin/users/backends.py
+++ b/admin/users/backends.py
@@ -1,0 +1,31 @@
+"""Custom authentication backend for email-based login."""
+
+from django.contrib.auth.backends import ModelBackend
+
+from .models import User
+
+
+class EmailBackend(ModelBackend):
+    """
+    Authenticate using email instead of username.
+
+    For admin users, login_method is always 'email'.
+    """
+
+    def authenticate(self, request, username=None, password=None, **kwargs):
+        # username field in login form contains email
+        email = username
+        if email is None:
+            return None
+
+        try:
+            # Admin users always use 'email' login method
+            user = User.objects.get(email=email, login_method="email")
+        except User.DoesNotExist:
+            # Run the default password hasher to reduce timing attacks
+            User().set_password(password)
+            return None
+
+        if user.check_password(password) and self.user_can_authenticate(user):
+            return user
+        return None


### PR DESCRIPTION
## Summary
Django Admin에서 email로 로그인 가능하도록 커스텀 인증 백엔드 추가

## Background
- User 모델의 `USERNAME_FIELD`가 `username` (형식: `{email}_{login_method}`)
- Django Admin 로그인 폼에서 email을 입력하면 인증 실패

## Solution
- `EmailBackend` 추가: email + login_method='email' 조합으로 사용자 조회 및 인증
- `AUTHENTICATION_BACKENDS`에 EmailBackend를 먼저 시도하도록 설정

## Changes
1. **users/backends.py** (신규)
   - `EmailBackend` 클래스: email 기반 인증 처리

2. **config/settings.py**
   - `AUTHENTICATION_BACKENDS` 설정 추가