### PR TITLE
fix(admin): Category 모델을 Go/DB 스키마와 동기화

### DIFF
--- a/admin/campaigns/admin.py
+++ b/admin/campaigns/admin.py
@@ -5,11 +5,10 @@ from .models import Category, Campaign, RawCategory, CategoryMapping
 
 @admin.register(Category)
 class CategoryAdmin(ModelAdmin):
-    list_display = ("name", "slug", "sort_order", "is_active", "created_at")
-    list_filter = ("is_active",)
-    search_fields = ("name", "slug")
-    ordering = ("sort_order", "id")
-    list_editable = ("sort_order", "is_active")
+    list_display = ("name", "display_order", "created_at")
+    search_fields = ("name",)
+    ordering = ("display_order", "id")
+    list_editable = ("display_order",)
 
 
 @admin.register(Campaign)

--- a/admin/campaigns/models.py
+++ b/admin/campaigns/models.py
@@ -10,18 +10,15 @@ class Category(models.Model):
     """캠페인 카테고리 - GORM 테이블 참조"""
 
     name = models.CharField(max_length=100, unique=True, verbose_name="카테고리명")
-    slug = models.CharField(max_length=100, unique=True, verbose_name="슬러그")
-    sort_order = models.IntegerField(default=0, verbose_name="표시 순서")
-    is_active = models.BooleanField(default=True, verbose_name="활성 상태")
+    display_order = models.IntegerField(default=99, verbose_name="표시 순서")
     created_at = models.DateTimeField(auto_now_add=True, verbose_name="생성일시")
-    updated_at = models.DateTimeField(auto_now=True, verbose_name="수정일시")
 
     class Meta:
         db_table = "categories"
         managed = False
         verbose_name = "카테고리"
         verbose_name_plural = "카테고리"
-        ordering = ["sort_order", "id"]
+        ordering = ["display_order", "id"]
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
## Summary
Campaign 목록 페이지 500 에러 해결 - Category 모델 필드 불일치 수정

## Root Cause
Django Admin의 Category 모델이 실제 DB 스키마(Go GORM)와 불일치:

| 필드 | Django (기존) | Go/DB (실제) |
|------|--------------|--------------|
| slug | ✅ | ❌ |
| sort_order | ✅ | ❌ |
| is_active | ✅ | ❌ |
| updated_at | ✅ | ❌ |
| display_order | ❌ | ✅ |

## Changes
1. **campaigns/models.py**
   - `slug`, `is_active`, `updated_at` 필드 제거
   - `sort_order` → `display_order` 변경

2. **campaigns/admin.py**
   - CategoryAdmin의 `list_display`, `list_filter`, `list_editable` 업데이트