### PR TITLE
fix(admin): 전체 모델을 Go/DB 스키마와 동기화

### DIFF
--- a/admin/keyword_alerts/models.py
+++ b/admin/keyword_alerts/models.py
@@ -19,8 +19,6 @@ class FCMDevice(models.Model):
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,
         related_name="fcm_devices",
-        null=True,
-        blank=True,
         verbose_name="사용자",
     )
     token = models.CharField(max_length=500, unique=True, verbose_name="FCM 토큰")
@@ -47,8 +45,6 @@ class Keyword(models.Model):
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,
         related_name="keywords",
-        null=True,
-        blank=True,
         verbose_name="사용자",
     )
     keyword = models.CharField(max_length=100, verbose_name="키워드")
@@ -73,9 +69,7 @@ class KeywordAlert(models.Model):
     keyword = models.ForeignKey(Keyword, on_delete=models.CASCADE, related_name="alerts", verbose_name="키워드")
     campaign = models.ForeignKey(
         "campaigns.Campaign",
-        on_delete=models.SET_NULL,
-        null=True,
-        blank=True,
+        on_delete=models.CASCADE,
         related_name="keyword_alerts",
         verbose_name="캠페인",
     )

--- a/admin/users/admin.py
+++ b/admin/users/admin.py
@@ -45,8 +45,8 @@ class SocialAccountAdmin(ModelAdmin):
 
 @admin.register(EmailVerification)
 class EmailVerificationAdmin(ModelAdmin):
-    list_display = ("email", "code", "is_verified", "attempts", "expires_at", "created_at")
+    list_display = ("email", "code", "is_verified", "expires_at", "created_at")
     list_filter = ("is_verified", "created_at")
     search_fields = ("email",)
     ordering = ("-created_at",)
-    readonly_fields = ("created_at", "last_sent_at")
+    readonly_fields = ("created_at",)

--- a/admin/users/models.py
+++ b/admin/users/models.py
@@ -121,13 +121,9 @@ class EmailVerification(models.Model):
 
     email = models.EmailField(verbose_name="이메일")
     code = models.CharField(max_length=10, verbose_name="인증코드")
-    created_at = models.DateTimeField(auto_now_add=True, verbose_name="생성일시")
-    expires_at = models.DateTimeField(verbose_name="만료일시")
-    attempts = models.IntegerField(default=0, verbose_name="시도 횟수")
     is_verified = models.BooleanField(default=False, verbose_name="인증 완료 여부")
-    verification_token = models.CharField(max_length=255, blank=True, verbose_name="인증 토큰")
-    send_count = models.IntegerField(default=1, verbose_name="발송 횟수")
-    last_sent_at = models.DateTimeField(auto_now_add=True, verbose_name="마지막 발송 시간")
+    expires_at = models.DateTimeField(verbose_name="만료일시")
+    created_at = models.DateTimeField(auto_now_add=True, verbose_name="생성일시")
 
     class Meta:
         db_table = "email_verifications"


### PR DESCRIPTION
## Summary
전체 Django Admin 모델을 Go/DB 스키마와 동기화하여 500 에러 방지

## 불일치 수정 내역

### EmailVerification
| 필드 | Django (기존) | Go/DB | 조치 |
|------|--------------|-------|------|
| attempts | ✅ | ❌ | 제거 |
| verification_token | ✅ | ❌ | 제거 |
| send_count | ✅ | ❌ | 제거 |
| last_sent_at | ✅ | ❌ | 제거 |

### FCMDevice, Keyword
- `user` FK: `null=True` → not null (Go 스키마와 일치)

### KeywordAlert
- `campaign` FK: `null=True, on_delete=SET_NULL` → not null, `on_delete=CASCADE`

## Changes
1. **users/models.py**: EmailVerification 필드 정리
2. **users/admin.py**: EmailVerificationAdmin 업데이트
3. **keyword_alerts/models.py**: FK nullable 제거