### PR TITLE
fix(admin): app_config 모델 DateTime 필드 호환성 수정

### DIFF
--- a/admin/app_config/models.py
+++ b/admin/app_config/models.py
@@ -20,8 +20,8 @@ class AdConfig(models.Model):
     is_active = models.BooleanField(default=True, verbose_name="활성화 여부")
     show_frequency = models.IntegerField(default=1, verbose_name="표시 빈도")
     show_after_count = models.IntegerField(default=0, verbose_name="표시 시작 카운트")
-    created_at = models.DateTimeField(auto_now_add=True, verbose_name="생성일시")
-    updated_at = models.DateTimeField(auto_now=True, verbose_name="수정일시")
+    created_at = models.DateTimeField(null=True, blank=True, verbose_name="생성일시")
+    updated_at = models.DateTimeField(null=True, blank=True, verbose_name="수정일시")
 
     class Meta:
         db_table = "ad_configs"
@@ -48,8 +48,8 @@ class AppVersion(models.Model):
     update_message = models.TextField(null=True, blank=True, verbose_name="업데이트 메시지")
     store_url = models.CharField(max_length=500, null=True, blank=True, verbose_name="스토어 URL")
     maintenance_mode = models.BooleanField(default=False, verbose_name="점검 모드")
-    created_at = models.DateTimeField(auto_now_add=True, verbose_name="생성일시")
-    updated_at = models.DateTimeField(auto_now=True, verbose_name="수정일시")
+    created_at = models.DateTimeField(null=True, blank=True, verbose_name="생성일시")
+    updated_at = models.DateTimeField(null=True, blank=True, verbose_name="수정일시")
 
     class Meta:
         db_table = "app_versions"
@@ -67,8 +67,8 @@ class AppSetting(models.Model):
     key = models.CharField(max_length=100, unique=True, verbose_name="설정 키")
     value = models.TextField(verbose_name="설정 값")
     value_type = models.CharField(max_length=20, default="string", verbose_name="값 타입")
-    created_at = models.DateTimeField(auto_now_add=True, verbose_name="생성일시")
-    updated_at = models.DateTimeField(auto_now=True, verbose_name="수정일시")
+    created_at = models.DateTimeField(null=True, blank=True, verbose_name="생성일시")
+    updated_at = models.DateTimeField(null=True, blank=True, verbose_name="수정일시")
 
     class Meta:
         db_table = "app_settings"
@@ -88,8 +88,8 @@ class RateLimitConfig(models.Model):
     max_requests = models.IntegerField(default=100, verbose_name="최대 요청 수")
     window_sec = models.IntegerField(default=60, verbose_name="시간 윈도우 (초)")
     is_active = models.BooleanField(default=True, verbose_name="활성화 여부")
-    created_at = models.DateTimeField(auto_now_add=True, verbose_name="생성일시")
-    updated_at = models.DateTimeField(auto_now=True, verbose_name="수정일시")
+    created_at = models.DateTimeField(null=True, blank=True, verbose_name="생성일시")
+    updated_at = models.DateTimeField(null=True, blank=True, verbose_name="수정일시")
 
     class Meta:
         db_table = "rate_limit_configs"


### PR DESCRIPTION
## Summary
- app_config 앱의 모든 모델에서 500 에러 발생 문제 수정
- `managed=False` 모델에서 `auto_now_add`/`auto_now` 사용 시 GORM 테이블과 충돌

## Changes
- `AdConfig`, `AppVersion`, `AppSetting`, `RateLimitConfig` 모델의 `created_at`, `updated_at` 필드 수정
- `auto_now_add=True` / `auto_now=True` → `null=True, blank=True`로 변경

## Test
- AppVersion, AppSetting 페이지 접근 시 500 에러 해결