### PR TITLE
fix(app_config): 실제 DB 스키마에 맞게 모델 동기화

### DIFF
--- a/admin/app_config/admin.py
+++ b/admin/app_config/admin.py
@@ -5,33 +5,34 @@ from .models import AdConfig, AppVersion, AppSetting, RateLimitConfig
 
 @admin.register(AdConfig)
 class AdConfigAdmin(ModelAdmin):
-    list_display = ("platform", "ad_type", "unit_id", "is_active", "show_frequency", "created_at")
-    list_filter = ("platform", "ad_type", "is_active")
-    search_fields = ("unit_id",)
-    ordering = ("platform", "ad_type")
+    list_display = ("platform", "ad_network", "is_enabled", "priority", "created_at")
+    list_filter = ("platform", "ad_network", "is_enabled")
+    search_fields = ("ad_network",)
+    ordering = ("platform", "priority")
     readonly_fields = ("created_at", "updated_at")
 
 
 @admin.register(AppVersion)
 class AppVersionAdmin(ModelAdmin):
-    list_display = ("platform", "latest_version", "min_version", "force_update", "maintenance_mode", "updated_at")
-    list_filter = ("platform", "force_update", "maintenance_mode")
+    list_display = ("platform", "version", "minimum_version", "build_number", "is_active", "force_update", "updated_at")
+    list_filter = ("platform", "is_active", "force_update")
     ordering = ("platform", "-updated_at")
     readonly_fields = ("created_at", "updated_at")
 
 
 @admin.register(AppSetting)
 class AppSettingAdmin(ModelAdmin):
-    list_display = ("key", "value", "value_type", "updated_at")
-    search_fields = ("key",)
+    list_display = ("key", "value", "is_active", "updated_at")
+    list_filter = ("is_active",)
+    search_fields = ("key", "description")
     ordering = ("key",)
     readonly_fields = ("created_at", "updated_at")
 
 
 @admin.register(RateLimitConfig)
 class RateLimitConfigAdmin(ModelAdmin):
-    list_display = ("endpoint", "max_requests", "window_sec", "is_active", "updated_at")
-    list_filter = ("is_active",)
-    search_fields = ("endpoint",)
-    ordering = ("endpoint",)
+    list_display = ("endpoint", "max_requests", "window_seconds", "is_enabled", "priority", "updated_at")
+    list_filter = ("is_enabled", "apply_to_authenticated", "apply_to_anonymous")
+    search_fields = ("endpoint", "description")
+    ordering = ("priority", "endpoint")
     readonly_fields = ("created_at", "updated_at")

--- a/admin/app_config/models.py
+++ b/admin/app_config/models.py
@@ -1,5 +1,5 @@
 """
-App Config 모델 - GORM이 관리하는 테이블 (managed=False)
+App Config 모델 - 실제 DB 스키마 기반 (managed=False)
 Django Admin CRUD 전용
 """
 
@@ -7,7 +7,7 @@ from django.db import models
 
 
 class AdConfig(models.Model):
-    """광고 설정 - GORM 테이블 참조"""
+    """광고 설정 - 실제 DB 스키마 기반"""
 
     PLATFORM_CHOICES = [
         ("android", "Android"),
@@ -15,13 +15,12 @@ class AdConfig(models.Model):
     ]
 
     platform = models.CharField(max_length=20, choices=PLATFORM_CHOICES, verbose_name="플랫폼")
-    ad_type = models.CharField(max_length=50, verbose_name="광고 유형")
-    unit_id = models.CharField(max_length=255, verbose_name="광고 유닛 ID")
-    is_active = models.BooleanField(default=True, verbose_name="활성화 여부")
-    show_frequency = models.IntegerField(default=1, verbose_name="표시 빈도")
-    show_after_count = models.IntegerField(default=0, verbose_name="표시 시작 카운트")
-    created_at = models.DateTimeField(null=True, blank=True, verbose_name="생성일시")
-    updated_at = models.DateTimeField(null=True, blank=True, verbose_name="수정일시")
+    ad_network = models.CharField(max_length=50, verbose_name="광고 네트워크")
+    ad_unit_ids = models.JSONField(default=dict, verbose_name="광고 유닛 ID")
+    is_enabled = models.BooleanField(default=True, verbose_name="활성화 여부")
+    priority = models.IntegerField(default=0, verbose_name="우선순위")
+    created_at = models.DateTimeField(verbose_name="생성일시")
+    updated_at = models.DateTimeField(verbose_name="수정일시")
 
     class Meta:
         db_table = "ad_configs"
@@ -30,11 +29,11 @@ class AdConfig(models.Model):
         verbose_name_plural = "광고 설정"
 
     def __str__(self):
-        return f"{self.platform} - {self.ad_type}"
+        return f"{self.platform} - {self.ad_network}"
 
 
 class AppVersion(models.Model):
-    """앱 버전 관리 - GORM 테이블 참조"""
+    """앱 버전 관리 - 실제 DB 스키마 기반"""
 
     PLATFORM_CHOICES = [
         ("android", "Android"),
@@ -42,14 +41,15 @@ class AppVersion(models.Model):
     ]
 
     platform = models.CharField(max_length=20, choices=PLATFORM_CHOICES, verbose_name="플랫폼")
-    min_version = models.CharField(max_length=20, verbose_name="최소 지원 버전")
-    latest_version = models.CharField(max_length=20, verbose_name="최신 버전")
+    version = models.CharField(max_length=20, verbose_name="현재 버전")
+    build_number = models.IntegerField(default=0, verbose_name="빌드 번호")
+    minimum_version = models.CharField(max_length=20, verbose_name="최소 지원 버전")
     force_update = models.BooleanField(default=False, verbose_name="강제 업데이트")
     update_message = models.TextField(null=True, blank=True, verbose_name="업데이트 메시지")
-    store_url = models.CharField(max_length=500, null=True, blank=True, verbose_name="스토어 URL")
-    maintenance_mode = models.BooleanField(default=False, verbose_name="점검 모드")
-    created_at = models.DateTimeField(null=True, blank=True, verbose_name="생성일시")
-    updated_at = models.DateTimeField(null=True, blank=True, verbose_name="수정일시")
+    store_url = models.CharField(max_length=500, default="", verbose_name="스토어 URL")
+    is_active = models.BooleanField(default=True, verbose_name="활성화 여부")
+    created_at = models.DateTimeField(verbose_name="생성일시")
+    updated_at = models.DateTimeField(verbose_name="수정일시")
 
     class Meta:
         db_table = "app_versions"
@@ -58,17 +58,18 @@ class AppVersion(models.Model):
         verbose_name_plural = "앱 버전"
 
     def __str__(self):
-        return f"{self.platform} - {self.latest_version}"
+        return f"{self.platform} - {self.version}"
 
 
 class AppSetting(models.Model):
-    """앱 설정 (Key-Value) - GORM 테이블 참조"""
+    """앱 설정 (Key-Value) - 실제 DB 스키마 기반"""
 
     key = models.CharField(max_length=100, unique=True, verbose_name="설정 키")
-    value = models.TextField(verbose_name="설정 값")
-    value_type = models.CharField(max_length=20, default="string", verbose_name="값 타입")
-    created_at = models.DateTimeField(null=True, blank=True, verbose_name="생성일시")
-    updated_at = models.DateTimeField(null=True, blank=True, verbose_name="수정일시")
+    value = models.JSONField(default=dict, verbose_name="설정 값")
+    description = models.TextField(null=True, blank=True, verbose_name="설명")
+    is_active = models.BooleanField(default=True, verbose_name="활성화 여부")
+    created_at = models.DateTimeField(verbose_name="생성일시")
+    updated_at = models.DateTimeField(verbose_name="수정일시")
 
     class Meta:
         db_table = "app_settings"
@@ -82,14 +83,19 @@ class AppSetting(models.Model):
 
 
 class RateLimitConfig(models.Model):
-    """Rate Limit 설정 - GORM 테이블 참조"""
+    """Rate Limit 설정 - 실제 DB 스키마 기반"""
 
-    endpoint = models.CharField(max_length=255, unique=True, verbose_name="엔드포인트")
+    endpoint = models.CharField(max_length=200, unique=True, verbose_name="엔드포인트")
     max_requests = models.IntegerField(default=100, verbose_name="최대 요청 수")
-    window_sec = models.IntegerField(default=60, verbose_name="시간 윈도우 (초)")
-    is_active = models.BooleanField(default=True, verbose_name="활성화 여부")
-    created_at = models.DateTimeField(null=True, blank=True, verbose_name="생성일시")
-    updated_at = models.DateTimeField(null=True, blank=True, verbose_name="수정일시")
+    window_seconds = models.IntegerField(default=60, verbose_name="시간 윈도우 (초)")
+    apply_to_authenticated = models.BooleanField(default=True, verbose_name="인증 사용자 적용")
+    apply_to_anonymous = models.BooleanField(default=True, verbose_name="비인증 사용자 적용")
+    block_duration_seconds = models.IntegerField(default=0, verbose_name="차단 시간 (초)")
+    is_enabled = models.BooleanField(default=True, verbose_name="활성화 여부")
+    priority = models.IntegerField(default=0, verbose_name="우선순위")
+    description = models.TextField(null=True, blank=True, verbose_name="설명")
+    created_at = models.DateTimeField(verbose_name="생성일시")
+    updated_at = models.DateTimeField(verbose_name="수정일시")
 
     class Meta:
         db_table = "rate_limit_configs"
@@ -98,4 +104,4 @@ class RateLimitConfig(models.Model):
         verbose_name_plural = "Rate Limit 설정"
 
     def __str__(self):
-        return f"{self.endpoint} - {self.max_requests}/{self.window_sec}s"
+        return f"{self.endpoint} - {self.max_requests}/{self.window_seconds}s"

--- a/server/internal/models/app_config.go
+++ b/server/internal/models/app_config.go
@@ -1,67 +1,74 @@
 package models
 
 import (
+	"encoding/json"
 	"time"
 )
 
-// AdConfig represents advertisement configuration
+// AdConfig represents advertisement configuration - matches actual DB schema
 type AdConfig struct {
-	ID             uint      `gorm:"primaryKey" json:"id"`
-	Platform       string    `gorm:"size:20;not null" json:"platform"`
-	AdType         string    `gorm:"size:50;not null" json:"ad_type"`
-	UnitID         string    `gorm:"size:255;not null" json:"unit_id"`
-	IsActive       bool      `gorm:"default:true" json:"is_active"`
-	ShowFrequency  int       `gorm:"default:1" json:"show_frequency"`
-	ShowAfterCount int       `gorm:"default:0" json:"show_after_count"`
-	CreatedAt      time.Time `gorm:"autoCreateTime" json:"created_at"`
-	UpdatedAt      time.Time `gorm:"autoUpdateTime" json:"updated_at"`
+	ID        uint            `gorm:"primaryKey" json:"id"`
+	Platform  string          `gorm:"size:20;not null" json:"platform"`
+	AdNetwork string          `gorm:"size:50;not null" json:"ad_network"`
+	IsEnabled bool            `gorm:"not null" json:"is_enabled"`
+	AdUnitIDs json.RawMessage `gorm:"type:jsonb;not null" json:"ad_unit_ids"`
+	Priority  int             `gorm:"not null" json:"priority"`
+	CreatedAt time.Time       `gorm:"not null" json:"created_at"`
+	UpdatedAt time.Time       `gorm:"not null" json:"updated_at"`
 }
 
 func (AdConfig) TableName() string {
 	return "ad_configs"
 }
 
-// AppVersion represents app version information
+// AppVersion represents app version information - matches actual DB schema
 type AppVersion struct {
-	ID              uint      `gorm:"primaryKey" json:"id"`
-	Platform        string    `gorm:"size:20;not null" json:"platform"`
-	MinVersion      string    `gorm:"size:20;not null" json:"min_version"`
-	LatestVersion   string    `gorm:"size:20;not null" json:"latest_version"`
-	ForceUpdate     bool      `gorm:"default:false" json:"force_update"`
-	UpdateMessage   *string   `gorm:"type:text" json:"update_message,omitempty"`
-	StoreURL        *string   `gorm:"size:500" json:"store_url,omitempty"`
-	MaintenanceMode bool      `gorm:"default:false" json:"maintenance_mode"`
-	CreatedAt       time.Time `gorm:"autoCreateTime" json:"created_at"`
-	UpdatedAt       time.Time `gorm:"autoUpdateTime" json:"updated_at"`
+	ID             uint      `gorm:"primaryKey" json:"id"`
+	Platform       string    `gorm:"size:20;not null" json:"platform"`
+	Version        string    `gorm:"size:20;not null" json:"version"`
+	MinimumVersion string    `gorm:"column:minimum_version;size:20;not null" json:"minimum_version"`
+	BuildNumber    int       `gorm:"default:0" json:"build_number"`
+	IsActive       bool      `gorm:"default:true" json:"is_active"`
+	ForceUpdate    bool      `gorm:"default:false" json:"force_update"`
+	UpdateMessage  *string   `gorm:"type:text" json:"update_message,omitempty"`
+	StoreURL       *string   `gorm:"size:500" json:"store_url,omitempty"`
+	CreatedAt      time.Time `gorm:"autoCreateTime" json:"created_at"`
+	UpdatedAt      time.Time `gorm:"autoUpdateTime" json:"updated_at"`
 }
 
 func (AppVersion) TableName() string {
 	return "app_versions"
 }
 
-// AppSetting represents general app settings
+// AppSetting represents general app settings - matches actual DB schema
 type AppSetting struct {
-	ID        uint      `gorm:"primaryKey" json:"id"`
-	Key       string    `gorm:"size:100;not null;uniqueIndex" json:"key"`
-	Value     string    `gorm:"type:text;not null" json:"value"`
-	ValueType string    `gorm:"size:20;default:string" json:"value_type"`
-	CreatedAt time.Time `gorm:"autoCreateTime" json:"created_at"`
-	UpdatedAt time.Time `gorm:"autoUpdateTime" json:"updated_at"`
+	ID          uint            `gorm:"primaryKey" json:"id"`
+	Key         string          `gorm:"size:100;not null;uniqueIndex" json:"key"`
+	Value       json.RawMessage `gorm:"type:jsonb;not null" json:"value"`
+	Description *string         `gorm:"type:text" json:"description,omitempty"`
+	IsActive    bool            `gorm:"not null" json:"is_active"`
+	CreatedAt   time.Time       `gorm:"not null" json:"created_at"`
+	UpdatedAt   time.Time       `gorm:"not null" json:"updated_at"`
 }
 
 func (AppSetting) TableName() string {
 	return "app_settings"
 }
 
-// RateLimitConfig represents rate limiting configuration
+// RateLimitConfig represents rate limiting configuration - matches actual DB schema
 type RateLimitConfig struct {
-	ID           uint      `gorm:"primaryKey" json:"id"`
-	Endpoint     string    `gorm:"size:255;not null" json:"endpoint"`
-	MaxRequests  int       `gorm:"default:100" json:"max_requests"`
-	WindowSec    int       `gorm:"default:60" json:"window_sec"`
-	IsActive     bool      `gorm:"default:true" json:"is_active"`
-	CreatedAt    time.Time `gorm:"autoCreateTime" json:"created_at"`
-	UpdatedAt    time.Time `gorm:"autoUpdateTime" json:"updated_at"`
+	ID                   uint      `gorm:"primaryKey" json:"id"`
+	Endpoint             string    `gorm:"size:255;not null" json:"endpoint"`
+	Description          *string   `gorm:"type:text" json:"description,omitempty"`
+	MaxRequests          int       `gorm:"default:100" json:"max_requests"`
+	WindowSeconds        int       `gorm:"column:window_seconds;default:60" json:"window_seconds"`
+	BlockDurationSeconds int       `gorm:"column:block_duration_seconds;default:0" json:"block_duration_seconds"`
+	ApplyToAuthenticated bool      `gorm:"column:apply_to_authenticated;default:true" json:"apply_to_authenticated"`
+	ApplyToAnonymous     bool      `gorm:"column:apply_to_anonymous;default:true" json:"apply_to_anonymous"`
+	IsEnabled            bool      `gorm:"default:true" json:"is_enabled"`
+	Priority             int       `gorm:"default:0" json:"priority"`
+	CreatedAt            time.Time `gorm:"autoCreateTime" json:"created_at"`
+	UpdatedAt            time.Time `gorm:"autoUpdateTime" json:"updated_at"`
 }
 
 func (RateLimitConfig) TableName() string {


### PR DESCRIPTION
## Summary
Django Admin 및 Go 서버 모델을 실제 DB 스키마에 맞게 수정

## Problem
- app_config 앱에서 500 에러 발생
- DB 스키마와 모델 필드 불일치 (`min_version` does not exist)

## Changes

### AppVersion
| DB 컬럼 | 이전 | 수정 후 |
|---------|------|---------|
| version | latest_version | version |
| minimum_version | min_version | minimum_version |
| build_number | ❌ 없음 | ✅ 추가 |
| is_active | ❌ 없음 | ✅ 추가 |
| maintenance_mode | ✅ 있음 | ❌ 제거 |

### AdConfig
| DB 컬럼 | 이전 | 수정 후 |
|---------|------|---------|
| ad_network | ad_type | ad_network |
| ad_unit_ids | unit_id | ad_unit_ids |
| is_enabled | is_active | is_enabled |
| priority | ❌ 없음 | ✅ 추가 |

### AppSetting
- `value_type` 제거, `description`, `is_active` 추가

### RateLimitConfig
- `window_sec` → `window_seconds`
- 추가 필드: `description`, `block_duration_seconds`, `apply_to_authenticated`, `apply_to_anonymous`, `is_enabled`, `priority`

## Test
- AppVersion, AppSetting, AdConfig, RateLimitConfig 페이지 정상 동작 확인 필요