### PR TITLE
fix(server): 버전 체크 API 모바일 호환성 수정

### DIFF
--- a/server/internal/handlers/app_config.go
+++ b/server/internal/handlers/app_config.go
@@ -52,15 +52,15 @@ func (h *AppConfigHandler) GetAdConfigs(c *fiber.Ctx) error {
 // @Accept json
 // @Produce json
 // @Param platform query string true "Platform (ios/android)"
-// @Param version query string true "Current app version"
+// @Param version query string false "Current app version (optional - client can compare locally)"
 // @Success 200 {object} services.VersionCheckResponse
 // @Router /app-config/version [get]
 func (h *AppConfigHandler) GetVersion(c *fiber.Ctx) error {
 	platform := c.Query("platform")
-	version := c.Query("version")
+	version := c.Query("version") // 옵셔널 - 모바일 클라이언트는 자체 비교 수행
 
-	if platform == "" || version == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "platform and version are required"})
+	if platform == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "platform is required"})
 	}
 
 	response, err := h.service.CheckVersion(platform, version)


### PR DESCRIPTION
## Summary
모바일 앱과 서버 간 버전 체크 API 호환성 문제 수정

## Problem
- 모바일: `platform`만 query parameter로 전송
- 서버: `platform`과 `version` 둘 다 필수로 요구 → 400 Bad Request

## Changes

### Handler (`app_config.go`)
- `version` 파라미터를 옵셔널로 변경
- `platform`만 필수 체크

### Service (`app_config.go`)
- `version` 미제공 시 버전 비교 없이 정책 정보만 반환
- 응답 필드명 변경: `minimum_version` → `min_version` (모바일 파싱 호환)

## API Response
```json
{
  "needs_update": false,
  "force_update": false,
  "latest_version": "1.3.2",
  "min_version": "1.0.0",    // ← 기존: minimum_version
  "update_message": "...",
  "store_url": "..."
}
```

## Mobile Code Reference
```dart
// mobile/lib/services/version_service.dart:36-39
final url = Uri.parse('${AppConfig.reviewMapBaseUrl}/app-config/version')
    .replace(queryParameters: {'platform': platform});  // version 없음
```