### PR TITLE
feat(telemetry): OTEL metrics 전송 기능 추가

### DIFF
--- a/server/cmd/api/main.go
+++ b/server/cmd/api/main.go
@@ -39,15 +39,26 @@ func main() {
 	// Load configuration
 	cfg := config.Load()
 
-	// Initialize OpenTelemetry
+	// Initialize OpenTelemetry Tracer
 	ctx := context.Background()
-	shutdown, err := telemetry.InitTracer(ctx, "reviewmaps-api", cfg.SigNozEndpoint)
+	tracerShutdown, err := telemetry.InitTracer(ctx, "reviewmaps-api", cfg.SigNozEndpoint)
 	if err != nil {
-		log.Printf("Failed to initialize telemetry: %v", err)
+		log.Printf("Failed to initialize tracer: %v", err)
 	}
 	defer func() {
-		if err := shutdown(ctx); err != nil {
-			log.Printf("Error shutting down telemetry: %v", err)
+		if err := tracerShutdown(ctx); err != nil {
+			log.Printf("Error shutting down tracer: %v", err)
+		}
+	}()
+
+	// Initialize OpenTelemetry Metrics
+	meterShutdown, err := telemetry.InitMeter(ctx, "reviewmaps-api", cfg.SigNozEndpoint)
+	if err != nil {
+		log.Printf("Failed to initialize metrics: %v", err)
+	}
+	defer func() {
+		if err := meterShutdown(ctx); err != nil {
+			log.Printf("Error shutting down metrics: %v", err)
 		}
 	}()
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -78,6 +78,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 // indirect
 	go.opentelemetry.io/otel v1.38.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.38.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.38.0 // indirect
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -172,6 +172,8 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 h1:sbiXRND
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0/go.mod h1:69uWxva0WgAA/4bu2Yy70SLDBwZXuQ6PbBpbsa5iZrQ=
 go.opentelemetry.io/otel v1.38.0 h1:RkfdswUDRimDg0m2Az18RKOsnI8UDzppJAtj01/Ymk8=
 go.opentelemetry.io/otel v1.38.0/go.mod h1:zcmtmQ1+YmQM9wrNsTGV/q/uyusom3P8RxwExxkZhjM=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.38.0 h1:Oe2z/BCg5q7k4iXC3cqJxKYg0ieRiOqF0cecFYdPTwk=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.38.0/go.mod h1:ZQM5lAJpOsKnYagGg/zV2krVqTtaVdYdDkhMoX6Oalg=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0 h1:GqRJVj7UmLjCVyVJ3ZFLdPRmhDUp2zFmQe3RHIOsw24=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0/go.mod h1:ri3aaHSmCTVYu2AWv44YMauwAQc0aqI9gHKIcSbI1pU=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.38.0 h1:aTL7F04bJHUlztTsNGJ2l+6he8c+y/b//eR0jjjemT4=

--- a/server/internal/telemetry/metrics.go
+++ b/server/internal/telemetry/metrics.go
@@ -1,0 +1,118 @@
+package telemetry
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+)
+
+var meter metric.Meter
+
+// HTTP metrics
+var (
+	HTTPRequestsTotal   metric.Int64Counter
+	HTTPRequestDuration metric.Float64Histogram
+	HTTPActiveRequests  metric.Int64UpDownCounter
+)
+
+// InitMeter initializes OpenTelemetry meter with OTLP HTTP exporter
+func InitMeter(ctx context.Context, serviceName, endpoint string) (func(context.Context) error, error) {
+	if endpoint == "" {
+		log.Println("SIGNOZ_ENDPOINT not set, metrics disabled")
+		return func(context.Context) error { return nil }, nil
+	}
+
+	// Create OTLP HTTP metric exporter
+	exporter, err := otlpmetrichttp.New(ctx,
+		otlpmetrichttp.WithEndpoint(endpoint),
+		otlpmetrichttp.WithInsecure(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create resource with service info
+	res, err := resource.New(ctx,
+		resource.WithAttributes(
+			semconv.ServiceNameKey.String(serviceName),
+			semconv.ServiceVersionKey.String("1.0.0"),
+		),
+		resource.WithHost(),
+		resource.WithOS(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create meter provider with periodic reader
+	mp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithResource(res),
+		sdkmetric.WithReader(
+			sdkmetric.NewPeriodicReader(exporter,
+				sdkmetric.WithInterval(15*time.Second),
+			),
+		),
+	)
+
+	// Set global meter provider
+	otel.SetMeterProvider(mp)
+
+	// Create meter
+	meter = mp.Meter(serviceName)
+
+	// Initialize HTTP metrics
+	if err := initHTTPMetrics(); err != nil {
+		return nil, err
+	}
+
+	log.Printf("OpenTelemetry metrics initialized with endpoint: %s", endpoint)
+
+	return mp.Shutdown, nil
+}
+
+// initHTTPMetrics creates HTTP-related metrics instruments
+func initHTTPMetrics() error {
+	var err error
+
+	HTTPRequestsTotal, err = meter.Int64Counter(
+		"http_requests_total",
+		metric.WithDescription("Total number of HTTP requests"),
+		metric.WithUnit("{request}"),
+	)
+	if err != nil {
+		return err
+	}
+
+	HTTPRequestDuration, err = meter.Float64Histogram(
+		"http_request_duration_seconds",
+		metric.WithDescription("HTTP request duration in seconds"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10),
+	)
+	if err != nil {
+		return err
+	}
+
+	HTTPActiveRequests, err = meter.Int64UpDownCounter(
+		"http_active_requests",
+		metric.WithDescription("Number of active HTTP requests"),
+		metric.WithUnit("{request}"),
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Meter returns the global meter
+func Meter() metric.Meter {
+	return meter
+}


### PR DESCRIPTION
## Summary
- OTEL metrics exporter 추가로 SigNoz에 메트릭 전송 기능 구현
- HTTP 요청 관련 메트릭 수집 (총 요청 수, 응답 시간, 활성 요청 수)
- 기존 tracer와 동일한 endpoint 사용

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `internal/telemetry/metrics.go` | MeterProvider 초기화, HTTP 메트릭 정의 |
| `internal/telemetry/middleware.go` | 메트릭 기록 로직 추가 |
| `cmd/api/main.go` | InitMeter 호출 추가 |
| `go.mod`, `go.sum` | otlpmetrichttp 의존성 추가 |

## Metrics 목록
| 메트릭 | 타입 | 설명 |
|--------|------|------|
| `http_requests_total` | Counter | 총 HTTP 요청 수 |
| `http_request_duration_seconds` | Histogram | HTTP 요청 처리 시간 |
| `http_active_requests` | UpDownCounter | 현재 활성 요청 수 |

## Test Plan
- [ ] 로컬에서 `go build ./...` 성공 확인
- [ ] SigNoz 대시보드에서 메트릭 수신 확인