### PR TITLE
fix(ci): goScraper → go-scraper 네이밍 변경

### DIFF
--- a/.github/workflows/ci-go-scraper.yml
+++ b/.github/workflows/ci-go-scraper.yml
@@ -91,11 +91,11 @@ jobs:
       - name: Install ruamel.yaml
         run: pip install ruamel.yaml
 
-      - name: Update tag (goScraper)
+      - name: Update tag (go-scraper)
         run: |
           python ./.github/workflows/scripts/update_values.py \
             ./infra/${{ env.VALUES_FILE_PATH }} \
-            goScraper \
+            go-scraper \
             ${{ needs.build-go-scraper.outputs.image_tag }}
 
       - name: Commit and push changes
@@ -110,6 +110,6 @@ jobs:
             exit 0
           fi
 
-          commit_message="ci: Update image tags (goScraper: ${{ needs.build-go-scraper.outputs.image_tag }})"
+          commit_message="ci: Update image tags (go-scraper: ${{ needs.build-go-scraper.outputs.image_tag }})"
           git commit -m "$commit_message"
           git push


### PR DESCRIPTION
## Summary
- CI workflow에서 goScraper → go-scraper로 변경
- Helm values.yaml의 키 이름과 일치시킴