### PR TITLE
feat(go-scraper): 최대 수집 개수 제한 기능 추가

### DIFF
--- a/go-scraper/internal/config/config.go
+++ b/go-scraper/internal/config/config.go
@@ -82,6 +82,11 @@ func (b *BatchConfig) Location() *time.Location {
 	return loc
 }
 
+// ScrapeConfig 스크래핑 관련 설정
+type ScrapeConfig struct {
+	MaxItems int // 최대 수집 개수 (0 = 무제한)
+}
+
 // Config 애플리케이션의 모든 설정을 통합 관리하는 메인 구조체
 type Config struct {
 	BaseURL   string
@@ -90,6 +95,7 @@ type Config struct {
 	DB        DatabaseConfig
 	NaverAPI  NaverAPIConfig
 	Batch     BatchConfig
+	Scrape    ScrapeConfig
 }
 
 // Load 환경변수에서 설정을 로드
@@ -125,6 +131,9 @@ func Load() (*Config, error) {
 			Timezone:        getEnv("TIMEZONE", "Asia/Seoul"),
 			RunAtStart:      getEnvBool("RUN_AT_START", false),
 			WaitTimeout:     time.Duration(getEnvInt("WAIT_TIMEOUT", 15)) * time.Second,
+		},
+		Scrape: ScrapeConfig{
+			MaxItems: getEnvInt("SCRAPE_MAX_ITEMS", 100),
 		},
 	}
 


### PR DESCRIPTION
## Summary
- ScrapeConfig 구조체에 MaxItems 필드 추가
- SCRAPE_MAX_ITEMS 환경변수로 최대 수집 개수 설정 (기본값 100개, 0 = 무제한)
- Scrape 함수에서 MaxItems 제한 체크 및 로깅 추가

## Test plan
- [ ] 환경변수 `SCRAPE_MAX_ITEMS=100` 설정 시 100개만 수집 확인
- [ ] 환경변수 `SCRAPE_MAX_ITEMS=0` 설정 시 전체 수집 확인