### PR TITLE
feat(go-scraper): 만료 캠페인 cleanup 기능 추가

### DIFF
--- a/go-scraper/cmd/scraper/main.go
+++ b/go-scraper/cmd/scraper/main.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/ggorockee/reviewmaps/go-scraper/internal/cleanup"
 	"github.com/ggorockee/reviewmaps/go-scraper/internal/config"
 	"github.com/ggorockee/reviewmaps/go-scraper/internal/db"
 	"github.com/ggorockee/reviewmaps/go-scraper/internal/logger"
@@ -126,9 +127,12 @@ func runScraper(ctx context.Context, name string, cfg *config.Config, database *
 	case "reviewnote":
 		scraper := reviewnote.New(cfg, database, tel)
 		return scraper.Run(ctx, keyword)
+	case "cleanup":
+		cleaner := cleanup.New(cfg, database, tel)
+		return cleaner.Run(ctx)
 	default:
 		log.Errorf("'%s' 스크레이퍼를 찾을 수 없습니다.", name)
-		log.Info("사용 가능한 스크레이퍼: reviewnote")
+		log.Info("사용 가능한 명령어: reviewnote, cleanup")
 		return nil
 	}
 }

--- a/go-scraper/internal/cleanup/cleanup.go
+++ b/go-scraper/internal/cleanup/cleanup.go
@@ -1,0 +1,100 @@
+package cleanup
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ggorockee/reviewmaps/go-scraper/internal/config"
+	"github.com/ggorockee/reviewmaps/go-scraper/internal/db"
+	"github.com/ggorockee/reviewmaps/go-scraper/internal/logger"
+	"github.com/ggorockee/reviewmaps/go-scraper/internal/telemetry"
+)
+
+// Cleaner 만료된 캠페인 정리
+type Cleaner struct {
+	config    *config.Config
+	database  *db.DB
+	telemetry *telemetry.Telemetry
+}
+
+// New 새로운 Cleaner 생성
+func New(cfg *config.Config, database *db.DB, tel *telemetry.Telemetry) *Cleaner {
+	return &Cleaner{
+		config:    cfg,
+		database:  database,
+		telemetry: tel,
+	}
+}
+
+// Run 만료된 캠페인 삭제 실행
+// 삭제 조건: apply_deadline < TODAY (자정이 지난 경우)
+// apply_deadline >= TODAY인 경우는 오늘까지 지원 가능하므로 유지
+func (c *Cleaner) Run(ctx context.Context) error {
+	log := logger.GetLogger("cleanup")
+	startTime := time.Now()
+
+	// 메트릭: cleanup 시작
+	if c.telemetry != nil {
+		c.telemetry.IncrementCleanupTotal(ctx)
+	}
+
+	// 오늘 날짜 (자정 기준)
+	today := time.Now().In(c.config.Batch.Location()).Truncate(24 * time.Hour)
+
+	log.Infof("===== 만료 캠페인 정리 시작 (기준일: %s) =====", today.Format("2006-01-02"))
+
+	// 삭제 대상 카운트
+	countQuery := `
+		SELECT COUNT(*)
+		FROM campaign
+		WHERE apply_deadline IS NOT NULL
+		  AND apply_deadline < $1
+	`
+
+	var count int
+	if err := c.database.Pool.QueryRow(ctx, countQuery, today).Scan(&count); err != nil {
+		if c.telemetry != nil {
+			c.telemetry.IncrementCleanupErrors(ctx)
+		}
+		return fmt.Errorf("삭제 대상 카운트 실패: %w", err)
+	}
+
+	if count == 0 {
+		log.Info("삭제할 만료 캠페인이 없습니다.")
+		// 메트릭: duration 기록
+		if c.telemetry != nil {
+			c.telemetry.RecordCleanupDuration(ctx, time.Since(startTime))
+		}
+		return nil
+	}
+
+	log.Infof("삭제 대상: %d개 캠페인 (apply_deadline < %s)", count, today.Format("2006-01-02"))
+
+	// 배치 삭제 실행
+	deleteQuery := `
+		DELETE FROM campaign
+		WHERE apply_deadline IS NOT NULL
+		  AND apply_deadline < $1
+	`
+
+	result, err := c.database.Pool.Exec(ctx, deleteQuery, today)
+	if err != nil {
+		if c.telemetry != nil {
+			c.telemetry.IncrementCleanupErrors(ctx)
+		}
+		return fmt.Errorf("캠페인 삭제 실패: %w", err)
+	}
+
+	rowsAffected := result.RowsAffected()
+	log.Infof("삭제 완료: %d개 캠페인 정리됨", rowsAffected)
+
+	// 메트릭: 삭제 개수 및 duration 기록
+	if c.telemetry != nil {
+		c.telemetry.AddCleanupDeleted(ctx, rowsAffected)
+		c.telemetry.RecordCleanupDuration(ctx, time.Since(startTime))
+	}
+
+	log.Info("===== 만료 캠페인 정리 종료 =====")
+	return nil
+}


### PR DESCRIPTION
## Summary
- cleanup 패키지 추가: `apply_deadline < TODAY`인 캠페인 삭제
- telemetry에 cleanup 메트릭 추가 (total, deleted, duration, errors)
- main.go에 cleanup 명령어 추가

## 삭제 조건
- `apply_deadline >= TODAY` → 유지 (오늘까지 지원 가능)
- `apply_deadline < TODAY` → 삭제 (자정이 지남)

## Test plan
- [ ] `./scraper cleanup` 실행 시 만료 캠페인 삭제 확인
- [ ] SigNoz에서 cleanup 메트릭 수집 확인