### PR TITLE
feat(go-scraper): inflexer 스크래퍼 추가

### DIFF
--- a/go-scraper/cmd/scraper/main.go
+++ b/go-scraper/cmd/scraper/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ggorockee/reviewmaps/go-scraper/internal/config"
 	"github.com/ggorockee/reviewmaps/go-scraper/internal/db"
 	"github.com/ggorockee/reviewmaps/go-scraper/internal/logger"
+	"github.com/ggorockee/reviewmaps/go-scraper/internal/scraper/inflexer"
 	"github.com/ggorockee/reviewmaps/go-scraper/internal/scraper/reviewnote"
 	"github.com/ggorockee/reviewmaps/go-scraper/internal/telemetry"
 )
@@ -127,12 +128,15 @@ func runScraper(ctx context.Context, name string, cfg *config.Config, database *
 	case "reviewnote":
 		scraper := reviewnote.New(cfg, database, tel)
 		return scraper.Run(ctx, keyword)
+	case "inflexer":
+		scraper := inflexer.New(cfg, database, tel)
+		return scraper.Run(ctx, keyword)
 	case "cleanup":
 		cleaner := cleanup.New(cfg, database, tel)
 		return cleaner.Run(ctx)
 	default:
 		log.Errorf("'%s' 스크레이퍼를 찾을 수 없습니다.", name)
-		log.Info("사용 가능한 명령어: reviewnote, cleanup")
+		log.Info("사용 가능한 명령어: reviewnote, inflexer, cleanup")
 		return nil
 	}
 }

--- a/go-scraper/entrypoint.sh
+++ b/go-scraper/entrypoint.sh
@@ -5,6 +5,7 @@ set -e
 # Usage: entrypoint.sh <command> [args...]
 # Commands:
 #   reviewnote [--keyword <keyword>]  - Run reviewnote scraper
+#   inflexer --keyword <keyword>      - Run inflexer scraper (keyword required)
 #   cleanup                           - Clean up expired campaigns
 #   help                              - Show this help message
 
@@ -15,6 +16,11 @@ case "$COMMAND" in
         shift
         echo "[$(date -Iseconds)] Starting reviewnote scraper..."
         exec /app/scraper reviewnote "$@"
+        ;;
+    inflexer)
+        shift
+        echo "[$(date -Iseconds)] Starting inflexer scraper..."
+        exec /app/scraper inflexer "$@"
         ;;
     cleanup)
         shift
@@ -28,6 +34,7 @@ case "$COMMAND" in
         echo ""
         echo "Commands:"
         echo "  reviewnote [--keyword <keyword>]  Run reviewnote scraper"
+        echo "  inflexer --keyword <keyword>      Run inflexer scraper (keyword required)"
         echo "  cleanup                           Clean up expired campaigns"
         echo "  help                              Show this help message"
         echo ""

--- a/go-scraper/internal/scraper/inflexer/enricher.go
+++ b/go-scraper/internal/scraper/inflexer/enricher.go
@@ -1,0 +1,328 @@
+package inflexer
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ggorockee/reviewmaps/go-scraper/internal/enricher"
+	"github.com/ggorockee/reviewmaps/go-scraper/internal/logger"
+	"github.com/ggorockee/reviewmaps/go-scraper/pkg/models"
+)
+
+// EnrichConfig Enrich 설정
+type EnrichConfig struct {
+	MaxWorkers     int           // 동시 API 호출 Worker 수 (기본: 3)
+	APIDelay       time.Duration // API 호출 간 딜레이 (기본: 200ms)
+	EnableParallel bool          // 병렬 처리 활성화
+}
+
+// DefaultEnrichConfig 기본 설정
+func DefaultEnrichConfig() *EnrichConfig {
+	return &EnrichConfig{
+		MaxWorkers:     3,             // 네이버 API 키 개수와 맞춤
+		APIDelay:       200 * time.Millisecond,
+		EnableParallel: true,
+	}
+}
+
+// EnrichJob Worker에 전달되는 작업
+type EnrichJob struct {
+	Index    int
+	Campaign *models.Campaign
+	Existing *models.CampaignKey // 기존 DB 데이터 (있으면)
+}
+
+// EnrichResult 보강 결과
+type EnrichResult struct {
+	Index      int
+	Address    *string
+	Lat        *float64
+	Lng        *float64
+	CategoryID *int64
+	Error      error
+}
+
+// EnrichStats 보강 통계
+type EnrichStats struct {
+	Total       int32
+	CacheHit    int32
+	APICalled   int32
+	Geocoded    int32
+	DriftFixed  int32
+	Skipped     int32
+	Errors      int32
+}
+
+// enrichVisitCampaigns 방문형 캠페인만 보강 (Worker Pool 패턴)
+func (s *Scraper) enrichVisitCampaigns(ctx context.Context, campaigns []models.Campaign, config *EnrichConfig) ([]models.Campaign, *EnrichStats) {
+	log := logger.GetLogger("scraper.inflexer.enrich")
+
+	if config == nil {
+		config = DefaultEnrichConfig()
+	}
+
+	stats := &EnrichStats{}
+
+	// 1. 기존 DB 캠페인 로드
+	existing, err := s.DB.LoadExistingCampaigns(ctx)
+	if err != nil {
+		log.Warnf("기존 캠페인 로드 실패: %v", err)
+		existing = make(map[string]*models.CampaignKey)
+	}
+	log.Infof("기존 DB에서 %d개 캠페인 로드", len(existing))
+
+	// 2. 방문형 캠페인 중 좌표가 없는 것만 필터링
+	var visitCampaigns []int
+	for i := range campaigns {
+		if campaigns[i].CampaignType != nil && *campaigns[i].CampaignType == "방문형" {
+			// Map API에서 이미 좌표가 있으면 스킵
+			if campaigns[i].Lat != nil && campaigns[i].Lng != nil {
+				atomic.AddInt32(&stats.Skipped, 1)
+				continue
+			}
+			visitCampaigns = append(visitCampaigns, i)
+		} else {
+			atomic.AddInt32(&stats.Skipped, 1)
+		}
+	}
+
+	log.Infof("방문형 캠페인 중 좌표 보강 필요: %d개 (총 %d개 중)", len(visitCampaigns), len(campaigns))
+
+	if len(visitCampaigns) == 0 {
+		return campaigns, stats
+	}
+
+	atomic.StoreInt32(&stats.Total, int32(len(visitCampaigns)))
+
+	// 3. Worker Pool 설정
+	if !config.EnableParallel {
+		config.MaxWorkers = 1
+	}
+
+	jobs := make(chan EnrichJob, len(visitCampaigns))
+	results := make(chan EnrichResult, len(visitCampaigns))
+
+	// 4. Workers 시작
+	var wg sync.WaitGroup
+	for w := 0; w < config.MaxWorkers; w++ {
+		wg.Add(1)
+		go s.enrichWorker(ctx, w, jobs, results, &wg, config, stats)
+	}
+
+	// 5. 작업 분배
+	for _, idx := range visitCampaigns {
+		campaign := &campaigns[idx]
+		key := campaignKey(campaign)
+		var existingData *models.CampaignKey
+		if ex, ok := existing[key]; ok {
+			existingData = ex
+		}
+
+		jobs <- EnrichJob{
+			Index:    idx,
+			Campaign: campaign,
+			Existing: existingData,
+		}
+	}
+	close(jobs)
+
+	// 6. Workers 완료 대기
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	// 7. 결과 수집 및 적용
+	for result := range results {
+		if result.Error != nil {
+			atomic.AddInt32(&stats.Errors, 1)
+			continue
+		}
+
+		// 결과 적용
+		if result.Address != nil {
+			campaigns[result.Index].Address = result.Address
+		}
+		if result.Lat != nil {
+			campaigns[result.Index].Lat = result.Lat
+		}
+		if result.Lng != nil {
+			campaigns[result.Index].Lng = result.Lng
+		}
+		if result.CategoryID != nil {
+			campaigns[result.Index].CategoryID = result.CategoryID
+		}
+	}
+
+	log.Infof("[Enrich 통계] Total:%d, CacheHit:%d, APICalled:%d, Geocoded:%d, DriftFixed:%d, Skipped:%d, Errors:%d",
+		stats.Total, stats.CacheHit, stats.APICalled, stats.Geocoded, stats.DriftFixed, stats.Skipped, stats.Errors)
+
+	// 메트릭 기록
+	if s.telemetry != nil {
+		s.telemetry.RecordEnrichStats(ctx, platformName,
+			int64(stats.Total),
+			int64(stats.CacheHit),
+			int64(stats.APICalled),
+			int64(stats.Geocoded),
+		)
+	}
+
+	return campaigns, stats
+}
+
+// enrichWorker 개별 Worker
+func (s *Scraper) enrichWorker(ctx context.Context, id int, jobs <-chan EnrichJob, results chan<- EnrichResult, wg *sync.WaitGroup, config *EnrichConfig, stats *EnrichStats) {
+	defer wg.Done()
+	log := logger.GetLogger("scraper.inflexer.enrich")
+
+	for job := range jobs {
+		select {
+		case <-ctx.Done():
+			results <- EnrichResult{Index: job.Index, Error: ctx.Err()}
+			continue
+		default:
+		}
+
+		result := s.enrichSingleCampaign(ctx, job, stats)
+		results <- result
+
+		// Rate limiting: API 호출 간 딜레이
+		time.Sleep(config.APIDelay)
+	}
+
+	log.Debugf("Worker %d 종료", id)
+}
+
+// enrichSingleCampaign 단일 캠페인 보강
+func (s *Scraper) enrichSingleCampaign(ctx context.Context, job EnrichJob, stats *EnrichStats) EnrichResult {
+	log := logger.GetLogger("scraper.inflexer.enrich")
+	campaign := job.Campaign
+
+	result := EnrichResult{Index: job.Index}
+
+	// 1. Local Cache 확인
+	cacheEntry, found := s.DB.GetLocalCache(ctx, campaign.Title)
+	if found && cacheEntry != nil {
+		atomic.AddInt32(&stats.CacheHit, 1)
+		log.Debugf("[Cache HIT] %s", campaign.Title)
+
+		result.Address = cacheEntry.Address
+		result.Lat = cacheEntry.Lat
+		result.Lng = cacheEntry.Lng
+
+		// 카테고리 매핑
+		if cacheEntry.Category != nil {
+			mappedID, err := s.DB.FindMappedCategoryID(ctx, *cacheEntry.Category)
+			if err == nil && mappedID != nil {
+				result.CategoryID = mappedID
+			}
+		}
+
+		return result
+	}
+
+	// 2. Cache MISS → 네이버 Local Search API 호출
+	atomic.AddInt32(&stats.APICalled, 1)
+	log.Debugf("[Cache MISS] %s → API 호출", campaign.Title)
+
+	place, err := s.Enricher.NaverLocalSearch(ctx, campaign.Title)
+	if err != nil {
+		log.Warnf("Local Search 실패 (%s): %v", campaign.Title, err)
+		return result
+	}
+
+	if place == nil {
+		log.Debugf("Local Search 결과 없음: %s", campaign.Title)
+		return result
+	}
+
+	// 3. 주소 추출
+	address := place.RoadAddress
+	if address == "" {
+		address = place.Address
+	}
+	if address != "" {
+		result.Address = &address
+	}
+
+	// 4. mapx/mapy → lat/lng 변환
+	if place.MapX != "" && place.MapY != "" {
+		lat, lng, valid := enricher.FromMapXY(place.MapX, place.MapY)
+		if valid {
+			result.Lat = &lat
+			result.Lng = &lng
+		}
+	}
+
+	// 5. 카테고리 처리
+	if place.Category != "" {
+		rawID, err := s.DB.GetOrCreateRawCategory(ctx, place.Category)
+		if err == nil && rawID != nil {
+			mappedID, err := s.DB.FindMappedCategoryID(ctx, *rawID)
+			if err == nil && mappedID != nil {
+				result.CategoryID = mappedID
+			}
+		}
+	}
+
+	// 6. 주소는 있는데 좌표가 없으면 Geocode
+	if result.Address != nil && (result.Lat == nil || result.Lng == nil) {
+		// Geocode Cache 확인
+		lat, lng, found := s.DB.GetGeocodeCache(ctx, *result.Address)
+		if found {
+			result.Lat = &lat
+			result.Lng = &lng
+		} else {
+			// Geocode API 호출
+			lat, lng, ok := s.Enricher.NaverGeocode(ctx, *result.Address)
+			if ok {
+				result.Lat = &lat
+				result.Lng = &lng
+				atomic.AddInt32(&stats.Geocoded, 1)
+
+				// Geocode Cache 저장
+				_ = s.DB.PutGeocodeCache(ctx, *result.Address, lat, lng)
+			}
+		}
+	}
+
+	// 7. 드리프트 체크 (기존 DB 좌표와 50m 이상 차이나면)
+	if job.Existing != nil && result.Lat != nil && result.Lng != nil && result.Address != nil {
+		if job.Existing.Lat != nil && job.Existing.Lng != nil {
+			dist := enricher.Haversine(*job.Existing.Lat, *job.Existing.Lng, *result.Lat, *result.Lng)
+			if dist > enricher.DRIFT_METERS {
+				log.Warnf("[Drift] %s: %.0fm 드리프트 감지, Geocode로 재보정", campaign.Title, dist)
+
+				// Geocode로 재보정
+				lat, lng, ok := s.Enricher.NaverGeocode(ctx, *result.Address)
+				if ok {
+					result.Lat = &lat
+					result.Lng = &lng
+					atomic.AddInt32(&stats.DriftFixed, 1)
+					atomic.AddInt32(&stats.Geocoded, 1)
+
+					// Geocode Cache 업데이트
+					_ = s.DB.PutGeocodeCache(ctx, *result.Address, lat, lng)
+				}
+			}
+		}
+	}
+
+	// 8. Local Cache 저장
+	if result.Address != nil && result.Lat != nil && result.Lng != nil {
+		var categoryForCache *int64
+		if result.CategoryID != nil {
+			categoryForCache = result.CategoryID
+		}
+		_ = s.DB.PutLocalCache(ctx, campaign.Title, *result.Address, *result.Lat, *result.Lng, categoryForCache)
+	}
+
+	return result
+}
+
+// campaignKey 캠페인 고유 키 생성
+func campaignKey(c *models.Campaign) string {
+	return c.Platform + "|" + c.Title + "|" + c.Offer + "|" + c.CampaignChannel
+}

--- a/go-scraper/internal/scraper/inflexer/inflexer.go
+++ b/go-scraper/internal/scraper/inflexer/inflexer.go
@@ -1,0 +1,458 @@
+package inflexer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/ggorockee/reviewmaps/go-scraper/internal/config"
+	"github.com/ggorockee/reviewmaps/go-scraper/internal/db"
+	"github.com/ggorockee/reviewmaps/go-scraper/internal/logger"
+	"github.com/ggorockee/reviewmaps/go-scraper/internal/scraper"
+	"github.com/ggorockee/reviewmaps/go-scraper/internal/telemetry"
+	"github.com/ggorockee/reviewmaps/go-scraper/pkg/models"
+)
+
+const (
+	platformName   = "inflexer"
+	searchURL      = "https://inflexer.net:5000/search"
+	mapURL         = "https://inflexer.net:5000/map"
+	requestTimeout = 30 * time.Second
+)
+
+// MEDIA_MAP 미디어 타입 매핑
+var mediaMap = map[string]string{
+	"BP_":       "blog",
+	"IP_":       "instagram",
+	"IR_":       "reels",
+	"BC_":       "clip",
+	"BP_BC_":    "blog,clip",
+	"IP_IR_":    "instagram,reels",
+	"BP_IP_":    "blog,instagram",
+	"IP_IP_":    "instagram",
+	"YP_":       "youtube",
+	"YS_":       "shorts",
+	"YP_YS_":    "youtube,shorts",
+	"SR_":       "shorts",
+	"":          "etc",
+}
+
+// TYPE_MAP 타입 매핑
+var typeMap = map[string]string{
+	"PRS":          "기자단",
+	"VST":          "방문형",
+	"SHP":          "배송형",
+	"서울오빠_기타": "구매평",
+}
+
+// SearchAPIResponse 검색 API 응답
+type SearchAPIResponse struct {
+	IsValid bool             `json:"is_valid"`
+	Result  []CampaignRawData `json:"result"`
+}
+
+// MapAPIResponse 맵 API 응답
+type MapAPIResponse struct {
+	Result []MapData `json:"result"`
+}
+
+// CampaignRawData API에서 받아온 캠페인 원시 데이터
+type CampaignRawData struct {
+	Domain    string  `json:"domain"`
+	Title     string  `json:"title"`
+	Offer     string  `json:"offer"`
+	URL       string  `json:"url"`
+	Media     string  `json:"media"`
+	Type      string  `json:"type"`
+	AplDueDt  *string `json:"apl_due_dt"`
+	PubDueDt  *string `json:"pub_due_dt"`
+	AplSttDt  *string `json:"apl_stt_dt"`
+}
+
+// MapData 맵 API 데이터
+type MapData struct {
+	Title     string   `json:"title"`
+	Latitude  *float64 `json:"latitude"`
+	Longitude *float64 `json:"longitude"`
+}
+
+// Scraper inflexer 스크래퍼
+type Scraper struct {
+	*scraper.BaseScraper
+	httpClient *http.Client
+	telemetry  *telemetry.Telemetry
+}
+
+// New 새로운 inflexer 스크래퍼 생성
+func New(cfg *config.Config, database *db.DB, tel *telemetry.Telemetry) *Scraper {
+	return &Scraper{
+		BaseScraper: scraper.NewBaseScraper(cfg, database),
+		httpClient: &http.Client{
+			Timeout: requestTimeout,
+		},
+		telemetry: tel,
+	}
+}
+
+// PlatformName 플랫폼 이름 반환
+func (s *Scraper) PlatformName() string {
+	return platformName
+}
+
+// BaseURL 기본 URL 반환
+func (s *Scraper) BaseURL() string {
+	return searchURL
+}
+
+// Run 전체 파이프라인 실행
+func (s *Scraper) Run(ctx context.Context, keyword *string) error {
+	log := logger.GetLogger("scraper.inflexer")
+
+	keywordStr := "전체"
+	if keyword != nil {
+		keywordStr = *keyword
+	}
+
+	log.Infof("===== %s 스크레이핑 시작 (키워드: %s) =====", platformName, keywordStr)
+
+	// 1. Scrape (Search + Map API 병렬 호출)
+	rawData, err := s.Scrape(ctx, keyword)
+	if err != nil {
+		log.Errorf("scrape 단계에서 에러 발생: %v", err)
+		return err
+	}
+	if len(rawData) == 0 {
+		log.Warn("scrape 단계에서 데이터를 가져오지 못했습니다.")
+		return nil
+	}
+
+	// 2. Parse
+	parsedData, err := s.Parse(ctx, rawData)
+	if err != nil {
+		log.Errorf("parse 단계에서 에러 발생: %v", err)
+		return err
+	}
+	if len(parsedData) == 0 {
+		log.Warn("parse 단계에서 데이터가 파싱되지 않았습니다.")
+		return nil
+	}
+	log.Infof("총 %d개의 아이템을 파싱했습니다.", len(parsedData))
+
+	// 3. Enrich (선택적)
+	enrichedData, err := s.Enrich(ctx, parsedData)
+	if err != nil {
+		log.Errorf("enrich 단계에서 에러 발생: %v", err)
+		return err
+	}
+
+	// 4. Save
+	if err := s.Save(ctx, enrichedData); err != nil {
+		log.Errorf("save 단계에서 에러 발생: %v", err)
+		return err
+	}
+
+	log.Infof("===== %s 스크레이핑 종료 =====", platformName)
+	return nil
+}
+
+// Scrape 데이터 수집 - Search API와 Map API 병렬 호출
+func (s *Scraper) Scrape(ctx context.Context, keyword *string) ([]map[string]interface{}, error) {
+	log := logger.GetLogger("scraper.inflexer")
+
+	if keyword == nil || *keyword == "" {
+		return nil, fmt.Errorf("inflexer는 keyword가 필수입니다")
+	}
+
+	// 병렬로 Search와 Map API 호출
+	type searchResult struct {
+		data []CampaignRawData
+		err  error
+	}
+	type mapResult struct {
+		data []MapData
+		err  error
+	}
+
+	searchCh := make(chan searchResult, 1)
+	mapCh := make(chan mapResult, 1)
+
+	// Search API 호출 (goroutine)
+	go func() {
+		data, err := s.fetchSearchAPI(ctx, *keyword)
+		searchCh <- searchResult{data: data, err: err}
+	}()
+
+	// Map API 호출 (goroutine)
+	go func() {
+		data, err := s.fetchMapAPI(ctx, *keyword)
+		mapCh <- mapResult{data: data, err: err}
+	}()
+
+	// 결과 수집
+	searchRes := <-searchCh
+	mapRes := <-mapCh
+
+	if searchRes.err != nil {
+		return nil, fmt.Errorf("search API 실패: %w", searchRes.err)
+	}
+
+	if len(searchRes.data) == 0 {
+		log.Info("Search API에서 데이터가 없습니다.")
+		return nil, nil
+	}
+
+	// Map 데이터를 title 기준으로 매핑
+	mapByTitle := make(map[string]*MapData)
+	if mapRes.err == nil && len(mapRes.data) > 0 {
+		for i := range mapRes.data {
+			mapByTitle[mapRes.data[i].Title] = &mapRes.data[i]
+		}
+		log.Infof("Map API에서 %d개 좌표 데이터 수집", len(mapRes.data))
+	} else if mapRes.err != nil {
+		log.Warnf("Map API 호출 실패 (계속 진행): %v", mapRes.err)
+	}
+
+	// 결과 병합
+	var allData []map[string]interface{}
+	for _, raw := range searchRes.data {
+		rawMap := make(map[string]interface{})
+		rawMap["domain"] = raw.Domain
+		rawMap["title"] = raw.Title
+		rawMap["offer"] = raw.Offer
+		rawMap["url"] = raw.URL
+		rawMap["media"] = raw.Media
+		rawMap["type"] = raw.Type
+		rawMap["keyword"] = *keyword
+
+		if raw.AplDueDt != nil {
+			rawMap["apl_due_dt"] = *raw.AplDueDt
+		}
+		if raw.PubDueDt != nil {
+			rawMap["pub_due_dt"] = *raw.PubDueDt
+		}
+		if raw.AplSttDt != nil {
+			rawMap["apl_stt_dt"] = *raw.AplSttDt
+		}
+
+		// Map 데이터 병합
+		if mapData, ok := mapByTitle[raw.Title]; ok {
+			if mapData.Latitude != nil {
+				rawMap["lat"] = *mapData.Latitude
+			}
+			if mapData.Longitude != nil {
+				rawMap["lng"] = *mapData.Longitude
+			}
+		}
+
+		allData = append(allData, rawMap)
+	}
+
+	log.Infof("Scrape 완료: 총 %d개 캠페인 수집", len(allData))
+	return allData, nil
+}
+
+// fetchSearchAPI Search API 호출
+func (s *Scraper) fetchSearchAPI(ctx context.Context, keyword string) ([]CampaignRawData, error) {
+	log := logger.GetLogger("scraper.inflexer")
+
+	reqURL := fmt.Sprintf("%s?query=%s", searchURL, url.QueryEscape(keyword))
+	log.Infof("Search API 호출: %s", reqURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
+	}
+
+	var apiResp SearchAPIResponse
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if !apiResp.IsValid {
+		log.Warn("API 응답 비정상: is_valid=false")
+		return nil, nil
+	}
+
+	return apiResp.Result, nil
+}
+
+// fetchMapAPI Map API 호출
+func (s *Scraper) fetchMapAPI(ctx context.Context, keyword string) ([]MapData, error) {
+	log := logger.GetLogger("scraper.inflexer")
+
+	reqURL := fmt.Sprintf("%s?query=%s&type=VST", mapURL, url.QueryEscape(keyword))
+	log.Infof("Map API 호출: %s", reqURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
+	}
+
+	var apiResp MapAPIResponse
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return apiResp.Result, nil
+}
+
+// Parse 데이터 파싱 - 원시 데이터를 Campaign 모델로 변환
+func (s *Scraper) Parse(ctx context.Context, rawData []map[string]interface{}) ([]models.Campaign, error) {
+	log := logger.GetLogger("scraper.inflexer")
+
+	var campaigns []models.Campaign
+	seen := make(map[string]bool)
+
+	for _, raw := range rawData {
+		campaign := models.Campaign{
+			Source: platformName,
+		}
+
+		// Platform (domain)
+		if domain, ok := raw["domain"].(string); ok {
+			campaign.Platform = strings.TrimSpace(domain)
+		}
+
+		// Title
+		if title, ok := raw["title"].(string); ok {
+			campaign.Title = strings.TrimSpace(title)
+			campaign.Company = campaign.Title
+		}
+
+		// Offer
+		if offer, ok := raw["offer"].(string); ok {
+			campaign.Offer = strings.TrimSpace(offer)
+		}
+
+		// URL
+		if contentURL, ok := raw["url"].(string); ok {
+			campaign.ContentLink = &contentURL
+			campaign.CompanyLink = &contentURL
+		}
+
+		// Channel 매핑 (media)
+		if media, ok := raw["media"].(string); ok {
+			media = strings.TrimSpace(media)
+			if mapped, exists := mediaMap[media]; exists {
+				campaign.CampaignChannel = mapped
+			} else {
+				campaign.CampaignChannel = "etc"
+			}
+		}
+
+		// Campaign Type 매핑 (type)
+		if typeStr, ok := raw["type"].(string); ok {
+			typeStr = strings.TrimSpace(typeStr)
+			if mapped, exists := typeMap[typeStr]; exists {
+				campaign.CampaignType = &mapped
+			}
+		}
+
+		// Region & SearchText (keyword)
+		if keyword, ok := raw["keyword"].(string); ok {
+			campaign.Region = &keyword
+			campaign.SearchText = keyword
+		}
+
+		// Apply Deadline
+		if aplDueDt, ok := raw["apl_due_dt"].(string); ok && aplDueDt != "" {
+			if t, err := time.Parse("2006-01-02T15:04:05", aplDueDt); err == nil {
+				campaign.ApplyDeadline = &t
+			} else if t, err := time.Parse("2006-01-02", aplDueDt); err == nil {
+				campaign.ApplyDeadline = &t
+			}
+		}
+
+		// Review Deadline
+		if pubDueDt, ok := raw["pub_due_dt"].(string); ok && pubDueDt != "" {
+			if t, err := time.Parse("2006-01-02T15:04:05", pubDueDt); err == nil {
+				campaign.ReviewDeadline = &t
+			} else if t, err := time.Parse("2006-01-02", pubDueDt); err == nil {
+				campaign.ReviewDeadline = &t
+			}
+		}
+
+		// Apply From
+		if aplSttDt, ok := raw["apl_stt_dt"].(string); ok && aplSttDt != "" {
+			if t, err := time.Parse("2006-01-02T15:04:05", aplSttDt); err == nil {
+				campaign.ApplyFrom = &t
+			} else if t, err := time.Parse("2006-01-02", aplSttDt); err == nil {
+				campaign.ApplyFrom = &t
+			}
+		}
+
+		// Map 데이터에서 lat/lng
+		if lat, ok := raw["lat"].(float64); ok {
+			campaign.Lat = &lat
+		}
+		if lng, ok := raw["lng"].(float64); ok {
+			campaign.Lng = &lng
+		}
+
+		// 중복 체크 (platform + title + offer + campaign_channel)
+		dedupKey := fmt.Sprintf("%s|%s|%s|%s",
+			campaign.Platform, campaign.Title, campaign.Offer, campaign.CampaignChannel)
+		if seen[dedupKey] {
+			continue
+		}
+		seen[dedupKey] = true
+
+		campaigns = append(campaigns, campaign)
+	}
+
+	log.Infof("Parse 완료: %d개 중 %d개 캠페인 파싱 (중복 제거)", len(rawData), len(campaigns))
+
+	// 메트릭 기록
+	if s.telemetry != nil {
+		s.telemetry.AddCampaignsScraped(ctx, int64(len(campaigns)), platformName)
+	}
+
+	return campaigns, nil
+}
+
+// Enrich 데이터 보강 - 주소/좌표 정보 추가 (방문형만)
+func (s *Scraper) Enrich(ctx context.Context, parsedData []models.Campaign) ([]models.Campaign, error) {
+	log := logger.GetLogger("scraper.inflexer")
+
+	log.Info("Enrich 단계: 방문형 캠페인 주소/좌표 보강 시작")
+
+	// Worker Pool 패턴으로 병렬 처리
+	config := DefaultEnrichConfig()
+
+	enrichedData, stats := s.enrichVisitCampaigns(ctx, parsedData, config)
+
+	log.Infof("Enrich 완료: %d건 처리 (CacheHit: %d, API: %d, Geocode: %d)",
+		stats.Total, stats.CacheHit, stats.APICalled, stats.Geocoded)
+
+	return enrichedData, nil
+}


### PR DESCRIPTION
## Summary
- inflexer 스크래퍼 구현 (Search + Map API 병렬 호출)
- Worker Pool 패턴으로 Enrich 병렬 처리 (3 workers)
- 방문형 캠페인 주소/좌표 보강 기능
- OpenTelemetry 메트릭 연동 (SigNoz)

## API 구조
- **Search API**: `https://inflexer.net:5000/search?query={keyword}` → 캠페인 목록
- **Map API**: `https://inflexer.net:5000/map?query={keyword}&type=VST` → 좌표 정보

## 병렬 처리
- Search + Map API 동시 호출 (goroutine)
- Enrich Worker Pool: 3 workers 동시 처리

## Test plan
- [ ] `./scraper inflexer --keyword "경기 김포"` 실행 테스트
- [ ] SigNoz에서 메트릭 수집 확인