### PR TITLE
fix(go-scraper): SCRAPE_KEYWORDS 환경변수 지원 추가

### DIFF
--- a/go-scraper/entrypoint.sh
+++ b/go-scraper/entrypoint.sh
@@ -5,22 +5,52 @@ set -e
 # Usage: entrypoint.sh <command> [args...]
 # Commands:
 #   reviewnote [--keyword <keyword>]  - Run reviewnote scraper
-#   inflexer --keyword <keyword>      - Run inflexer scraper (keyword required)
+#   inflexer [--keyword <keyword>]    - Run inflexer scraper (keyword required)
 #   cleanup                           - Clean up expired campaigns
 #   help                              - Show this help message
+#
+# Environment variables:
+#   SCRAPE_KEYWORDS  Comma-separated keywords (used if --keyword not provided)
 
 COMMAND=${1:-help}
+
+# Function to run scraper with keywords from env if not provided in args
+run_with_keywords() {
+    SCRAPER_NAME=$1
+    shift
+
+    # Check if --keyword is already provided in args
+    if echo "$@" | grep -q "\-\-keyword"; then
+        exec /app/scraper "$SCRAPER_NAME" "$@"
+    elif [ -n "$SCRAPE_KEYWORDS" ]; then
+        # Use keywords from environment variable (comma-separated)
+        # Run for each keyword sequentially
+        echo "[$(date -Iseconds)] Keywords from env: $SCRAPE_KEYWORDS"
+
+        # Split by comma and run for each keyword
+        echo "$SCRAPE_KEYWORDS" | tr ',' '\n' | while read -r keyword; do
+            keyword=$(echo "$keyword" | xargs)  # trim whitespace
+            if [ -n "$keyword" ]; then
+                echo "[$(date -Iseconds)] Running $SCRAPER_NAME with keyword: $keyword"
+                /app/scraper "$SCRAPER_NAME" --keyword "$keyword" "$@"
+            fi
+        done
+    else
+        # No keywords - run without
+        exec /app/scraper "$SCRAPER_NAME" "$@"
+    fi
+}
 
 case "$COMMAND" in
     reviewnote)
         shift
         echo "[$(date -Iseconds)] Starting reviewnote scraper..."
-        exec /app/scraper reviewnote "$@"
+        run_with_keywords reviewnote "$@"
         ;;
     inflexer)
         shift
         echo "[$(date -Iseconds)] Starting inflexer scraper..."
-        exec /app/scraper inflexer "$@"
+        run_with_keywords inflexer "$@"
         ;;
     cleanup)
         shift
@@ -34,17 +64,17 @@ case "$COMMAND" in
         echo ""
         echo "Commands:"
         echo "  reviewnote [--keyword <keyword>]  Run reviewnote scraper"
-        echo "  inflexer --keyword <keyword>      Run inflexer scraper (keyword required)"
+        echo "  inflexer [--keyword <keyword>]    Run inflexer scraper (keyword required)"
         echo "  cleanup                           Clean up expired campaigns"
         echo "  help                              Show this help message"
         echo ""
         echo "Environment variables:"
+        echo "  SCRAPE_KEYWORDS    Comma-separated keywords (used if --keyword not provided)"
         echo "  POSTGRES_HOST      Database host (required)"
         echo "  POSTGRES_PORT      Database port (default: 5432)"
         echo "  POSTGRES_USER      Database user (required)"
         echo "  POSTGRES_PASSWORD  Database password (required)"
         echo "  POSTGRES_DB        Database name (required)"
-        echo "  NAVER_API_KEYS     Naver API keys for enrichment (required)"
         exit 0
         ;;
     *)


### PR DESCRIPTION
## Summary
- entrypoint.sh에서 SCRAPE_KEYWORDS 환경변수 처리
- 콤마로 구분된 키워드 목록을 순차적으로 실행
- --keyword 인자가 없으면 환경변수에서 키워드 사용

## 동작 방식
1. `--keyword` 인자가 있으면 그대로 사용
2. 없으면 `SCRAPE_KEYWORDS` 환경변수 확인
3. 환경변수가 있으면 콤마로 분리하여 각각 실행

## Test plan
- [ ] `SCRAPE_KEYWORDS="경기 김포"` 환경변수로 inflexer 실행 확인