### PR TITLE
feat(scraper): 캠페인 저장 방식을 DELETE+INSERT로 변경

### DIFF
--- a/go-scraper/cmd/scraper/main.go
+++ b/go-scraper/cmd/scraper/main.go
@@ -152,9 +152,17 @@ func runScraper(ctx context.Context, name string, cfg *config.Config, database *
 	case "cleanup":
 		cleaner := cleanup.New(cfg, database, tel)
 		return cleaner.Run(ctx)
+	case "dedupe":
+		// 중복 캠페인 정리 (가장 최신 레코드만 유지)
+		cleaner := cleanup.New(cfg, database, tel)
+		return cleaner.DeduplicateCampaigns(ctx)
+	case "add-unique":
+		// UNIQUE 제약조건 추가 (dedupe 실행 후 사용)
+		cleaner := cleanup.New(cfg, database, tel)
+		return cleaner.AddUniqueConstraint(ctx)
 	default:
 		log.Errorf("'%s' 스크레이퍼를 찾을 수 없습니다.", name)
-		log.Info("사용 가능한 명령어: reviewnote, inflexer, cleanup")
+		log.Info("사용 가능한 명령어: reviewnote, inflexer, cleanup, dedupe, add-unique")
 		return nil
 	}
 }

--- a/go-scraper/entrypoint.sh
+++ b/go-scraper/entrypoint.sh
@@ -64,6 +64,16 @@ case "$COMMAND" in
         echo "[$(date -Iseconds)] Starting cleanup..."
         exec /app/scraper cleanup "$@"
         ;;
+    dedupe)
+        shift
+        echo "[$(date -Iseconds)] Starting dedupe (remove duplicate campaigns)..."
+        exec /app/scraper dedupe "$@"
+        ;;
+    add-unique)
+        shift
+        echo "[$(date -Iseconds)] Adding UNIQUE constraint..."
+        exec /app/scraper add-unique "$@"
+        ;;
     help|--help|-h)
         echo "go-scraper - Campaign data scraper"
         echo ""
@@ -73,6 +83,8 @@ case "$COMMAND" in
         echo "  reviewnote [--keyword <keyword>]  Run reviewnote scraper"
         echo "  inflexer [--keyword <keyword>]    Run inflexer scraper (keyword required)"
         echo "  cleanup                           Clean up expired campaigns"
+        echo "  dedupe                            Remove duplicate campaigns (keep newest)"
+        echo "  add-unique                        Add UNIQUE constraint (run after dedupe)"
         echo "  help                              Show this help message"
         echo ""
         echo "Environment variables:"

--- a/go-scraper/internal/cleanup/dedupe.go
+++ b/go-scraper/internal/cleanup/dedupe.go
@@ -1,0 +1,167 @@
+package cleanup
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ggorockee/reviewmaps/go-scraper/internal/logger"
+)
+
+// DeduplicateCampaigns 중복 캠페인 정리
+// (platform, title, offer, campaign_channel) 기준으로 중복된 레코드 중
+// 가장 최신(updated_at 기준) 레코드만 남기고 삭제
+func (c *Cleaner) DeduplicateCampaigns(ctx context.Context) error {
+	log := logger.GetLogger("cleanup.dedupe")
+	startTime := time.Now()
+
+	log.Info("===== 중복 캠페인 정리 시작 =====")
+
+	// 1. 중복 그룹 개수 확인
+	countQuery := `
+		SELECT COUNT(*) as dup_groups
+		FROM (
+			SELECT platform, title, offer, campaign_channel
+			FROM campaign
+			GROUP BY platform, title, offer, campaign_channel
+			HAVING COUNT(*) > 1
+		) as duplicates
+	`
+
+	var dupGroups int
+	if err := c.database.Pool.QueryRow(ctx, countQuery).Scan(&dupGroups); err != nil {
+		return fmt.Errorf("중복 그룹 카운트 실패: %w", err)
+	}
+
+	if dupGroups == 0 {
+		log.Info("중복된 캠페인이 없습니다.")
+		return nil
+	}
+
+	log.Infof("중복 그룹 발견: %d개", dupGroups)
+
+	// 2. 중복 레코드 총 개수 (삭제 대상)
+	totalDupQuery := `
+		SELECT COALESCE(SUM(cnt - 1), 0)
+		FROM (
+			SELECT platform, title, offer, campaign_channel, COUNT(*) as cnt
+			FROM campaign
+			GROUP BY platform, title, offer, campaign_channel
+			HAVING COUNT(*) > 1
+		) as duplicates
+	`
+
+	var totalDuplicates int64
+	if err := c.database.Pool.QueryRow(ctx, totalDupQuery).Scan(&totalDuplicates); err != nil {
+		return fmt.Errorf("중복 레코드 카운트 실패: %w", err)
+	}
+
+	log.Infof("삭제 대상 중복 레코드: %d개", totalDuplicates)
+
+	// 3. 중복 삭제 (가장 최신 updated_at 레코드만 유지)
+	// CTE를 사용하여 각 그룹에서 가장 최신 레코드의 ID를 찾고
+	// 그 외의 레코드를 삭제
+	deleteQuery := `
+		WITH ranked AS (
+			SELECT id,
+				   ROW_NUMBER() OVER (
+					   PARTITION BY platform, title, offer, campaign_channel
+					   ORDER BY updated_at DESC NULLS LAST, id DESC
+				   ) as rn
+			FROM campaign
+		),
+		to_delete AS (
+			SELECT id FROM ranked WHERE rn > 1
+		)
+		DELETE FROM campaign
+		WHERE id IN (SELECT id FROM to_delete)
+	`
+
+	result, err := c.database.Pool.Exec(ctx, deleteQuery)
+	if err != nil {
+		return fmt.Errorf("중복 캠페인 삭제 실패: %w", err)
+	}
+
+	rowsAffected := result.RowsAffected()
+	log.Infof("중복 캠페인 삭제 완료: %d개 레코드 삭제됨", rowsAffected)
+
+	// 4. 삭제 후 검증
+	var remainingDups int
+	if err := c.database.Pool.QueryRow(ctx, countQuery).Scan(&remainingDups); err != nil {
+		log.Warnf("검증 쿼리 실패: %v", err)
+	} else if remainingDups > 0 {
+		log.Warnf("아직 %d개 중복 그룹이 남아있습니다.", remainingDups)
+	} else {
+		log.Info("모든 중복이 제거되었습니다. ✓")
+	}
+
+	// 메트릭 기록
+	if c.telemetry != nil {
+		c.telemetry.AddCleanupDeleted(ctx, rowsAffected)
+		c.telemetry.RecordCleanupDuration(ctx, time.Since(startTime))
+	}
+
+	log.Infof("===== 중복 캠페인 정리 종료 (소요시간: %v) =====", time.Since(startTime))
+	return nil
+}
+
+// AddUniqueConstraint UNIQUE 제약조건 추가
+// 중복 정리 후에만 실행 가능
+func (c *Cleaner) AddUniqueConstraint(ctx context.Context) error {
+	log := logger.GetLogger("cleanup.dedupe")
+
+	log.Info("===== UNIQUE 제약조건 추가 시작 =====")
+
+	// 1. 기존 제약조건 확인
+	checkQuery := `
+		SELECT COUNT(*)
+		FROM pg_constraint
+		WHERE conname = 'uq_campaign_platform_title_offer_channel'
+	`
+
+	var exists int
+	if err := c.database.Pool.QueryRow(ctx, checkQuery).Scan(&exists); err != nil {
+		return fmt.Errorf("제약조건 확인 실패: %w", err)
+	}
+
+	if exists > 0 {
+		log.Info("UNIQUE 제약조건이 이미 존재합니다.")
+		return nil
+	}
+
+	// 2. 중복 확인
+	dupCheckQuery := `
+		SELECT COUNT(*)
+		FROM (
+			SELECT platform, title, offer, campaign_channel
+			FROM campaign
+			GROUP BY platform, title, offer, campaign_channel
+			HAVING COUNT(*) > 1
+		) as duplicates
+	`
+
+	var dupCount int
+	if err := c.database.Pool.QueryRow(ctx, dupCheckQuery).Scan(&dupCount); err != nil {
+		return fmt.Errorf("중복 확인 실패: %w", err)
+	}
+
+	if dupCount > 0 {
+		return fmt.Errorf("중복 데이터가 %d개 그룹 존재합니다. 먼저 dedupe를 실행하세요", dupCount)
+	}
+
+	// 3. UNIQUE 제약조건 추가
+	alterQuery := `
+		ALTER TABLE campaign
+		ADD CONSTRAINT uq_campaign_platform_title_offer_channel
+		UNIQUE (platform, title, offer, campaign_channel)
+	`
+
+	if _, err := c.database.Pool.Exec(ctx, alterQuery); err != nil {
+		return fmt.Errorf("UNIQUE 제약조건 추가 실패: %w", err)
+	}
+
+	log.Info("UNIQUE 제약조건 추가 완료 ✓")
+	log.Info("===== UNIQUE 제약조건 추가 종료 =====")
+
+	return nil
+}

--- a/go-scraper/internal/config/config.go
+++ b/go-scraper/internal/config/config.go
@@ -87,6 +87,13 @@ type ScrapeConfig struct {
 	MaxItems int // 최대 수집 개수 (0 = 무제한)
 }
 
+// ServerAPIConfig Server API 연동 설정
+type ServerAPIConfig struct {
+	BaseURL    string // Server API Base URL (예: http://localhost:3000)
+	APIKey     string // Internal API Key
+	Enabled    bool   // API 호출 활성화 여부
+}
+
 // Config 애플리케이션의 모든 설정을 통합 관리하는 메인 구조체
 type Config struct {
 	BaseURL   string
@@ -96,6 +103,7 @@ type Config struct {
 	NaverAPI  NaverAPIConfig
 	Batch     BatchConfig
 	Scrape    ScrapeConfig
+	ServerAPI ServerAPIConfig
 }
 
 // Load 환경변수에서 설정을 로드
@@ -135,6 +143,11 @@ func Load() (*Config, error) {
 		Scrape: ScrapeConfig{
 			MaxItems: getEnvInt("SCRAPE_MAX_ITEMS", 100),
 		},
+		ServerAPI: ServerAPIConfig{
+			BaseURL: getEnv("SERVER_API_BASE_URL", ""),
+			APIKey:  getEnvWithFallback("SERVER_API_KEY", "API_SECRET_KEY", ""),
+			Enabled: getEnvBool("SERVER_API_ENABLED", false),
+		},
 	}
 
 	return cfg, nil
@@ -168,4 +181,15 @@ func getEnvInt(key string, defaultValue int) int {
 		return defaultValue
 	}
 	return intVal
+}
+
+// getEnvWithFallback 주 키가 없으면 대체 키 사용
+func getEnvWithFallback(primary, fallback, defaultValue string) string {
+	if value := os.Getenv(primary); value != "" {
+		return value
+	}
+	if value := os.Getenv(fallback); value != "" {
+		return value
+	}
+	return defaultValue
 }

--- a/go-scraper/internal/scraper/reviewnote/enricher.go
+++ b/go-scraper/internal/scraper/reviewnote/enricher.go
@@ -167,10 +167,14 @@ func (s *Scraper) enrichVisitCampaigns(ctx context.Context, campaigns []models.C
 	return campaigns, stats
 }
 
-// enrichWorker 개별 Worker
+// enrichWorker 개별 Worker (각 Worker별 전용 API 키 할당)
 func (s *Scraper) enrichWorker(ctx context.Context, id int, jobs <-chan EnrichJob, results chan<- EnrichResult, wg *sync.WaitGroup, config *EnrichConfig, stats *EnrichStats) {
 	defer wg.Done()
 	log := logger.GetLogger("scraper.reviewnote.enrich")
+
+	// Worker별 전용 Enricher 생성 (각 Worker는 자신만의 API 키 사용)
+	workerEnricher := enricher.NewForWorker(s.Config, id)
+	log.Infof("[Worker-%d] 시작 (전용 API 키 할당)", id)
 
 	for job := range jobs {
 		select {
@@ -180,18 +184,23 @@ func (s *Scraper) enrichWorker(ctx context.Context, id int, jobs <-chan EnrichJo
 		default:
 		}
 
-		result := s.enrichSingleCampaign(ctx, job, stats)
+		result := s.enrichSingleCampaignWithEnricher(ctx, job, stats, workerEnricher)
 		results <- result
 
 		// Rate limiting: API 호출 간 딜레이
 		time.Sleep(config.APIDelay)
 	}
 
-	log.Debugf("Worker %d 종료", id)
+	log.Infof("[Worker-%d] 종료", id)
 }
 
-// enrichSingleCampaign 단일 캠페인 보강
+// enrichSingleCampaign 단일 캠페인 보강 (BaseScraper의 공유 Enricher 사용)
 func (s *Scraper) enrichSingleCampaign(ctx context.Context, job EnrichJob, stats *EnrichStats) EnrichResult {
+	return s.enrichSingleCampaignWithEnricher(ctx, job, stats, s.Enricher)
+}
+
+// enrichSingleCampaignWithEnricher 단일 캠페인 보강 (지정된 Enricher 사용)
+func (s *Scraper) enrichSingleCampaignWithEnricher(ctx context.Context, job EnrichJob, stats *EnrichStats, workerEnricher *enricher.Enricher) EnrichResult {
 	log := logger.GetLogger("scraper.reviewnote.enrich")
 	campaign := job.Campaign
 
@@ -207,11 +216,14 @@ func (s *Scraper) enrichSingleCampaign(ctx context.Context, job EnrichJob, stats
 		result.Lat = cacheEntry.Lat
 		result.Lng = cacheEntry.Lng
 
-		// 카테고리 매핑
-		if cacheEntry.Category != nil {
-			mappedID, err := s.DB.FindMappedCategoryID(ctx, *cacheEntry.Category)
-			if err == nil && mappedID != nil {
-				result.CategoryID = mappedID
+		// 카테고리 매핑 (캐시에 저장된 원본 텍스트 → raw_categories → category_mappings)
+		if cacheEntry.CategoryText != nil && *cacheEntry.CategoryText != "" {
+			rawID, err := s.DB.GetOrCreateRawCategory(ctx, *cacheEntry.CategoryText)
+			if err == nil && rawID != nil {
+				mappedID, err := s.DB.FindMappedCategoryID(ctx, *rawID)
+				if err == nil && mappedID != nil {
+					result.CategoryID = mappedID
+				}
 			}
 		}
 
@@ -222,7 +234,7 @@ func (s *Scraper) enrichSingleCampaign(ctx context.Context, job EnrichJob, stats
 	atomic.AddInt32(&stats.APICalled, 1)
 	log.Debugf("[Cache MISS] %s → API 호출", campaign.Title)
 
-	place, err := s.Enricher.NaverLocalSearch(ctx, campaign.Title)
+	place, err := workerEnricher.NaverLocalSearch(ctx, campaign.Title)
 	if err != nil {
 		log.Warnf("Local Search 실패 (%s): %v", campaign.Title, err)
 		return result
@@ -252,7 +264,9 @@ func (s *Scraper) enrichSingleCampaign(ctx context.Context, job EnrichJob, stats
 	}
 
 	// 5. 카테고리 처리
+	var categoryTextForCache *string
 	if place.Category != "" {
+		categoryTextForCache = &place.Category
 		rawID, err := s.DB.GetOrCreateRawCategory(ctx, place.Category)
 		if err == nil && rawID != nil {
 			mappedID, err := s.DB.FindMappedCategoryID(ctx, *rawID)
@@ -271,7 +285,7 @@ func (s *Scraper) enrichSingleCampaign(ctx context.Context, job EnrichJob, stats
 			result.Lng = &lng
 		} else {
 			// Geocode API 호출
-			lat, lng, ok := s.Enricher.NaverGeocode(ctx, *result.Address)
+			lat, lng, ok := workerEnricher.NaverGeocode(ctx, *result.Address)
 			if ok {
 				result.Lat = &lat
 				result.Lng = &lng
@@ -291,7 +305,7 @@ func (s *Scraper) enrichSingleCampaign(ctx context.Context, job EnrichJob, stats
 				log.Warnf("[Drift] %s: %.0fm 드리프트 감지, Geocode로 재보정", campaign.Title, dist)
 
 				// Geocode로 재보정
-				lat, lng, ok := s.Enricher.NaverGeocode(ctx, *result.Address)
+				lat, lng, ok := workerEnricher.NaverGeocode(ctx, *result.Address)
 				if ok {
 					result.Lat = &lat
 					result.Lng = &lng
@@ -305,13 +319,9 @@ func (s *Scraper) enrichSingleCampaign(ctx context.Context, job EnrichJob, stats
 		}
 	}
 
-	// 8. Local Cache 저장
+	// 8. Local Cache 저장 (원본 카테고리 텍스트 저장)
 	if result.Address != nil && result.Lat != nil && result.Lng != nil {
-		var categoryForCache *int64
-		if result.CategoryID != nil {
-			categoryForCache = result.CategoryID
-		}
-		_ = s.DB.PutLocalCache(ctx, campaign.Title, *result.Address, *result.Lat, *result.Lng, categoryForCache)
+		_ = s.DB.PutLocalCache(ctx, campaign.Title, *result.Address, *result.Lat, *result.Lng, categoryTextForCache)
 	}
 
 	return result

--- a/go-scraper/internal/server/client.go
+++ b/go-scraper/internal/server/client.go
@@ -1,0 +1,108 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/ggorockee/reviewmaps/go-scraper/internal/config"
+	"github.com/ggorockee/reviewmaps/go-scraper/internal/logger"
+)
+
+// Client Server API 클라이언트
+type Client struct {
+	baseURL    string
+	apiKey     string
+	enabled    bool
+	httpClient *http.Client
+}
+
+// NewClient 새 클라이언트 생성
+func NewClient(cfg *config.Config) *Client {
+	return &Client{
+		baseURL: cfg.ServerAPI.BaseURL,
+		apiKey:  cfg.ServerAPI.APIKey,
+		enabled: cfg.ServerAPI.Enabled,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// ProcessCampaignAlertsRequest 캠페인 알림 처리 요청
+type ProcessCampaignAlertsRequest struct {
+	CampaignIDs []uint `json:"campaign_ids"`
+}
+
+// ProcessCampaignAlertsResponse 캠페인 알림 처리 응답
+type ProcessCampaignAlertsResponse struct {
+	ProcessedCount int      `json:"processed_count"`
+	AlertsCreated  int      `json:"alerts_created"`
+	Errors         []string `json:"errors,omitempty"`
+}
+
+// ProcessCampaignAlerts 저장된 캠페인들에 대해 키워드 알림 처리 요청
+func (c *Client) ProcessCampaignAlerts(ctx context.Context, campaignIDs []uint) (*ProcessCampaignAlertsResponse, error) {
+	log := logger.GetLogger("server.client")
+
+	if !c.enabled {
+		log.Info("[ServerAPI] Server API 연동이 비활성화되어 있습니다")
+		return nil, nil
+	}
+
+	if len(campaignIDs) == 0 {
+		log.Info("[ServerAPI] 처리할 캠페인 ID가 없습니다")
+		return nil, nil
+	}
+
+	if c.baseURL == "" {
+		log.Warn("[ServerAPI] Server API Base URL이 설정되지 않았습니다")
+		return nil, nil
+	}
+
+	log.Infof("[ServerAPI] %d개 캠페인 알림 처리 요청 시작", len(campaignIDs))
+
+	// 요청 생성
+	reqBody := ProcessCampaignAlertsRequest{
+		CampaignIDs: campaignIDs,
+	}
+
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("요청 JSON 생성 실패: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/v1/internal/process-campaign-alerts", c.baseURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("HTTP 요청 생성 실패: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", c.apiKey)
+
+	// 요청 실행
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP 요청 실패: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// 응답 처리
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Server API 오류: status=%d", resp.StatusCode)
+	}
+
+	var result ProcessCampaignAlertsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("응답 JSON 파싱 실패: %w", err)
+	}
+
+	log.Infof("[ServerAPI] 알림 처리 완료: processed=%d, alerts_created=%d",
+		result.ProcessedCount, result.AlertsCreated)
+
+	return &result, nil
+}

--- a/go-scraper/pkg/models/campaign.go
+++ b/go-scraper/pkg/models/campaign.go
@@ -46,12 +46,14 @@ func (c *CampaignKey) Key() string {
 }
 
 // LocalCacheEntry local_search_cache 테이블 엔트리
+// Note: category는 DB에서 text 타입이지만, 내부적으로는 raw_category_id로 변환하여 사용
 type LocalCacheEntry struct {
-	Address   *string
-	Lat       *float64
-	Lng       *float64
-	Category  *int64
-	UpdatedAt time.Time
+	Address      *string
+	Lat          *float64
+	Lng          *float64
+	CategoryText *string // DB의 category 컬럼 (text 타입)
+	Category     *int64  // 변환된 raw_category_id (코드 내부용)
+	UpdatedAt    time.Time
 }
 
 // NaverLocalSearchResult 네이버 Local API 검색 결과

--- a/server/cmd/api/main.go
+++ b/server/cmd/api/main.go
@@ -166,4 +166,8 @@ func setupRoutes(app *fiber.App, db *database.DB, cfg *config.Config) {
 	// App config routes (public)
 	appConfig := v1.Group("/app-config")
 	handlers.SetupAppConfigRoutes(appConfig, db)
+
+	// Internal API routes (Scraper 전용 - API Key 인증)
+	internal := v1.Group("/internal")
+	handlers.SetupInternalRoutes(internal, db, cfg)
 }

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -38,6 +38,9 @@ type Config struct {
 
 	// SigNoz
 	SigNozEndpoint string
+
+	// Internal API
+	InternalAPIKey string
 }
 
 func Load() *Config {
@@ -73,6 +76,9 @@ func Load() *Config {
 
 		// SigNoz
 		SigNozEndpoint: getEnv("SIGNOZ_ENDPOINT", ""),
+
+		// Internal API (Scraper → Server 통신용, API_SECRET_KEY 재사용)
+		InternalAPIKey: getEnvWithFallback("INTERNAL_API_KEY", "API_SECRET_KEY", ""),
 	}
 }
 

--- a/server/internal/handlers/internal.go
+++ b/server/internal/handlers/internal.go
@@ -1,0 +1,97 @@
+package handlers
+
+import (
+	"log"
+
+	"github.com/ggorockee/reviewmaps/server/internal/config"
+	"github.com/ggorockee/reviewmaps/server/internal/database"
+	"github.com/ggorockee/reviewmaps/server/internal/services"
+	"github.com/gofiber/fiber/v2"
+)
+
+type InternalHandler struct {
+	db           *database.DB
+	cfg          *config.Config
+	keywordMatch *services.KeywordMatchService
+}
+
+func NewInternalHandler(db *database.DB, cfg *config.Config) *InternalHandler {
+	return &InternalHandler{
+		db:           db,
+		cfg:          cfg,
+		keywordMatch: services.NewKeywordMatchService(db),
+	}
+}
+
+func SetupInternalRoutes(router fiber.Router, db *database.DB, cfg *config.Config) {
+	h := NewInternalHandler(db, cfg)
+
+	// 내부 API (Scraper용) - API Key 인증 필요
+	router.Post("/process-campaign-alerts", h.ProcessCampaignAlerts)
+}
+
+// ProcessCampaignAlertsRequest 캠페인 알림 처리 요청
+type ProcessCampaignAlertsRequest struct {
+	CampaignIDs []uint `json:"campaign_ids"`
+}
+
+// ProcessCampaignAlertsResponse 캠페인 알림 처리 응답
+type ProcessCampaignAlertsResponse struct {
+	ProcessedCount int      `json:"processed_count"`
+	AlertsCreated  int      `json:"alerts_created"`
+	Errors         []string `json:"errors,omitempty"`
+}
+
+// ProcessCampaignAlerts godoc
+// @Summary Process keyword alerts for campaigns
+// @Description Scraper에서 새로 저장한 캠페인들에 대해 키워드 매칭 및 알림 처리
+// @Tags internal
+// @Accept json
+// @Produce json
+// @Param X-API-Key header string true "Internal API Key"
+// @Param request body ProcessCampaignAlertsRequest true "Campaign IDs to process"
+// @Success 200 {object} ProcessCampaignAlertsResponse
+// @Router /internal/process-campaign-alerts [post]
+func (h *InternalHandler) ProcessCampaignAlerts(c *fiber.Ctx) error {
+	// API Key 검증
+	apiKey := c.Get("X-API-Key")
+	if apiKey == "" || apiKey != h.cfg.InternalAPIKey {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error": "Invalid or missing API key",
+		})
+	}
+
+	var req ProcessCampaignAlertsRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Invalid request body",
+		})
+	}
+
+	if len(req.CampaignIDs) == 0 {
+		return c.JSON(ProcessCampaignAlertsResponse{
+			ProcessedCount: 0,
+			AlertsCreated:  0,
+		})
+	}
+
+	log.Printf("[Internal] Processing %d campaigns for keyword alerts", len(req.CampaignIDs))
+
+	// 캠페인별 키워드 매칭
+	ctx := c.Context()
+	alertsCreated := 0
+	var errors []string
+
+	for _, campaignID := range req.CampaignIDs {
+		count := h.keywordMatch.ProcessCampaignKeywordMatchingByID(ctx, campaignID)
+		alertsCreated += count
+	}
+
+	log.Printf("[Internal] Processed %d campaigns, created %d alerts", len(req.CampaignIDs), alertsCreated)
+
+	return c.JSON(ProcessCampaignAlertsResponse{
+		ProcessedCount: len(req.CampaignIDs),
+		AlertsCreated:  alertsCreated,
+		Errors:         errors,
+	})
+}


### PR DESCRIPTION
## 요약

캠페인 저장 방식을 UPSERT에서 DELETE+INSERT 방식으로 변경하여 Firebase 푸시 알림이 새 캠페인으로 인식하도록 개선했습니다.

## 주요 변경사항

### 1. UpsertCampaigns 로직 변경
- **기존**: `ON CONFLICT DO UPDATE` (UPSERT 방식)
- **변경**: `DELETE` + `INSERT` (트랜잭션)
- **효과**: `created_at`이 갱신되어 Firebase 푸시 알림이 새 캠페인으로 인식

### 2. 중복 캠페인 정리 기능 추가
- **dedupe 명령어**: 중복 캠페인 제거 (가장 최신 `created_at` 레코드만 유지)
- **add-unique 명령어**: UNIQUE 제약조건 추가 (dedupe 실행 후 사용)

### 3. 안전성 보장
- 트랜잭션으로 DELETE + INSERT 원자성 보장
- 상세한 로깅 (삭제/신규 건수 출력)

## 변경된 파일

- `go-scraper/internal/db/db.go`: UpsertCampaigns 로직 변경
- `go-scraper/internal/cleanup/dedupe.go`: 중복 제거 기능 신규 추가
- `go-scraper/cmd/scraper/main.go`: dedupe, add-unique 명령어 추가
- `go-scraper/entrypoint.sh`: 새 명령어 헬프 메시지 추가

## 테스트 계획

- [ ] 로컬에서 스크레이퍼 실행 후 DB 확인
- [ ] DELETE + INSERT 트랜잭션 정상 동작 확인
- [ ] dedupe 명령어로 중복 캠페인 제거 확인
- [ ] add-unique 명령어로 제약조건 추가 확인
- [ ] Firebase 푸시 알림 새 캠페인 인식 확인