### PR TITLE
fix(server): SNS 로그인 에러 디버깅 로그 추가

### DIFF
--- a/server/internal/handlers/auth.go
+++ b/server/internal/handlers/auth.go
@@ -183,6 +183,8 @@ func (h *AuthHandler) KakaoLogin(c *fiber.Ctx) error {
 
 	response, err := h.service.KakaoLogin(req.AccessToken)
 	if err != nil {
+		// Log the error for debugging
+		c.Context().Logger().Printf("[KakaoLogin] Error: %v", err)
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": err.Error()})
 	}
 
@@ -205,6 +207,8 @@ func (h *AuthHandler) GoogleLogin(c *fiber.Ctx) error {
 
 	response, err := h.service.GoogleLogin(req.AccessToken)
 	if err != nil {
+		// Log the error for debugging
+		c.Context().Logger().Printf("[GoogleLogin] Error: %v", err)
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": err.Error()})
 	}
 

--- a/server/pkg/sns/google.go
+++ b/server/pkg/sns/google.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 )
@@ -45,7 +46,9 @@ func VerifyGoogleToken(ctx context.Context, accessToken string) (*GoogleUserInfo
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("google API returned status %d", resp.StatusCode)
+		// Read response body for debugging
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("google API returned status %d: %s", resp.StatusCode, string(body))
 	}
 
 	var googleResp GoogleAPIResponse

--- a/server/pkg/sns/kakao.go
+++ b/server/pkg/sns/kakao.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 )
@@ -51,7 +52,9 @@ func VerifyKakaoToken(ctx context.Context, accessToken string) (*KakaoUserInfo, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("kakao API returned status %d", resp.StatusCode)
+		// Read response body for debugging
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("kakao API returned status %d: %s", resp.StatusCode, string(body))
 	}
 
 	var kakaoResp KakaoAPIResponse


### PR DESCRIPTION
## Summary
- SNS 로그인 401 에러 원인 파악을 위한 디버깅 로그 추가

## 변경 내용
- Google/Kakao API 호출 실패 시 응답 본문을 에러 메시지에 포함
- 핸들러에서 에러 발생 시 서버 로그에 상세 에러 출력

## 문제 상황
- iPhone에서 Google/Kakao 로그인 시 401 에러 발생
- SDK에서 Access Token 획득 성공 후 서버 API 호출에서 실패

## Test plan
- [ ] 배포 후 SNS 로그인 시도
- [ ] 서버 로그에서 상세 에러 메시지 확인