### PR TITLE
fix(server): SNS 로그인 시 username NULL 에러 수정

### DIFF
--- a/server/internal/services/auth.go
+++ b/server/internal/services/auth.go
@@ -433,13 +433,16 @@ func (s *AuthService) handleSNSLogin(provider, providerUserID, email, name, prof
 			user = &socialAccount.User
 
 			// Update social account info (Django: social_account.save())
-			socialAccount.Email = email
-			socialAccount.Name = name
-			socialAccount.ProfileImage = profileImage
-			if accessToken != "" {
-				socialAccount.AccessToken = accessToken
+			// Use Updates instead of Save to avoid updating the preloaded User
+			socialAccountUpdates := map[string]interface{}{
+				"email":         email,
+				"name":          name,
+				"profile_image": profileImage,
 			}
-			if err := tx.Save(&socialAccount).Error; err != nil {
+			if accessToken != "" {
+				socialAccountUpdates["access_token"] = accessToken
+			}
+			if err := tx.Model(&socialAccount).Updates(socialAccountUpdates).Error; err != nil {
 				return fmt.Errorf("failed to update social account: %w", err)
 			}
 


### PR DESCRIPTION
## Summary
- 기존 SNS 사용자 로그인 시 username NULL 에러 수정

## 원인
- `tx.Save(&socialAccount)`가 Preload된 User 객체까지 함께 저장 시도
- 레거시 DB의 일부 사용자는 username이 NULL
- NOT NULL 제약조건 위반 에러 발생

## 해결
- `Save` 대신 `Updates`를 사용하여 SocialAccount 필드만 업데이트

## 에러 메시지
```
failed to update social account: ERROR: null value in column "username" of relation "users" violates not-null constraint (SQLSTATE 23502)
```

## Test plan
- [ ] 기존 Google 계정으로 로그인 테스트
- [ ] 기존 Kakao 계정으로 로그인 테스트