### PR TITLE
fix(go-scraper): 플랫폼 표시명 reviewnote → 리뷰노트로 변경

### DIFF
--- a/go-scraper/internal/scraper/reviewnote/enricher_test.go
+++ b/go-scraper/internal/scraper/reviewnote/enricher_test.go
@@ -258,8 +258,8 @@ func TestScraperWithMockDB(t *testing.T) {
 		},
 	}
 
-	if s.PlatformName() != "reviewnote" {
-		t.Errorf("Expected platform 'reviewnote', got '%s'", s.PlatformName())
+	if s.PlatformName() != "리뷰노트" {
+		t.Errorf("Expected platform '리뷰노트', got '%s'", s.PlatformName())
 	}
 
 	if s.BaseURL() != "https://www.reviewnote.co.kr/api/v2/campaigns" {

--- a/go-scraper/internal/scraper/reviewnote/reviewnote.go
+++ b/go-scraper/internal/scraper/reviewnote/reviewnote.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	platformName = "reviewnote"
+	platformName = "리뷰노트"
 	baseURL      = "https://www.reviewnote.co.kr/api/v2/campaigns"
 	imageBaseURL = "https://reviewnote.s3.ap-northeast-2.amazonaws.com/"
 	pageLimit    = 100

--- a/go-scraper/internal/scraper/reviewnote/reviewnote_test.go
+++ b/go-scraper/internal/scraper/reviewnote/reviewnote_test.go
@@ -62,8 +62,8 @@ func TestScrapeAndParse(t *testing.T) {
 
 	// 첫 번째 캠페인 검증
 	c1 := campaigns[0]
-	if c1.Platform != "reviewnote" {
-		t.Errorf("Expected platform 'reviewnote', got '%s'", c1.Platform)
+	if c1.Platform != "리뷰노트" {
+		t.Errorf("Expected platform '리뷰노트', got '%s'", c1.Platform)
 	}
 	if c1.Title != "필립스 전자동 에스프레소 커피머신" {
 		t.Errorf("Unexpected title: %s", c1.Title)


### PR DESCRIPTION
## Summary
- 앱 홈화면에서 플랫폼명이 한글로 표시되도록 수정

## 변경 내용
- `platformName = "reviewnote"` → `platformName = "리뷰노트"`

## DB 마이그레이션 쿼리
기존 데이터도 업데이트 필요:
```sql
UPDATE campaigns SET platform = '리뷰노트' WHERE platform = 'reviewnote';
```

## Test plan
- [x] 테스트 통과
- [ ] 배포 후 스크래퍼 실행
- [ ] 앱에서 플랫폼명 확인