### PR TITLE
fix(admin,mobile): 키워드 알람 관련 에러 수정

### DIFF
--- a/admin/keyword_alerts/models.py
+++ b/admin/keyword_alerts/models.py
@@ -73,9 +73,10 @@ class KeywordAlert(models.Model):
         related_name="keyword_alerts",
         verbose_name="캠페인",
     )
+    matched_field = models.CharField(max_length=50, default="title", verbose_name="매칭 필드")
     is_read = models.BooleanField(default=False, verbose_name="읽음 여부")
-    is_sent = models.BooleanField(default=False, verbose_name="발송 여부")
     created_at = models.DateTimeField(auto_now_add=True, verbose_name="생성일시")
+    updated_at = models.DateTimeField(auto_now=True, verbose_name="수정일시")
 
     class Meta:
         db_table = "keyword_alerts_alerts"

--- a/mobile/lib/services/keyword_service.dart
+++ b/mobile/lib/services/keyword_service.dart
@@ -175,7 +175,8 @@ class KeywordService {
 
         _debugPrintResponse('DELETE', uri.toString(), response);
 
-        if (response.statusCode != 200) {
+        // 200 OK 또는 204 No Content 모두 성공
+        if (response.statusCode != 200 && response.statusCode != 204) {
           _handleHttpError(response, '키워드를 삭제할 수 없습니다.');
         }
       } catch (e) {
@@ -251,7 +252,8 @@ class KeywordService {
 
         _debugPrintResponse('DELETE', uri.toString(), response);
 
-        if (response.statusCode != 200) {
+        // 200 OK 또는 204 No Content 모두 성공
+        if (response.statusCode != 200 && response.statusCode != 204) {
           _handleHttpError(response, '알람을 삭제할 수 없습니다.');
         }
       } catch (e) {
@@ -373,7 +375,8 @@ class KeywordService {
 
         _debugPrintResponse('DELETE', uri.toString(), response);
 
-        if (response.statusCode != 200) {
+        // 200 OK 또는 204 No Content 모두 성공
+        if (response.statusCode != 200 && response.statusCode != 204) {
           _handleHttpError(response, 'FCM 토큰 해제에 실패했습니다.');
         }
 

--- a/mobile/lib/utils/network_error_handler.dart
+++ b/mobile/lib/utils/network_error_handler.dart
@@ -79,7 +79,7 @@ class NetworkErrorHandler {
       case 403:
         return '접근 권한이 없습니다.';
       case 404:
-        return '요청하신 정보를 찾을 수 없습니다.';
+        return '이미 삭제되었거나 존재하지 않는 항목이에요.';
       case 409:
         return '이미 처리된 요청입니다.';
       case 422:


### PR DESCRIPTION
## Summary
- Admin: KeywordAlert 모델 DB 스키마 불일치 수정
- Mobile: DELETE 요청 시 204 응답 처리 및 에러 메시지 개선

## 문제 및 해결

### Admin - is_sent 컬럼 에러
**에러**: `column keyword_alerts_alerts.is_sent does not exist`

**원인**: Django Admin 모델에 `is_sent` 필드가 정의되어 있으나 실제 DB에 해당 컬럼 없음

**해결**: 
- `is_sent` 필드 제거
- DB 스키마에 맞게 `matched_field`, `updated_at` 필드 추가

### Mobile - 키워드 삭제 실패
**에러**: `키워드 삭제실패: Exception: 이미 삭제되었거나 존재하지 않는 항목이에요.`

**원인**: 서버가 204 No Content를 반환하지만 Mobile은 200만 성공으로 처리

**해결**:
- DELETE 요청 시 200/204 모두 성공으로 처리
- 키워드 삭제, 알람 삭제, FCM 해제 모두 수정
- 404 에러 메시지를 사용자 친화적으로 변경

## Test plan
- [ ] Admin에서 KeywordAlert 목록 조회
- [ ] Admin에서 KeywordAlert 삭제
- [ ] Mobile에서 키워드 삭제
- [ ] Mobile에서 알람 삭제