### PR TITLE
fix(admin): KeywordAlert __str__에서 삭제된 캠페인 처리

### DIFF
--- a/admin/keyword_alerts/models.py
+++ b/admin/keyword_alerts/models.py
@@ -86,5 +86,8 @@ class KeywordAlert(models.Model):
         ordering = ["-created_at"]
 
     def __str__(self):
-        campaign_title = self.campaign.title[:30] if self.campaign and self.campaign.title else "(삭제된 캠페인)"
+        try:
+            campaign_title = self.campaign.title[:30] if self.campaign_id and self.campaign.title else "(삭제된 캠페인)"
+        except Exception:
+            campaign_title = "(삭제된 캠페인)"
         return f"{self.keyword.keyword} → {campaign_title}"


### PR DESCRIPTION
## Summary
- KeywordAlert의 `__str__` 메서드에서 삭제된 캠페인 참조 시 에러 수정

## 문제
**에러**: `KeywordAlert has no campaign.. Did you mean: 'campaign_id'`

**원인**: 
- `self.campaign` 접근 시 Django FK가 resolve를 시도
- 참조하는 캠페인이 삭제된 경우 `RelatedObjectDoesNotExist` 예외 발생

## 해결
- `campaign_id`로 먼저 NULL 체크
- `try-except`로 모든 예외 상황 처리

## Test plan
- [ ] Admin에서 Keyword 삭제 시 관련 Alert 표시 확인
- [ ] 삭제된 캠페인을 참조하는 Alert 표시 확인