### PR TITLE
fix(server): GORM 모델 DB 스키마와 동기화

### DIFF
--- a/server/internal/models/keyword_alert.go
+++ b/server/internal/models/keyword_alert.go
@@ -6,16 +6,17 @@ import (
 
 // FCMDevice represents FCM device tokens
 type FCMDevice struct {
-	ID        uint      `gorm:"primaryKey" json:"id"`
-	UserID    uint      `gorm:"index;not null" json:"user_id"`
-	Token     string    `gorm:"size:500;not null;uniqueIndex" json:"token"`
-	Platform  string    `gorm:"size:20;not null" json:"platform"`
-	IsActive  bool      `gorm:"default:true" json:"is_active"`
-	CreatedAt time.Time `gorm:"autoCreateTime" json:"created_at"`
-	UpdatedAt time.Time `gorm:"autoUpdateTime" json:"updated_at"`
+	ID                 uint      `gorm:"primaryKey" json:"id"`
+	UserID             *uint     `gorm:"index" json:"user_id"`
+	AnonymousSessionID *string   `gorm:"column:anonymous_session_id;size:255" json:"anonymous_session_id"`
+	FCMToken           string    `gorm:"column:fcm_token;size:500;not null;uniqueIndex" json:"fcm_token"`
+	DeviceType         string    `gorm:"column:device_type;size:20;not null" json:"device_type"`
+	IsActive           bool      `gorm:"default:true" json:"is_active"`
+	CreatedAt          time.Time `gorm:"autoCreateTime" json:"created_at"`
+	UpdatedAt          time.Time `gorm:"autoUpdateTime" json:"updated_at"`
 
 	// Relations
-	User User `gorm:"foreignKey:UserID" json:"user,omitempty"`
+	User *User `gorm:"foreignKey:UserID" json:"user,omitempty"`
 }
 
 func (FCMDevice) TableName() string {

--- a/server/internal/services/keyword_alert.go
+++ b/server/internal/services/keyword_alert.go
@@ -167,23 +167,23 @@ func (s *KeywordAlertService) DeleteAlert(userID, alertID uint) error {
 func (s *KeywordAlertService) RegisterFCM(userID uint, req *FCMRegisterRequest) (*models.FCMDevice, error) {
 	// Upsert: update if exists, create if not
 	var device models.FCMDevice
-	err := s.db.Where("token = ?", req.Token).First(&device).Error
+	err := s.db.Where("fcm_token = ?", req.Token).First(&device).Error
 
 	if err != nil {
 		// Create new
 		device = models.FCMDevice{
-			UserID:   userID,
-			Token:    req.Token,
-			Platform: req.Platform,
-			IsActive: true,
+			UserID:     &userID,
+			FCMToken:   req.Token,
+			DeviceType: req.Platform,
+			IsActive:   true,
 		}
 		if err := s.db.Create(&device).Error; err != nil {
 			return nil, err
 		}
 	} else {
 		// Update existing
-		device.UserID = userID
-		device.Platform = req.Platform
+		device.UserID = &userID
+		device.DeviceType = req.Platform
 		device.IsActive = true
 		if err := s.db.Save(&device).Error; err != nil {
 			return nil, err
@@ -195,7 +195,7 @@ func (s *KeywordAlertService) RegisterFCM(userID uint, req *FCMRegisterRequest) 
 
 // UnregisterFCM unregisters an FCM token
 func (s *KeywordAlertService) UnregisterFCM(userID uint, token string) error {
-	result := s.db.Where("user_id = ? AND token = ?", userID, token).Delete(&models.FCMDevice{})
+	result := s.db.Where("user_id = ? AND fcm_token = ?", userID, token).Delete(&models.FCMDevice{})
 	if result.RowsAffected == 0 {
 		return errors.New("device not found")
 	}

--- a/server/internal/services/keyword_match.go
+++ b/server/internal/services/keyword_match.go
@@ -202,7 +202,9 @@ func (s *KeywordMatchService) sendPushNotifications(ctx context.Context, alerts 
 	// Group devices by user
 	userDevices := make(map[uint][]string)
 	for _, device := range devices {
-		userDevices[device.UserID] = append(userDevices[device.UserID], device.Token)
+		if device.UserID != nil {
+			userDevices[*device.UserID] = append(userDevices[*device.UserID], device.FCMToken)
+		}
 	}
 
 	// Campaign name for push body
@@ -247,7 +249,7 @@ func (s *KeywordMatchService) sendPushNotifications(ctx context.Context, alerts 
 
 	// Deactivate failed tokens
 	if len(allFailedTokens) > 0 {
-		s.db.Model(&models.FCMDevice{}).Where("token IN ?", allFailedTokens).Update("is_active", false)
+		s.db.Model(&models.FCMDevice{}).Where("fcm_token IN ?", allFailedTokens).Update("is_active", false)
 		log.Printf("[KeywordMatch] Deactivated %d invalid tokens", len(allFailedTokens))
 	}
 


### PR DESCRIPTION
## Summary
- KeywordAlert 모델에서 `is_sent` 컬럼 제거, `matched_field`와 `updated_at` 추가
- FCMDevice 모델 컬럼명 수정: `token`→`fcm_token`, `platform`→`device_type`
- FCMDevice 모델에 `anonymous_session_id` 필드 추가, `user_id` nullable 처리
- 관련 서비스 코드 수정 (keyword_match.go, keyword_alert.go)

## Problem
- `is_sent` 컬럼이 DB에 없어서 키워드 알림 INSERT 실패
- FCM 토큰 조회 시 컬럼명 불일치로 빈 토큰이 반환되어 푸시 알림 실패

## Test plan
- [ ] 스크래퍼 실행 후 키워드 알림 생성 확인
- [ ] FCM 푸시 알림 수신 확인