### PR TITLE
fix(go-scraper): 캠페인 삭제 시 FK constraint 위반 해결

### DIFF
--- a/go-scraper/internal/cleanup/cleanup.go
+++ b/go-scraper/internal/cleanup/cleanup.go
@@ -71,7 +71,24 @@ func (c *Cleaner) Run(ctx context.Context) error {
 
 	log.Infof("삭제 대상: %d개 캠페인 (apply_deadline < %s)", count, today.Format("2006-01-02"))
 
-	// 배치 삭제 실행
+	// 1. 관련 알림의 campaign_id를 NULL로 설정 (FK constraint 해결)
+	nullifyQuery := `
+		UPDATE keyword_alerts_alerts
+		SET campaign_id = NULL
+		WHERE campaign_id IN (
+			SELECT id FROM campaign
+			WHERE apply_deadline IS NOT NULL
+			  AND apply_deadline < $1
+		)
+	`
+	nullifyResult, err := c.database.Pool.Exec(ctx, nullifyQuery, today)
+	if err != nil {
+		log.Warnf("알림 campaign_id NULL 설정 실패: %v", err)
+	} else if nullifyResult.RowsAffected() > 0 {
+		log.Infof("관련 알림 %d건의 campaign_id를 NULL로 설정", nullifyResult.RowsAffected())
+	}
+
+	// 2. 배치 삭제 실행
 	deleteQuery := `
 		DELETE FROM campaign
 		WHERE apply_deadline IS NOT NULL


### PR DESCRIPTION
## Summary
- 캠페인 삭제 시 발생하는 FK constraint 위반 오류 해결
- `keyword_alerts_alerts` 테이블의 `campaign_id` 참조로 인한 삭제 실패 방지

## Problem
```
ERROR: update or delete on table "campaign" violates foreign key constraint 
"keyword_alerts_alerts_campaign_id_e4ee7037_fk_campaign_id" on table "keyword_alerts_alerts"
```

## Solution
캠페인 삭제 전에 해당 캠페인을 참조하는 알림 레코드의 `campaign_id`를 NULL로 설정

## Changes

| 파일 | 수정 내용 |
|------|----------|
| `db/db.go` | SaveCampaigns에서 삭제 대상 ID 조회 후 알림 FK 처리 |
| `cleanup/cleanup.go` | 만료 캠페인 정리 시 알림 FK 처리 추가 |
| `cleanup/dedupe.go` | 중복 캠페인 삭제 시 알림 FK 처리 추가 |

## Test Plan
- [x] Go 빌드 성공
- [ ] inflexer 스크레이퍼 테스트