### PR TITLE
fix(server): 푸시 알림 중복 발송 방지

### DIFF
--- a/server/internal/services/keyword_match.go
+++ b/server/internal/services/keyword_match.go
@@ -259,27 +259,27 @@ func (s *KeywordMatchService) sendPushNotifications(ctx context.Context, alerts 
 }
 
 // ProcessCampaignKeywordMatchingByID processes keyword matching for a campaign by its ID
-// Returns the number of alerts created
-func (s *KeywordMatchService) ProcessCampaignKeywordMatchingByID(ctx context.Context, campaignID uint) int {
+// Returns the created alert IDs (for batch push notification)
+func (s *KeywordMatchService) ProcessCampaignKeywordMatchingByID(ctx context.Context, campaignID uint) []uint {
 	log.Printf("[KeywordMatch] Processing campaign by ID: %d", campaignID)
 
 	// Get campaign from DB
 	var campaign models.Campaign
 	if err := s.db.First(&campaign, campaignID).Error; err != nil {
 		log.Printf("[KeywordMatch] Failed to get campaign ID %d: %v", campaignID, err)
-		return 0
+		return nil
 	}
 
 	// Get all active keywords
 	var activeKeywords []models.Keyword
 	if err := s.db.Where("is_active = ?", true).Find(&activeKeywords).Error; err != nil {
 		log.Printf("[KeywordMatch] Failed to get active keywords: %v", err)
-		return 0
+		return nil
 	}
 
 	if len(activeKeywords) == 0 {
 		log.Printf("[KeywordMatch] No active keywords found")
-		return 0
+		return nil
 	}
 
 	log.Printf("[KeywordMatch] Active keywords count: %d", len(activeKeywords))
@@ -359,15 +359,136 @@ func (s *KeywordMatchService) ProcessCampaignKeywordMatchingByID(ctx context.Con
 	if len(alertsToCreate) > 0 {
 		if err := s.db.Create(&alertsToCreate).Error; err != nil {
 			log.Printf("[KeywordMatch] Failed to create alerts: %v", err)
-			return 0
+			return nil
 		}
 		log.Printf("[KeywordMatch] Created %d alerts for campaign ID: %d", len(alertsToCreate), campaign.ID)
 
-		// Send push notifications
-		go s.sendPushNotifications(ctx, alertsToCreate, &campaign)
-		return len(alertsToCreate)
+		// Return created alert IDs for batch push notification
+		alertIDs := make([]uint, len(alertsToCreate))
+		for i, alert := range alertsToCreate {
+			alertIDs[i] = alert.ID
+		}
+		return alertIDs
 	}
 
 	log.Printf("[KeywordMatch] No keywords matched for campaign ID: %d", campaign.ID)
-	return 0
+	return nil
+}
+
+// SendPushForRecentAlerts sends push notifications for recently created alerts
+// Call this after batch processing to avoid duplicate pushes
+func (s *KeywordMatchService) SendPushForRecentAlerts(ctx context.Context, alertIDs []uint) {
+	if len(alertIDs) == 0 {
+		return
+	}
+
+	log.Printf("[KeywordMatch] Sending push for %d alerts", len(alertIDs))
+
+	// Get alerts with keyword and campaign info
+	var alerts []models.KeywordAlert
+	if err := s.db.Preload("Keyword").Preload("Campaign").Where("id IN ?", alertIDs).Find(&alerts).Error; err != nil {
+		log.Printf("[KeywordMatch] Failed to get alerts: %v", err)
+		return
+	}
+
+	if len(alerts) == 0 {
+		return
+	}
+
+	fcm := firebase.GetFCMService()
+	if !fcm.IsInitialized() {
+		log.Println("[KeywordMatch] FCM not initialized, skipping push")
+		return
+	}
+
+	// Group alerts by user
+	userAlerts := make(map[uint][]models.KeywordAlert)
+	for _, alert := range alerts {
+		if alert.Keyword.UserID != nil {
+			userAlerts[*alert.Keyword.UserID] = append(userAlerts[*alert.Keyword.UserID], alert)
+		}
+	}
+
+	if len(userAlerts) == 0 {
+		log.Println("[KeywordMatch] No user alerts found for push")
+		return
+	}
+
+	// Get user IDs
+	userIDs := make([]uint, 0, len(userAlerts))
+	for userID := range userAlerts {
+		userIDs = append(userIDs, userID)
+	}
+
+	// Get active FCM tokens
+	var devices []models.FCMDevice
+	if err := s.db.Where("user_id IN ? AND is_active = ?", userIDs, true).Find(&devices).Error; err != nil {
+		log.Printf("[KeywordMatch] Failed to get FCM devices: %v", err)
+		return
+	}
+
+	if len(devices) == 0 {
+		log.Println("[KeywordMatch] No active FCM tokens found")
+		return
+	}
+
+	// Group devices by user
+	userDevices := make(map[uint][]string)
+	for _, device := range devices {
+		if device.UserID != nil {
+			userDevices[*device.UserID] = append(userDevices[*device.UserID], device.FCMToken)
+		}
+	}
+
+	// Send personalized push per user (only once per user)
+	var totalSuccess, totalFailure int
+	var allFailedTokens []string
+
+	for userID, tokens := range userDevices {
+		alerts := userAlerts[userID]
+		if len(alerts) == 0 || len(tokens) == 0 {
+			continue
+		}
+
+		// Count unique keywords
+		keywordSet := make(map[string]bool)
+		for _, alert := range alerts {
+			keywordSet[alert.Keyword.Keyword] = true
+		}
+
+		// Build push message
+		var title, body string
+		if len(keywordSet) == 1 {
+			// Single keyword
+			for kw := range keywordSet {
+				title = fmt.Sprintf("키워드 \"%s\" 매칭", kw)
+			}
+			body = fmt.Sprintf("%d개의 새로운 체험단이 등록되었습니다", len(alerts))
+		} else {
+			// Multiple keywords
+			title = fmt.Sprintf("%d개 키워드 매칭", len(keywordSet))
+			body = fmt.Sprintf("%d개의 새로운 체험단이 등록되었습니다", len(alerts))
+		}
+
+		data := map[string]string{
+			"type":         "keyword_alert",
+			"alert_count":  strconv.Itoa(len(alerts)),
+		}
+
+		result := fcm.SendPushMultiple(ctx, tokens, title, body, data)
+		totalSuccess += result.SuccessCount
+		totalFailure += result.FailureCount
+		allFailedTokens = append(allFailedTokens, result.FailedTokens...)
+
+		log.Printf("[KeywordMatch] Push sent to user %d - keywords: %d, alerts: %d, success: %d, failure: %d",
+			userID, len(keywordSet), len(alerts), result.SuccessCount, result.FailureCount)
+	}
+
+	log.Printf("[KeywordMatch] Push total - success: %d, failure: %d", totalSuccess, totalFailure)
+
+	// Deactivate failed tokens (only once)
+	if len(allFailedTokens) > 0 {
+		s.db.Model(&models.FCMDevice{}).Where("fcm_token IN ?", allFailedTokens).Update("is_active", false)
+		log.Printf("[KeywordMatch] Deactivated %d invalid tokens", len(allFailedTokens))
+	}
 }


### PR DESCRIPTION
## Summary
- 스크래퍼 배치 처리 시 발생하는 푸시 알림 중복 발송 문제 해결
- 사용자별 통합 푸시 발송으로 알림 스팸 방지

## Problem
```
[KeywordMatch] Push sent to user 17 - keyword: '김포', success: 1, failure: 0
[KeywordMatch] Push sent to user 17 - keyword: '김포', success: 1, failure: 0
... (22번 반복)
[KeywordMatch] Deactivated 3 invalid tokens
[KeywordMatch] Deactivated 3 invalid tokens
... (수십 번 반복)
```

- N개 캠페인이 매칭되면 N번 푸시 발송
- 여러 goroutine에서 동일 실패 토큰 반복 비활성화

## Solution

### 변경된 흐름
1. `ProcessCampaignKeywordMatchingByID`: 알림만 생성, alert ID 반환
2. 핸들러: 모든 캠페인 처리 후 alert ID 수집
3. `SendPushForRecentAlerts`: 사용자별로 통합 푸시 한 번 발송

### 개선된 푸시 메시지
| 상황 | 제목 | 본문 |
|------|------|------|
| 단일 키워드 | 키워드 "김포" 매칭 | 22개의 새로운 체험단이 등록되었습니다 |
| 복수 키워드 | 2개 키워드 매칭 | 35개의 새로운 체험단이 등록되었습니다 |

## Test Plan
- [x] Go 빌드 성공
- [ ] 스크래퍼 테스트 후 푸시 1회 발송 확인