### PR TITLE
fix(admin): Django 키워드 알림 모델을 DB 스키마와 동기화

### DIFF
--- a/admin/keyword_alerts/admin.py
+++ b/admin/keyword_alerts/admin.py
@@ -5,9 +5,9 @@ from .models import FCMDevice, Keyword, KeywordAlert
 
 @admin.register(FCMDevice)
 class FCMDeviceAdmin(ModelAdmin):
-    list_display = ("user", "platform", "is_active", "created_at")
-    list_filter = ("platform", "is_active")
-    search_fields = ("user__email", "token")
+    list_display = ("user", "device_type", "is_active", "created_at")
+    list_filter = ("device_type", "is_active")
+    search_fields = ("user__email", "fcm_token")
     ordering = ("-created_at",)
     readonly_fields = ("created_at", "updated_at")
 

--- a/admin/keyword_alerts/models.py
+++ b/admin/keyword_alerts/models.py
@@ -18,11 +18,14 @@ class FCMDevice(models.Model):
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,
+        null=True,
+        blank=True,
         related_name="fcm_devices",
         verbose_name="사용자",
     )
-    token = models.CharField(max_length=500, unique=True, verbose_name="FCM 토큰")
-    platform = models.CharField(max_length=20, choices=DEVICE_TYPE_CHOICES, default="android", verbose_name="플랫폼")
+    anonymous_session_id = models.CharField(max_length=255, null=True, blank=True, verbose_name="익명 세션 ID")
+    fcm_token = models.CharField(max_length=500, unique=True, db_column="fcm_token", verbose_name="FCM 토큰")
+    device_type = models.CharField(max_length=20, choices=DEVICE_TYPE_CHOICES, default="android", db_column="device_type", verbose_name="디바이스 타입")
     is_active = models.BooleanField(default=True, verbose_name="활성 상태")
     created_at = models.DateTimeField(auto_now_add=True, verbose_name="생성일시")
     updated_at = models.DateTimeField(auto_now=True, verbose_name="수정일시")
@@ -34,8 +37,8 @@ class FCMDevice(models.Model):
         verbose_name_plural = "FCM 디바이스"
 
     def __str__(self):
-        owner = self.user.email if self.user else "알 수 없음"
-        return f"{self.platform} - {owner}"
+        owner = self.user.email if self.user else "익명"
+        return f"{self.device_type} - {owner}"
 
 
 class Keyword(models.Model):
@@ -44,9 +47,12 @@ class Keyword(models.Model):
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,
+        null=True,
+        blank=True,
         related_name="keywords",
         verbose_name="사용자",
     )
+    anonymous_session_id = models.CharField(max_length=255, null=True, blank=True, verbose_name="익명 세션 ID")
     keyword = models.CharField(max_length=100, verbose_name="키워드")
     is_active = models.BooleanField(default=True, verbose_name="활성 상태")
     created_at = models.DateTimeField(auto_now_add=True, verbose_name="생성일시")
@@ -59,7 +65,7 @@ class Keyword(models.Model):
         verbose_name_plural = "관심 키워드"
 
     def __str__(self):
-        owner = self.user.email if self.user else "알 수 없음"
+        owner = self.user.email if self.user else "익명"
         return f"{self.keyword} - {owner}"
 
 
@@ -69,7 +75,9 @@ class KeywordAlert(models.Model):
     keyword = models.ForeignKey(Keyword, on_delete=models.CASCADE, related_name="alerts", verbose_name="키워드")
     campaign = models.ForeignKey(
         "campaigns.Campaign",
-        on_delete=models.CASCADE,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
         related_name="keyword_alerts",
         verbose_name="캠페인",
     )


### PR DESCRIPTION
## Summary
Django Admin의 키워드 알림 모델을 실제 DB 스키마와 동기화

## Problem
```
django.db.utils.ProgrammingError: column keyword_alerts_fcm_devices.token does not exist
```

## Changes

### FCMDevice
| 변경 전 | 변경 후 |
|---------|---------|
| `token` | `fcm_token` |
| `platform` | `device_type` |
| `user` (required) | `user` (nullable) |
| - | `anonymous_session_id` 추가 |

### Keyword
| 변경 전 | 변경 후 |
|---------|---------|
| `user` (required) | `user` (nullable) |
| - | `anonymous_session_id` 추가 |

### KeywordAlert
| 변경 전 | 변경 후 |
|---------|---------|
| `campaign` (CASCADE) | `campaign` (SET_NULL, nullable) |