### PR TITLE
fix(fcm): Android/iOS 플랫폼별 푸시 설정 추가

### DIFF
--- a/server/pkg/firebase/fcm.go
+++ b/server/pkg/firebase/fcm.go
@@ -155,6 +155,31 @@ func (s *FCMService) SendPushMultiple(ctx context.Context, tokens []string, titl
 		},
 		Data:   data,
 		Tokens: tokens,
+		Android: &messaging.AndroidConfig{
+			Priority: "high",
+			Notification: &messaging.AndroidNotification{
+				Title:       title,
+				Body:        body,
+				ClickAction: "FLUTTER_NOTIFICATION_CLICK",
+				ChannelID:   "keyword_alerts",
+			},
+		},
+		APNS: &messaging.APNSConfig{
+			Headers: map[string]string{
+				"apns-priority": "10",
+			},
+			Payload: &messaging.APNSPayload{
+				Aps: &messaging.Aps{
+					Alert: &messaging.ApsAlert{
+						Title: title,
+						Body:  body,
+					},
+					Sound:            "default",
+					ContentAvailable: true,
+					MutableContent:   true,
+				},
+			},
+		},
 	}
 
 	response, err := s.client.SendEachForMulticast(ctx, message)


### PR DESCRIPTION
## Summary
- Android: high priority, FLUTTER_NOTIFICATION_CLICK 액션, keyword_alerts 채널 ID 설정
- iOS: apns-priority 10, sound default, content-available/mutable-content 활성화
- 포그라운드/백그라운드 모두에서 푸시 알림 수신 가능하도록 FCM 메시지 설정 추가

## Changes
- `server/pkg/firebase/fcm.go`: SendPushMultiple 함수에 Android/iOS 플랫폼별 설정 추가

## Test plan
- [ ] 앱 포그라운드 상태에서 키워드 알림 푸시 수신 확인
- [ ] 앱 백그라운드 상태에서 키워드 알림 푸시 수신 확인
- [ ] 앱 종료 상태에서 키워드 알림 푸시 수신 확인