### PR TITLE
fix(alerts): 빈 keywordIDs 및 NULL campaign 처리

### DIFF
--- a/server/internal/services/keyword_alert.go
+++ b/server/internal/services/keyword_alert.go
@@ -112,10 +112,21 @@ func (s *KeywordAlertService) ListAlerts(userID uint, page, limit int) (*AlertLi
 	var keywordIDs []uint
 	s.db.Model(&models.Keyword{}).Where("user_id = ?", userID).Pluck("id", &keywordIDs)
 
+	// Return empty if no keywords
+	if len(keywordIDs) == 0 {
+		return &AlertListResponse{
+			Items:      []models.KeywordAlert{},
+			Total:      0,
+			Page:       page,
+			Limit:      limit,
+			TotalPages: 0,
+		}, nil
+	}
+
 	query := s.db.Model(&models.KeywordAlert{}).
 		Preload("Keyword").
-		Preload("Campaign").
-		Preload("Campaign.Category").
+		Preload("Campaign", "id IS NOT NULL").
+		Preload("Campaign.Category", "id IS NOT NULL").
 		Where("keyword_id IN ?", keywordIDs)
 
 	query.Count(&total)


### PR DESCRIPTION
## Summary
- ListAlerts에서 keywordIDs가 빈 배열일 때 빈 응답 반환
- Campaign이 NULL인 경우 Preload 조건 추가로 에러 방지

## Root Cause
- 키워드가 없는 사용자가 알림 목록 조회 시 `WHERE keyword_id IN ()` 쿼리 에러
- campaign_id가 NULL인 알림에서 Campaign.Category Preload 시 에러

## Test
- 키워드 없는 사용자 알림 목록 조회
- campaign이 삭제된 알림 조회