### PR TITLE
fix(fcm): FCM 등록 요청 필드명을 앱과 일치시킴

### DIFF
--- a/server/internal/services/keyword_alert.go
+++ b/server/internal/services/keyword_alert.go
@@ -26,8 +26,8 @@ type MarkReadRequest struct {
 }
 
 type FCMRegisterRequest struct {
-	Token    string `json:"token"`
-	Platform string `json:"platform"`
+	Token    string `json:"fcm_token"`
+	Platform string `json:"device_type"`
 }
 
 type FCMUnregisterRequest struct {


### PR DESCRIPTION
## Summary
- FCM 토큰 등록 API 필드명을 앱과 일치시킴
- `token` → `fcm_token`
- `platform` → `device_type`

## Root Cause
- 앱: `fcm_token`, `device_type` 필드로 요청
- 서버: `token`, `platform` 필드 기대
- 필드명 불일치로 빈 값이 저장되어 FCM 전송 실패