### PR TITLE
fix(admin): DATA_UPLOAD_MAX_NUMBER_FIELDS 3000으로 증가

### DIFF
--- a/admin/config/settings.py
+++ b/admin/config/settings.py
@@ -126,6 +126,9 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 # Default primary key field type
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
+# Data upload settings - Allow bulk operations in admin
+DATA_UPLOAD_MAX_NUMBER_FIELDS = 3000  # Default is 1000
+
 # Logging Configuration - Always log errors, debug in development
 LOGGING = {
     "version": 1,


### PR DESCRIPTION
## Summary
- 기본값 1000 → 3000으로 변경
- Admin에서 대량 항목 선택/삭제 시 TooManyFieldsSent 에러 해결

## Error
```
django.core.exceptions.TooManyFieldsSent: The number of GET/POST parameters exceeded settings.DATA_UPLOAD_MAX_NUMBER_FIELDS.
```