### PR TITLE
fix(mobile): 키워드 알람 화면 API 중복 호출 및 성능 개선

### DIFF
--- a/mobile/lib/models/keyword_models.dart
+++ b/mobile/lib/models/keyword_models.dart
@@ -188,6 +188,30 @@ class AlertInfo {
     if (d > 0) return 'D-$d';
     return '마감';
   }
+
+  /// 읽음 상태만 변경한 복사본 생성
+  AlertInfo copyWithRead(bool read) {
+    return AlertInfo(
+      id: id,
+      keyword: keyword,
+      campaignId: campaignId,
+      campaignTitle: campaignTitle,
+      campaignCompany: campaignCompany,
+      campaignOffer: campaignOffer,
+      campaignAddress: campaignAddress,
+      campaignLat: campaignLat,
+      campaignLng: campaignLng,
+      campaignImgUrl: campaignImgUrl,
+      campaignPlatform: campaignPlatform,
+      campaignApplyDeadline: campaignApplyDeadline,
+      campaignContentLink: campaignContentLink,
+      campaignChannel: campaignChannel,
+      matchedField: matchedField,
+      isRead: read,
+      createdAt: createdAt,
+      distance: distance,
+    );
+  }
 }
 
 /// 알람 목록 응답 데이터


### PR DESCRIPTION
## Summary
키워드 알람 화면에서 API가 중복 호출되는 문제 수정 및 성능 개선

## Changes
- **중복 호출 방지**: `_isLoadingInProgress` 플래그로 동시 다중 요청 차단
- **병렬 API 호출**: `Future.wait`으로 키워드/알림 목록 동시 로드
- **즉시 UI 업데이트**: 키워드 추가/삭제/읽음 처리 후 전체 리로드 대신 로컬 상태만 업데이트
- **코드 개선**: `AlertInfo.copyWithRead()` 메서드 추가로 중복 코드 제거
- **안정성**: `mounted` 체크 강화로 위젯 dispose 후 상태 변경 방지

## Before
- 화면 진입 시 API 여러 번 호출
- 키워드 추가/삭제 시 전체 데이터 리로드

## After
- 화면 진입 시 병렬로 1회만 호출
- 키워드 추가/삭제 시 로컬 상태만 업데이트 (API 재호출 없음)