### PR TITLE
fix(auth): SNS 로그인 지원을 위한 username unique 제약조건 제거

### DIFF
--- a/admin/users/models.py
+++ b/admin/users/models.py
@@ -50,7 +50,7 @@ class User(AbstractBaseUser, PermissionsMixin):
         ("anonymous", "익명"),
     ]
 
-    username = models.CharField(max_length=255, unique=True, editable=False, default="", verbose_name="사용자명")
+    username = models.CharField(max_length=255, editable=False, default="", verbose_name="사용자명")
     email = models.EmailField(verbose_name="이메일")
     login_method = models.CharField(
         max_length=20, choices=LOGIN_METHOD_CHOICES, default="email", verbose_name="로그인 방식"

--- a/server/internal/models/user.go
+++ b/server/internal/models/user.go
@@ -8,7 +8,7 @@ import (
 // DB: users
 type User struct {
 	ID           uint       `gorm:"primaryKey" json:"id"`
-	Username     string     `gorm:"column:username;size:255;not null;uniqueIndex:users_username_key" json:"username"`
+	Username     string     `gorm:"column:username;size:255;not null" json:"username"`
 	Email        string     `gorm:"column:email;size:255;not null" json:"email"`
 	Password     string     `gorm:"column:password;size:255;not null" json:"-"`
 	LoginMethod  string     `gorm:"column:login_method;size:20;not null" json:"login_method"`


### PR DESCRIPTION
## Summary
SNS 로그인(Kakao, Google, Apple) 사용자들이 동일한 username을 가질 수 있도록 username 필드의 unique 제약조건을 제거했습니다.

## Changes
- GORM User 모델에서 `uniqueIndex:users_username_key` 제거 (server/internal/models/user.go)
- Django Admin User 모델에서 `unique=True` 제거 (admin/users/models.py)

## Reason
각 SNS 제공자(Kakao, Google, Apple)가 같은 username을 사용할 수 있어야 하므로, username 필드에 대한 unique 제약조건을 제거해야 합니다.

## Test Plan
- [x] GORM 모델 변경 확인
- [x] Django Admin 모델 변경 확인
- [x] Go 코드 컴파일 테스트 통과
- [x] Python 코드 포맷 검사 통과