### PR TITLE
fix(server): SNS 로그인 에러 로깅 및 응답 개선

### DIFF
--- a/server/internal/handlers/auth.go
+++ b/server/internal/handlers/auth.go
@@ -178,14 +178,21 @@ func (h *AuthHandler) AnonymousSession(c *fiber.Ctx) error {
 func (h *AuthHandler) KakaoLogin(c *fiber.Ctx) error {
 	var req services.SNSLoginRequest
 	if err := c.BodyParser(&req); err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request body"})
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Invalid request body",
+			"detail": err.Error(),
+		})
 	}
 
 	response, err := h.service.KakaoLogin(req.AccessToken)
 	if err != nil {
-		// Log the error for debugging
-		c.Context().Logger().Printf("[KakaoLogin] Error: %v", err)
-		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": err.Error()})
+		// Log detailed error to console
+		c.Context().Logger().Printf("[KakaoLogin] Error: %v, Token (first 20 chars): %s", err, truncateString(req.AccessToken, 20))
+
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error": "Kakao login failed",
+			"detail": err.Error(),
+		})
 	}
 
 	return c.JSON(response)
@@ -202,17 +209,32 @@ func (h *AuthHandler) KakaoLogin(c *fiber.Ctx) error {
 func (h *AuthHandler) GoogleLogin(c *fiber.Ctx) error {
 	var req services.SNSLoginRequest
 	if err := c.BodyParser(&req); err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request body"})
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Invalid request body",
+			"detail": err.Error(),
+		})
 	}
 
 	response, err := h.service.GoogleLogin(req.AccessToken)
 	if err != nil {
-		// Log the error for debugging
-		c.Context().Logger().Printf("[GoogleLogin] Error: %v", err)
-		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": err.Error()})
+		// Log detailed error to console
+		c.Context().Logger().Printf("[GoogleLogin] Error: %v, Token (first 20 chars): %s", err, truncateString(req.AccessToken, 20))
+
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error": "Google login failed",
+			"detail": err.Error(),
+		})
 	}
 
 	return c.JSON(response)
+}
+
+// truncateString safely truncates a string to maxLen characters
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
 }
 
 // AppleLogin godoc
@@ -226,12 +248,21 @@ func (h *AuthHandler) GoogleLogin(c *fiber.Ctx) error {
 func (h *AuthHandler) AppleLogin(c *fiber.Ctx) error {
 	var req services.SNSLoginRequest
 	if err := c.BodyParser(&req); err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request body"})
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Invalid request body",
+			"detail": err.Error(),
+		})
 	}
 
 	response, err := h.service.AppleLogin(req.AccessToken)
 	if err != nil {
-		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": err.Error()})
+		// Log detailed error to console
+		c.Context().Logger().Printf("[AppleLogin] Error: %v, Token (first 20 chars): %s", err, truncateString(req.AccessToken, 20))
+
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error": "Apple login failed",
+			"detail": err.Error(),
+		})
 	}
 
 	return c.JSON(response)


### PR DESCRIPTION
## Summary
Google 로그인 401 에러 디버깅을 위해 SNS 로그인(Kakao, Google, Apple) 핸들러의 에러 로깅 및 응답을 개선했습니다.

## Changes
- **에러 응답 개선**: JSON 응답에 `error`와 `detail` 필드 분리
  - `error`: 간단한 에러 메시지 (예: "Google login failed")
  - `detail`: 상세 에러 정보 (서비스 레이어에서 반환된 에러 메시지)

- **로깅 강화**: 콘솔 로그에 토큰 일부(앞 20자) 출력
  - `truncateString` 헬퍼 함수 추가
  - 토큰 전체를 로그하지 않아 보안 유지

- **일관성**: Kakao, Google, Apple 모든 SNS 로그인에 동일한 패턴 적용

## Before
```json
{
  "error": "google 토큰 검증에 실패했습니다: ..."
}
```

**로그**: 에러 메시지 없음 (JSON 로그의 `error` 필드가 비어있음)

## After
```json
{
  "error": "Google login failed",
  "detail": "google 토큰 검증에 실패했습니다: google API returned status 401: ..."
}
```

**로그**: 
```
[GoogleLogin] Error: google 토큰 검증에 실패했습니다: ..., Token (first 20 chars): ya29.a0AfB_byC...
```

## Test Plan
- [ ] 서버 재배포 후 Google 로그인 시도
- [ ] 로그에서 상세 에러 메시지 확인
- [ ] JSON 응답에서 `error`와 `detail` 필드 확인
- [ ] 모바일 앱에서 에러 메시지 표시 테스트

## Related Issues
- Google 로그인 401 에러 원인 파악