### PR TITLE
fix(server): 이메일 인증코드 발송 API 응답 형식 수정

### DIFF
--- a/server/internal/handlers/auth.go
+++ b/server/internal/handlers/auth.go
@@ -48,7 +48,7 @@ func SetupAuthRoutes(router fiber.Router, db *database.DB, cfg *config.Config) {
 // @Accept json
 // @Produce json
 // @Param request body services.SendEmailCodeRequest true "Email"
-// @Success 200 {object} map[string]string
+// @Success 200 {object} services.EmailCodeSentResponse
 // @Router /auth/email/send-code [post]
 func (h *AuthHandler) SendEmailCode(c *fiber.Ctx) error {
 	var req services.SendEmailCodeRequest
@@ -60,7 +60,10 @@ func (h *AuthHandler) SendEmailCode(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
 	}
 
-	return c.JSON(fiber.Map{"message": "Verification code sent"})
+	return c.JSON(services.EmailCodeSentResponse{
+		Message:   "Verification code sent",
+		ExpiresIn: 600, // 10 minutes in seconds
+	})
 }
 
 // VerifyEmailCode godoc

--- a/server/internal/services/auth.go
+++ b/server/internal/services/auth.go
@@ -56,6 +56,11 @@ type SNSLoginRequest struct {
 	AccessToken string `json:"access_token"`
 }
 
+type EmailCodeSentResponse struct {
+	Message   string `json:"message"`
+	ExpiresIn int    `json:"expires_in"` // seconds
+}
+
 // AppleLoginRequest for Apple Sign In (identity_token + optional authorization_code)
 type AppleLoginRequest struct {
 	IdentityToken     string `json:"identity_token"`


### PR DESCRIPTION
## Summary
모바일 앱과의 API 계약을 맞추기 위해 이메일 인증코드 발송 API 응답에 `expires_in` 필드를 추가했습니다.

## Problem
모바일 앱에서 이메일 인증코드 발송 후 "오류가 발생했다"는 메시지가 표시되었습니다.

**원인**: 서버 응답에 모바일 앱이 필요로 하는 `expires_in` 필드가 없었습니다.

## Changes
- **새로운 응답 타입 추가**: `EmailCodeSentResponse`
  - `message`: string - 발송 확인 메시지
  - `expires_in`: int - 만료 시간(초 단위)

- **핸들러 수정**: `/v1/auth/email/send-code`
  - 구조화된 응답 타입 사용
  - `expires_in: 600` (10분) 명시

## Before
```json
{
  "message": "Verification code sent"
}
```

**모바일 앱 에러**: `expires_in` 필드를 파싱하지 못해 에러 표시

## After
```json
{
  "message": "Verification code sent",
  "expires_in": 600
}
```

**모바일 앱**: 정상적으로 응답 파싱 및 UI 표시

## Test Plan
- [x] 서버 코드 변경 완료
- [ ] 서버 재배포 후 모바일 앱에서 이메일 인증 테스트
- [ ] 응답 형식 확인
- [ ] 모바일 UI에 에러 없이 정상 표시 확인

## API Documentation
Swagger 문서도 업데이트되어 `@Success 200 {object} services.EmailCodeSentResponse`로 명시되었습니다.