### PR TITLE
fix(server): 이메일 인증코드 검증 API 응답에 verification_token 필드 추가

### DIFF
--- a/server/internal/handlers/auth.go
+++ b/server/internal/handlers/auth.go
@@ -72,7 +72,7 @@ func (h *AuthHandler) SendEmailCode(c *fiber.Ctx) error {
 // @Accept json
 // @Produce json
 // @Param request body services.VerifyEmailCodeRequest true "Email and code"
-// @Success 200 {object} map[string]bool
+// @Success 200 {object} services.EmailVerifyCodeResponse
 // @Router /auth/email/verify-code [post]
 func (h *AuthHandler) VerifyEmailCode(c *fiber.Ctx) error {
 	var req services.VerifyEmailCodeRequest
@@ -80,12 +80,15 @@ func (h *AuthHandler) VerifyEmailCode(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request body"})
 	}
 
-	valid, err := h.service.VerifyEmailCode(req.Email, req.Code)
+	verificationToken, err := h.service.VerifyEmailCode(req.Email, req.Code)
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
 	}
 
-	return c.JSON(fiber.Map{"verified": valid})
+	return c.JSON(services.EmailVerifyCodeResponse{
+		Verified:          true,
+		VerificationToken: verificationToken,
+	})
 }
 
 // Signup godoc


### PR DESCRIPTION
## Summary
모바일 앱과의 API 계약을 맞추기 위해 이메일 인증코드 검증 API 응답에 `verification_token` 필드를 추가했습니다.

## Problem
서버는 인증에 성공했지만(200 OK) 모바일 앱에서 "오류가 발생했습니다" 메시지가 표시되었습니다.

**원인**: 서버 응답에 모바일 앱이 필요로 하는 `verification_token` 필드가 없어서 파싱 에러 발생

## Changes

### 1. 새로운 응답 타입 추가
```go
type EmailVerifyCodeResponse struct {
    Verified          bool   `json:"verified"`
    VerificationToken string `json:"verification_token"`
}
```

### 2. VerifyEmailCode 함수 수정
- 반환 타입 변경: `(bool, error)` → `(string, error)`
- UUID 기반 verification_token 생성
- DB에 verification_token 저장
- 상세 로깅 추가

### 3. 핸들러 응답 구조화
- 구조화된 응답 타입 사용
- Swagger 문서 업데이트

## Before
**서버 응답:**
```json
{
  "verified": true
}
```

**모바일 앱**: `verification_token` 필드 파싱 실패 → "오류가 발생했습니다" 표시

## After
**서버 응답:**
```json
{
  "verified": true,
  "verification_token": "550e8400-e29b-41d4-a716-446655440000"
}
```

**모바일 앱**: 정상적으로 응답 파싱 → 회원가입 단계로 진행

## Logs Example
```
[VerifyEmailCode] Attempting to verify - Email: user@example.com, Code: 500049
[VerifyEmailCode] Code verified successfully for: user@example.com, Token: 550e8400-e29b-41d4-a716-446655440000
```

## Benefits
1. ✅ 모바일 앱과 서버 간 API 계약 일치
2. ✅ 이메일 인증 완료 후 회원가입 진행 가능
3. ✅ verification_token으로 인증 여부 추적 가능
4. ✅ 보안 강화 (UUID 기반 토큰)

## Test Plan
- [ ] 서버 재배포
- [ ] 모바일 앱에서 이메일 인증 테스트
- [ ] 응답 형식 확인
- [ ] 회원가입까지 정상 진행 확인

## Related Issues
- 모바일 앱 "오류가 발생했습니다" 메시지 해결
- 이메일 인증 → 회원가입 플로우 정상화