### PR TITLE
feat(auth): Gmail SMTP 기반 이메일 인증코드 발송 기능 구현

### DIFF
--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -41,6 +41,14 @@ type Config struct {
 
 	// Internal API
 	InternalAPIKey string
+
+	// Email (SMTP)
+	EmailHost         string
+	EmailPort         int
+	EmailHostUser     string
+	EmailHostPassword string
+	EmailUseTLS       bool
+	DefaultFromEmail  string
 }
 
 func Load() *Config {
@@ -79,6 +87,14 @@ func Load() *Config {
 
 		// Internal API (Scraper → Server 통신용, API_SECRET_KEY 재사용)
 		InternalAPIKey: getEnvWithFallback("INTERNAL_API_KEY", "API_SECRET_KEY", ""),
+
+		// Email (SMTP)
+		EmailHost:         getEnv("EMAIL_HOST", "smtp.gmail.com"),
+		EmailPort:         getEnvAsInt("EMAIL_PORT", 587),
+		EmailHostUser:     getEnv("EMAIL_HOST_USER", ""),
+		EmailHostPassword: getEnv("EMAIL_HOST_PASSWORD", ""),
+		EmailUseTLS:       getEnvAsBool("EMAIL_USE_TLS", true),
+		DefaultFromEmail:  getEnv("DEFAULT_FROM_EMAIL", ""),
 	}
 }
 
@@ -104,6 +120,15 @@ func getEnvAsInt(key string, defaultValue int) int {
 	if value, exists := os.LookupEnv(key); exists {
 		if intValue, err := strconv.Atoi(value); err == nil {
 			return intValue
+		}
+	}
+	return defaultValue
+}
+
+func getEnvAsBool(key string, defaultValue bool) bool {
+	if value, exists := os.LookupEnv(key); exists {
+		if boolValue, err := strconv.ParseBool(value); err == nil {
+			return boolValue
 		}
 	}
 	return defaultValue

--- a/server/pkg/email/smtp.go
+++ b/server/pkg/email/smtp.go
@@ -1,0 +1,141 @@
+package email
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/smtp"
+	"strings"
+
+	"github.com/ggorockee/reviewmaps/server/internal/config"
+)
+
+type EmailService struct {
+	cfg *config.Config
+}
+
+func NewEmailService(cfg *config.Config) *EmailService {
+	return &EmailService{cfg: cfg}
+}
+
+// SendVerificationCode sends email verification code
+func (s *EmailService) SendVerificationCode(toEmail, code string) error {
+	subject := "[ReviewMaps] 이메일 인증코드"
+	body := fmt.Sprintf(`
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+</head>
+<body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+    <div style="max-width: 600px; margin: 0 auto; padding: 20px;">
+        <h2 style="color: #4CAF50;">ReviewMaps 이메일 인증</h2>
+        <p>안녕하세요,</p>
+        <p>ReviewMaps 회원가입을 위한 인증코드입니다.</p>
+        <div style="background-color: #f4f4f4; padding: 20px; border-radius: 5px; text-align: center; margin: 20px 0;">
+            <h1 style="color: #4CAF50; font-size: 36px; margin: 0; letter-spacing: 5px;">%s</h1>
+        </div>
+        <p>인증코드는 <strong>10분간</strong> 유효합니다.</p>
+        <p>본인이 요청하지 않은 경우, 이 이메일을 무시하셔도 됩니다.</p>
+        <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
+        <p style="color: #999; font-size: 12px;">
+            이 이메일은 ReviewMaps에서 자동으로 발송되었습니다.<br>
+            문의사항이 있으시면 고객센터로 연락주세요.
+        </p>
+    </div>
+</body>
+</html>
+`, code)
+
+	return s.sendEmail(toEmail, subject, body)
+}
+
+// sendEmail sends an email using SMTP
+func (s *EmailService) sendEmail(to, subject, body string) error {
+	from := s.cfg.DefaultFromEmail
+	if from == "" {
+		from = s.cfg.EmailHostUser
+	}
+
+	// Set up authentication
+	auth := smtp.PlainAuth("", s.cfg.EmailHostUser, s.cfg.EmailHostPassword, s.cfg.EmailHost)
+
+	// Build message
+	headers := make(map[string]string)
+	headers["From"] = from
+	headers["To"] = to
+	headers["Subject"] = subject
+	headers["MIME-Version"] = "1.0"
+	headers["Content-Type"] = "text/html; charset=UTF-8"
+
+	message := ""
+	for k, v := range headers {
+		message += fmt.Sprintf("%s: %s\r\n", k, v)
+	}
+	message += "\r\n" + body
+
+	// Server address
+	addr := fmt.Sprintf("%s:%d", s.cfg.EmailHost, s.cfg.EmailPort)
+
+	// Send email
+	if s.cfg.EmailUseTLS {
+		return s.sendMailTLS(addr, auth, from, []string{to}, []byte(message))
+	}
+
+	return smtp.SendMail(addr, auth, from, []string{to}, []byte(message))
+}
+
+// sendMailTLS sends email with TLS
+func (s *EmailService) sendMailTLS(addr string, auth smtp.Auth, from string, to []string, msg []byte) error {
+	// Connect to server
+	host := strings.Split(addr, ":")[0]
+	conn, err := tls.Dial("tcp", addr, &tls.Config{
+		ServerName: host,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to dial: %w", err)
+	}
+	defer conn.Close()
+
+	client, err := smtp.NewClient(conn, host)
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+	defer client.Close()
+
+	// Auth
+	if auth != nil {
+		if err = client.Auth(auth); err != nil {
+			return fmt.Errorf("failed to authenticate: %w", err)
+		}
+	}
+
+	// Set sender
+	if err = client.Mail(from); err != nil {
+		return fmt.Errorf("failed to set sender: %w", err)
+	}
+
+	// Set recipients
+	for _, addr := range to {
+		if err = client.Rcpt(addr); err != nil {
+			return fmt.Errorf("failed to set recipient: %w", err)
+		}
+	}
+
+	// Send data
+	w, err := client.Data()
+	if err != nil {
+		return fmt.Errorf("failed to get data writer: %w", err)
+	}
+
+	_, err = w.Write(msg)
+	if err != nil {
+		return fmt.Errorf("failed to write message: %w", err)
+	}
+
+	err = w.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close data writer: %w", err)
+	}
+
+	return client.Quit()
+}


### PR DESCRIPTION
## Summary
- Gmail SMTP 연동하여 실제 이메일 인증코드 발송 기능 구현
- 기존 TODO 상태였던 이메일 전송을 완전한 SMTP 서비스로 구현
- TLS 암호화 지원 및 HTML 템플릿 기반 이메일 발송

## Changes
### 1. Email Service 패키지 생성 (`server/pkg/email/smtp.go`)
- `EmailService` 구조체 구현
- `SendVerificationCode`: 인증코드 이메일 발송 (HTML 템플릿)
- `sendEmail`: SMTP 이메일 전송 로직
- `sendMailTLS`: TLS 암호화 SMTP 연결

### 2. Config 확장 (`server/internal/config/config.go`)
- 이메일 SMTP 설정 필드 추가
  - `EmailHost`, `EmailPort`, `EmailHostUser`, `EmailHostPassword`
  - `EmailUseTLS`, `DefaultFromEmail`
- 환경변수 로드 로직 구현

### 3. AuthService 통합 (`server/internal/services/auth.go`)
- EmailService를 AuthService에 통합
- SendEmailCode에서 Go routine으로 비동기 이메일 발송
- 발송 성공/실패 로그 추가

## Environment Variables
```
EMAIL_HOST=smtp.gmail.com
EMAIL_PORT=587
EMAIL_HOST_USER=your-email@gmail.com
EMAIL_HOST_PASSWORD=your-app-password
EMAIL_USE_TLS=true
DEFAULT_FROM_EMAIL=noreply@reviewmaps.com
```

## Test Plan
- [x] 이메일 발송 코드 구현 완료
- [ ] 환경변수 설정 후 실제 이메일 수신 테스트
- [ ] 인증코드 검증 플로우 확인
- [ ] 모바일 앱에서 회원가입 전체 플로우 테스트

## Technical Details
- **HTML 템플릿**: 한글 이메일 템플릿 (인증코드 10분 유효)
- **비동기 처리**: Go routine으로 이메일 발송하여 API 응답 속도 유지
- **TLS 암호화**: Gmail SMTP TLS 연결 지원
- **에러 처리**: 발송 실패 시 로그 기록 (사용자 응답에는 영향 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)