### PR TITLE
feat(web): Docker 이미지 빌드 및 CI/CD 파이프라인 구현

### DIFF
--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -1,0 +1,134 @@
+name: Web CI/CD
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "web/**"
+      - ".github/workflows/ci-web.yml"
+
+# infra repo 동시 업데이트 방지
+concurrency:
+  group: reviewmaps-infra-update
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: "20"
+  DOCKER_IMAGE: ggorockee/reviewmaps-web
+  INFRA_REPO: ggorockee/infra
+  VALUES_FILE_PATH: charts/helm/prod/reviewmaps/values.yaml
+
+jobs:
+  # 린트 및 빌드 테스트
+  lint-and-build:
+    name: Lint & Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./web
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Build application
+        run: npm run build
+        env:
+          NEXT_TELEMETRY_DISABLED: 1
+
+  # Docker 빌드 및 푸시 (main 브랜치 푸시 시에만)
+  build-and-push:
+    name: Build & Push Docker
+    runs-on: ubuntu-latest
+    needs: lint-and-build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    outputs:
+      image_tag: ${{ steps.meta.outputs.tag }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Generate image tag
+        id: meta
+        run: |
+          TAG=$(date +%Y%m%d)-$(git rev-parse --short HEAD)
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./web
+          push: true
+          tags: |
+            ${{ env.DOCKER_IMAGE }}:${{ steps.meta.outputs.tag }}
+            ${{ env.DOCKER_IMAGE }}:latest
+
+  # 매니페스트 업데이트 (ArgoCD GitOps)
+  update-manifest:
+    name: Update Kubernetes Manifest
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout App Repo for script
+        uses: actions/checkout@v4
+
+      - name: Checkout Infra Repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.INFRA_REPO }}
+          token: ${{ secrets.INFRA_GITHUB_TOKEN }}
+          ref: main
+          path: "infra"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install ruamel.yaml
+
+      - name: Update values.yaml
+        run: |
+          python .github/workflows/scripts/update_values.py \
+            infra/${{ env.VALUES_FILE_PATH }} \
+            web \
+            "${{ needs.build-and-push.outputs.image_tag }}"
+
+      - name: Commit and push changes
+        working-directory: ./infra
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add ${{ env.VALUES_FILE_PATH }}
+
+          if git diff --staged --quiet; then
+            echo "No changes to commit in values.yaml."
+            exit 0
+          fi
+
+          git commit -m "ci: Update reviewmaps-web image tag to ${{ needs.build-and-push.outputs.image_tag }}"
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ scrape/.env
 server_backup/
 docker-compose.yml
 my_req.txt
+my_request.txt

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+.next
+.git
+.gitignore
+README.md
+npm-debug.log
+.DS_Store
+*.md
+.env*.local

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,50 @@
+# Dependencies stage
+FROM node:20-alpine AS deps
+
+WORKDIR /app
+
+# Install dependencies based on package-lock.json
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Builder stage
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# Copy dependencies from deps stage
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# Next.js telemetry 비활성화
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Build Next.js application
+RUN npm run build
+
+# Runner stage
+FROM node:20-alpine AS runner
+
+WORKDIR /app
+
+# Set production environment
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Create non-root user
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+# Copy built application
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+CMD ["node", "server.js"]

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
Web 프론트엔드를 위한 Docker 이미지 빌드 및 CI/CD 파이프라인을 구현했습니다.

## Changes
- ✅ Next.js 16 standalone 모드 Dockerfile 추가
- ✅ GitHub Actions workflow 생성
  - Lint 및 Build 검증
  - Docker Hub에 이미지 푸시 (ggorockee/reviewmaps-web)
  - Infra repo values.yaml 자동 업데이트 (GitOps)
- ✅ .dockerignore 추가
- ✅ next.config.ts에 standalone 출력 모드 설정

## Docker Image
- **Image**: `ggorockee/reviewmaps-web`
- **Tag Format**: `YYYYMMDD-{git-short-hash}`
- **Latest Tag**: 항상 최신 이미지 유지

## Test Plan
- [x] Dockerfile 빌드 가능 확인
- [x] GitHub Actions workflow 문법 검증
- [ ] PR 머지 후 CI/CD 파이프라인 동작 확인
- [ ] Infra repo에 values.yaml 업데이트 확인

## Related
- Server CI/CD: `.github/workflows/ci-server.yml`
- Mobile CI/CD: (별도 저장소)

🤖 Generated with [Claude Code](https://claude.com/claude-code)