### PR TITLE
fix(mobile): 알림 화면 탭 전환 시 AppBar 버튼 갱신 문제 해결

### DIFF
--- a/mobile/lib/screens/notification_screen.dart
+++ b/mobile/lib/screens/notification_screen.dart
@@ -87,6 +87,15 @@ class _NotificationScreenState extends State<NotificationScreen>
   }
 
   void _onTabChanged() {
+    // 탭 변경 시 AppBar 버튼 업데이트를 위해 setState 호출
+    setState(() {
+      // 선택 모드 해제
+      if (_isSelectionMode) {
+        _isSelectionMode = false;
+        _selectedAlertIds.clear();
+      }
+    });
+
     if (_tabController.index == 1 && _alerts.isEmpty && !_isAlertsLoading) {
       _loadAlerts();
     }


### PR DESCRIPTION
## 수정 사항

### 탭 전환 시 setState 호출 추가
- `_onTabChanged()` 메서드에 `setState()` 추가
- 탭 전환 시 AppBar의 삭제 버튼들이 즉시 표시되도록 수정  
- 탭 전환 시 선택 모드 자동 해제 및 선택 항목 초기화

## 해결된 이슈
- ✅ 알림 기록 탭으로 전환 시 "선택", "전체 삭제" 버튼이 즉시 표시됨
- ✅ 선택 모드 활성화 시 탭 전환하면 자동으로 선택 모드 해제됨
- ✅ 탭 전환 시 AppBar가 올바른 상태로 즉시 렌더링됨

## 기술적 세부사항
- TabController의 리스너에서 setState 호출하여 UI 강제 갱신
- 탭 전환 시 일관된 UX를 위해 선택 모드 초기화

## 변경된 파일
- `mobile/lib/screens/notification_screen.dart` (9줄 추가)

## 테스트
- ✅ flutter analyze 통과 (1개 info 레벨 경고만 존재)