### PR TITLE
feat(server): 알림 기록 최대 개수를 20개에서 1000개로 증가

### DIFF
--- a/server/internal/handlers/keyword_alert.go
+++ b/server/internal/handlers/keyword_alert.go
@@ -139,7 +139,7 @@ func (h *KeywordAlertHandler) ToggleKeyword(c *fiber.Ctx) error {
 func (h *KeywordAlertHandler) ListAlerts(c *fiber.Ctx) error {
 	userID := c.Locals("userID").(uint)
 	page, _ := strconv.Atoi(c.Query("page", "1"))
-	limit, _ := strconv.Atoi(c.Query("limit", "20"))
+	limit, _ := strconv.Atoi(c.Query("limit", "1000"))
 
 	response, err := h.service.ListAlerts(userID, page, limit)
 	if err != nil {


### PR DESCRIPTION
## 변경 사항

### 알림 기록 limit 기본값 변경
- 기존: 20개
- 변경: 1000개
- 3일 필터는 유지 (3일 지난 알림은 자동으로 API에서 제외)

## 효과
- ✅ 사용자가 더 많은 알림 기록을 볼 수 있음
- ✅ 3일 지난 알림은 자동으로 화면에서 제거됨
- ✅ 페이지네이션 지원으로 성능 문제 없음

## 기술적 세부사항
- `ListAlerts` 핸들러의 기본 limit 값을 20 → 1000으로 변경
- `created_at >= NOW() - INTERVAL '3 days'` 필터 유지
- 클라이언트가 limit 파라미터를 지정하지 않으면 1000개까지 조회 가능

## 변경된 파일
- `server/internal/handlers/keyword_alert.go` (1줄 수정)

## 테스트
- ✅ Go 빌드 성공