### PR TITLE
feat(server,admin): 알림 보관 일수 설정 기능 추가

### DIFF
--- a/admin/app_config/admin.py
+++ b/admin/app_config/admin.py
@@ -22,11 +22,21 @@ class AppVersionAdmin(ModelAdmin):
 
 @admin.register(AppSetting)
 class AppSettingAdmin(ModelAdmin):
-    list_display = ("key", "value", "is_active", "updated_at")
+    list_display = ("key", "get_value_display", "is_active", "updated_at")
     list_filter = ("is_active",)
     search_fields = ("key", "description")
     ordering = ("key",)
     readonly_fields = ("created_at", "updated_at")
+
+    def get_value_display(self, obj):
+        """사람이 읽기 쉬운 형태로 value 표시"""
+        if obj.key == "keyword_limit":
+            return f"{obj.value} 개"
+        elif obj.key == "alert_retention_days":
+            return f"{obj.value} 일"
+        return str(obj.value)
+
+    get_value_display.short_description = "설정 값"
 
 
 @admin.register(RateLimitConfig)

--- a/server/internal/handlers/app_config.go
+++ b/server/internal/handlers/app_config.go
@@ -25,6 +25,8 @@ func SetupAppConfigRoutes(router fiber.Router, db *database.DB) {
 	router.Get("/settings/:key", h.GetSetting)
 	router.Get("/settings/keyword-limit", h.GetKeywordLimit)
 	router.Put("/settings/keyword-limit", h.SetKeywordLimit)
+	router.Get("/settings/alert-retention-days", h.GetAlertRetentionDays)
+	router.Put("/settings/alert-retention-days", h.SetAlertRetentionDays)
 }
 
 // GetAdConfigs godoc
@@ -141,4 +143,43 @@ func (h *AppConfigHandler) SetKeywordLimit(c *fiber.Ctx) error {
 	}
 
 	return c.JSON(fiber.Map{"limit": req.Limit})
+}
+
+// GetAlertRetentionDays godoc
+// @Summary Get alert retention days setting
+// @Tags app-config
+// @Accept json
+// @Produce json
+// @Success 200 {object} map[string]int
+// @Router /app-config/settings/alert-retention-days [get]
+func (h *AppConfigHandler) GetAlertRetentionDays(c *fiber.Ctx) error {
+	days, err := h.service.GetAlertRetentionDays()
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	return c.JSON(fiber.Map{"days": days})
+}
+
+// SetAlertRetentionDays godoc
+// @Summary Set alert retention days setting
+// @Tags app-config
+// @Accept json
+// @Produce json
+// @Param request body map[string]int true "Days value"
+// @Success 200 {object} map[string]int
+// @Router /app-config/settings/alert-retention-days [put]
+func (h *AppConfigHandler) SetAlertRetentionDays(c *fiber.Ctx) error {
+	var req struct {
+		Days int `json:"days"`
+	}
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request body"})
+	}
+
+	if err := h.service.SetAlertRetentionDays(req.Days); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	return c.JSON(fiber.Map{"days": req.Days})
 }

--- a/server/internal/services/keyword_alert.go
+++ b/server/internal/services/keyword_alert.go
@@ -123,12 +123,16 @@ func (s *KeywordAlertService) ListAlerts(userID uint, page, limit int) (*AlertLi
 		}, nil
 	}
 
+	// Get alert retention days from app settings (default 3 days)
+	appConfigService := NewAppConfigService(s.db)
+	retentionDays, _ := appConfigService.GetAlertRetentionDays()
+
 	query := s.db.Model(&models.KeywordAlert{}).
 		Preload("Keyword").
 		Preload("Campaign", "id IS NOT NULL").
 		Preload("Campaign.Category", "id IS NOT NULL").
 		Where("keyword_id IN ?", keywordIDs).
-		Where("created_at >= NOW() - INTERVAL '3 days'")
+		Where("created_at >= NOW() - INTERVAL '? days'", retentionDays)
 
 	query.Count(&total)
 


### PR DESCRIPTION
## Summary
알림 보관 일수를 Django Admin에서 제어할 수 있는 설정 기능을 추가했습니다.

## Changes

### Server (Go Fiber)
- **AppConfigService**: 
  - `GetAlertRetentionDays()`: 알림 보관 일수 조회 (기본값 3일)
  - `SetAlertRetentionDays()`: 알림 보관 일수 설정 저장
- **API Endpoints**:
  - `GET /v1/app-config/settings/alert-retention-days`: 현재 설정 조회
  - `PUT /v1/app-config/settings/alert-retention-days`: 설정 업데이트
- **KeywordAlertService**: 
  - `ListAlerts()` 메서드에서 하드코딩된 3일 → 동적 설정값 사용
  - `WHERE created_at >= NOW() - INTERVAL '? days'` 쿼리로 동적 필터링

### Admin (Django)
- **AppSettingAdmin UI 개선**:
  - `get_value_display()` 메서드로 사람이 읽기 쉬운 표시
  - `alert_retention_days`: "N 일" 형식
  - `keyword_limit`: "N 개" 형식

## Database Schema
| 컬럼 | 값 예시 |
|------|---------|
| key | "alert_retention_days" |
| value | `3` (JSON number) |
| description | "알림 보관 일수 (일)" |
| is_active | `true` |

## Usage

### Django Admin에서 설정
1. Admin → App Config → App Settings
2. "alert_retention_days" 키로 새 설정 생성
3. value에 숫자 입력 (예: 7)
4. 저장 시 즉시 적용됨

### API 사용
```bash
# 현재 설정 조회
GET /v1/app-config/settings/alert-retention-days
Response: {"days": 3}

# 설정 변경
PUT /v1/app-config/settings/alert-retention-days
Body: {"days": 7}
Response: {"days": 7}
```

## Default Behavior
- 설정이 없을 경우: 기본값 3일 사용
- 오류 발생 시: 기본값 3일로 폴백

## Benefits
✅ 하드코딩된 3일 제한 제거  
✅ 관리자가 유연하게 보관 정책 조정 가능  
✅ 즉시 적용으로 재배포 불필요  
✅ 기본값 보장으로 안전한 폴백

## Testing
- [x] Go build 성공
- [x] Python formatting 확인 (Ruff)
- [ ] Admin UI에서 설정 생성/수정 테스트
- [ ] API 엔드포인트 동작 확인
- [ ] 알림 목록 필터링 동작 확인

## Related Issues
#212 (알림 시스템 개선 요청)