### PR TITLE
release(mobile): 버전 2.0.5+78 업데이트

### DIFF
--- a/mobile/lib/config/app_version.dart
+++ b/mobile/lib/config/app_version.dart
@@ -14,7 +14,7 @@ class AppVersion {
   ///
   /// 새 버전 배포 시 이 값을 업데이트합니다.
   /// Semantic Versioning (major.minor.patch) 형식을 따릅니다.
-  static const String current = '2.0.4';
+  static const String current = '2.0.5';
 
   /// 버전 문자열을 파싱하여 비교 가능한 형태로 변환
   ///

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -10,6 +10,9 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # appstore.reviewer@review-maps.com
 # ReviewMaps2025
 
+# 계정 삭제 안내:
+# https://review-maps.com/privacy#account-deletion
+
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -25,10 +28,10 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # of the product and file versions while build-number is used as the build suffix.
 
 # ios
-# version: 2.0.4+1
+# version: 2.0.5+1
 
 # # android
-version: 2.0.4+76
+version: 2.0.5+78
 
 # minversion: 2.0.2
 


### PR DESCRIPTION
## Summary
모바일 앱 버전 2.0.5 (빌드 78) 릴리스 업데이트입니다.

## Changes

### 버전 정보
- **앱 버전**: 2.0.5
- **빌드 번호**: 78 (Android)
- **파일**: pubspec.yaml, app_version.dart

### 주요 기능

#### 알림 관리 기능 개선
- **다중 선택 삭제**: 여러 알림을 체크박스로 선택하여 일괄 삭제
- **전체 삭제**: 모든 알림을 한 번에 정리
- **개별 삭제**: 각 알림 카드의 휴지통 아이콘으로 빠른 삭제

#### 알림 화면 UI/UX 개선
- 탭 전환 시 삭제 버튼 즉시 표시
- 선택 모드에서 선택된 개수 AppBar에 표시
- 삭제 전 확인 다이얼로그로 실수 방지
- 선택 모드 진입/해제 버튼

#### 푸시 알림 개선
- 알림 페이로드에 캠페인 전체 정보 포함
- 알림 탭 시 알림 기록 화면으로 자동 이동
- 앱 종료 상태에서도 정상 동작

### 빌드 정보
- **Android AAB**: 83.9MB
- **출력 경로**: `build/app/outputs/bundle/release/app-release.aab`
- **빌드 방식**: Release (Production)

## Testing
- [x] Android AAB 빌드 성공
- [x] 버전 정보 동기화 확인
- [ ] 알림 관리 기능 테스트 필요
- [ ] 푸시 알림 동작 테스트 필요

## Related PRs
- #212: 알림 시스템 개선 요청
- #213: 탭 전환 UI 버그 수정
- #214: 알림 기록 제한 해제
- #215: 알림 보관 일수 설정 기능

## Release Notes
사용자용 업데이트 노트는 별도 작성 완료.