### PR TITLE
fix(ci): infra 레포 브랜치 자동 삭제 추가

### DIFF
--- a/.github/workflows/ci-server.yml
+++ b/.github/workflows/ci-server.yml
@@ -163,5 +163,5 @@ jobs:
 
           echo "Created PR: $PR_URL"
 
-          # Enable auto-merge (squash) using PR URL
-          gh pr merge --auto --squash "$PR_URL"
+          # Enable auto-merge (squash) and delete branch after merge
+          gh pr merge --auto --squash --delete-branch "$PR_URL"


### PR DESCRIPTION
## 변경 사항
- Server CI/CD 워크플로우에 `--delete-branch` 플래그 추가
- infra 레포 PR auto-merge 후 feature 브랜치 자동 삭제

## 문제점
현재 ReviewMaps Server CI/CD는 infra 레포에 feature 브랜치를 생성하고 PR을 auto-merge하지만, 병합 후 브랜치를 삭제하지 않아 `ci/update-reviewmaps-server-*` 브랜치들이 누적됨

## 해결 방법
```yaml
# 변경 전
gh pr merge --auto --squash "$PR_URL"

# 변경 후  
gh pr merge --auto --squash --delete-branch "$PR_URL"
```

## 적용 효과
- ✅ infra 레포의 브랜치 관리 자동화
- ✅ 수동 브랜치 삭제 작업 불필요
- ✅ 레포지토리 정리 상태 유지

## 참고
- 작업 계획서: `infra/docs/prometheus-metrics-implementation.md`
- 관련 이슈: Phase 2 진행 전 CI/CD 개선사항