### PR TITLE
fix(server): 키워드 알림 API Campaign 데이터 로딩 수정

### DIFF
--- a/server/internal/services/keyword_alert.go
+++ b/server/internal/services/keyword_alert.go
@@ -142,8 +142,8 @@ func (s *KeywordAlertService) ListAlerts(userID uint, page, limit int, lat, lng 
 
 	query := s.db.Model(&models.KeywordAlert{}).
 		Preload("Keyword").
-		Preload("Campaign", "id IS NOT NULL").
-		Preload("Campaign.Category", "id IS NOT NULL").
+		Preload("Campaign").
+		Preload("Campaign.Category").
 		Where("keyword_id IN ?", keywordIDs).
 		Where("created_at >= ?", retentionCutoff)
 


### PR DESCRIPTION
## 문제
키워드 알림 API 응답에서 Campaign 데이터(제목, 업체명, 제공내역 등)가 누락되는 문제

## 원인
`Preload("Campaign", "id IS NOT NULL")` 조건이 Campaign 필드 로딩을 방해

## 해결
- `Preload("Campaign")` - 조건 제거하여 모든 Campaign 필드 로드
- `Preload("Campaign.Category")` - Category도 동일하게 조건 제거

## 관련
- Commit 8b7b9a4에서 NULL campaign 처리를 위해 조건을 추가했으나, 이로 인해 필드 로딩이 안되는 부작용 발생
- 모바일 앱에서 체험단 제목, 업체정보 등이 표시되지 않던 문제 해결

🤖 Generated with Claude Code