### PR TITLE
debug(server): 키워드 알림 API 캠페인 데이터 디버깅

### DIFF
--- a/server/internal/handlers/keyword_alert.go
+++ b/server/internal/handlers/keyword_alert.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"encoding/json"
+	"log"
 	"strconv"
 
 	"github.com/ggorockee/reviewmaps/server/internal/config"
@@ -166,6 +168,14 @@ func (h *KeywordAlertHandler) ListAlerts(c *fiber.Ctx) error {
 	response, err := h.service.ListAlerts(userID, page, limit, lat, lng, sortBy)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	// DEBUG: Log first 2 alerts to check campaign data
+	if len(response.Items) > 0 {
+		for i := 0; i < 2 && i < len(response.Items); i++ {
+			alertJSON, _ := json.MarshalIndent(response.Items[i], "", "  ")
+			log.Printf("[DEBUG] Alert #%d: %s\n", i+1, string(alertJSON))
+		}
 	}
 
 	return c.JSON(response)


### PR DESCRIPTION
첫 2개 alert의 campaign 데이터 구조 확인용 임시 로그 추가

Campaign 필드가 제대로 로드되는지 확인하기 위한 디버그 로그