### PR TITLE
feat: Campaign soft delete로 알림 히스토리 보존

### DIFF
--- a/server/internal/models/campaign.go
+++ b/server/internal/models/campaign.go
@@ -2,6 +2,8 @@ package models
 
 import (
 	"time"
+
+	"gorm.io/gorm"
 )
 
 // Category represents campaign categories
@@ -43,9 +45,10 @@ type Campaign struct {
 	CampaignType    *string    `gorm:"column:campaign_type;size:50;index:idx_cpg_type" json:"campaign_type,omitempty"`
 	Region          *string    `gorm:"column:region;size:100;index:idx_cpg_region" json:"region,omitempty"`
 	CampaignChannel *string    `gorm:"column:campaign_channel;size:255" json:"campaign_channel,omitempty"`
-	PromotionLevel  int        `gorm:"column:promotion_level;not null;default:0" json:"promotion_level"`
-	CreatedAt       time.Time  `gorm:"column:created_at;not null;index:idx_cpg_created,sort:desc" json:"created_at"`
-	UpdatedAt       time.Time  `gorm:"column:updated_at;not null" json:"updated_at"`
+	PromotionLevel  int            `gorm:"column:promotion_level;not null;default:0" json:"promotion_level"`
+	CreatedAt       time.Time      `gorm:"column:created_at;not null;index:idx_cpg_created,sort:desc" json:"created_at"`
+	UpdatedAt       time.Time      `gorm:"column:updated_at;not null" json:"updated_at"`
+	DeletedAt       gorm.DeletedAt `gorm:"column:deleted_at;index:idx_cpg_deleted" json:"deleted_at,omitempty"`
 
 	// Relations
 	Category *Category `gorm:"foreignKey:CategoryID" json:"category,omitempty"`

--- a/server/internal/services/keyword_alert.go
+++ b/server/internal/services/keyword_alert.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ggorockee/reviewmaps/server/internal/config"
 	"github.com/ggorockee/reviewmaps/server/internal/database"
 	"github.com/ggorockee/reviewmaps/server/internal/models"
+	"gorm.io/gorm"
 )
 
 type KeywordAlertService struct {
@@ -142,7 +143,9 @@ func (s *KeywordAlertService) ListAlerts(userID uint, page, limit int, lat, lng 
 
 	query := s.db.Model(&models.KeywordAlert{}).
 		Preload("Keyword").
-		Preload("Campaign").
+		Preload("Campaign", func(db *gorm.DB) *gorm.DB {
+			return db.Unscoped() // 삭제된 캠페인도 포함 (히스토리 보존)
+		}).
 		Preload("Campaign.Category").
 		Where("keyword_id IN ?", keywordIDs).
 		Where("created_at >= ?", retentionCutoff)


### PR DESCRIPTION
## 문제

cleanup cronjob이 만료된 캠페인을 hard delete하면서 다음 문제 발생:
- 연관된 alert의 `campaign_id`가 NULL로 설정됨
- 알림 히스토리에서 캠페인 정보(제목, 업체명, 제공내역) 영구 손실
- 사용자가 "어떤 캠페인 알림이 왔었는지" 확인 불가

## 해결 방법

**Soft Delete 적용**으로 히스토리 보존:

### 1. Campaign 모델에 DeletedAt 추가
```go
type Campaign struct {
    ...
    DeletedAt gorm.DeletedAt `gorm:"column:deleted_at;index:idx_cpg_deleted"`
}
```

### 2. cleanup 로직 변경
- **Before**: `DELETE FROM campaign` (hard delete)
- **After**: `UPDATE campaign SET deleted_at = NOW()` (soft delete)
- alert의 campaign_id NULL 설정 로직 제거 (불필요)

### 3. 알림 히스토리 조회 개선
```go
Preload("Campaign", func(db *gorm.DB) *gorm.DB {
    return db.Unscoped() // 삭제된 캠페인도 포함
})
```

## 영향

### 사용자 경험 개선
- ✅ 만료된 캠페인이라도 알림 히스토리에서 정보 확인 가능
- ✅ 과거 알림 기록의 불변성 보장
- ✅ "이런 캠페인 알림이 왔었구나" 확인 가능

### 시스템 동작
- 일반 캠페인 목록: 삭제된 것 자동 제외 (GORM 기본 동작)
- 알림 히스토리: Unscoped()로 삭제된 것도 포함
- DB 용량: 캠페인 레코드 누적 (주기적 정리 필요 시 별도 작업)

## 테스트

- [x] server 빌드 성공
- [x] go-scraper 빌드 성공
- [ ] 배포 후 알림 히스토리에서 만료 캠페인 정보 확인

## 관련 이슈

- cleanup cronjob의 히스토리 손실 문제 해결
- 사용자 요청: "히스토리에서는 만료된게 보여야하는거 아닌가?"