### PR TITLE
fix(mobile,server,scraper): 키워드 알림 UX 개선 및 중복 방지

### DIFF
--- a/go-scraper/cmd/scraper/main.go
+++ b/go-scraper/cmd/scraper/main.go
@@ -160,9 +160,13 @@ func runScraper(ctx context.Context, name string, cfg *config.Config, database *
 		// UNIQUE 제약조건 추가 (dedupe 실행 후 사용)
 		cleaner := cleanup.New(cfg, database, tel)
 		return cleaner.AddUniqueConstraint(ctx)
+	case "dedupe-alerts":
+		// 중복 키워드 알람 정리 (가장 최신 레코드만 유지)
+		cleaner := cleanup.New(cfg, database, tel)
+		return cleaner.DeduplicateKeywordAlerts(ctx)
 	default:
 		log.Errorf("'%s' 스크레이퍼를 찾을 수 없습니다.", name)
-		log.Info("사용 가능한 명령어: reviewnote, inflexer, cleanup, dedupe, add-unique")
+		log.Info("사용 가능한 명령어: reviewnote, inflexer, cleanup, dedupe, add-unique, dedupe-alerts")
 		return nil
 	}
 }

--- a/mobile/lib/screens/keyword_alerts_screen.dart
+++ b/mobile/lib/screens/keyword_alerts_screen.dart
@@ -137,9 +137,7 @@ class _KeywordAlertsScreenState extends State<KeywordAlertsScreen>
         );
       } catch (e) {
         if (mounted) {
-          // "Exception: " 접두어 제거하여 사용자 친화적 메시지 표시
-          final errorMessage = e.toString().replaceFirst('Exception: ', '');
-          _showErrorDialog(errorMessage);
+          _showErrorDialog(e.toString());
         }
       }
     }
@@ -242,7 +240,7 @@ class _KeywordAlertsScreenState extends State<KeywordAlertsScreen>
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('읽음 처리 실패: ${e.toString().replaceFirst('Exception: ', '')}'),
+            content: Text('읽음 처리 실패: ${e.toString()}'),
             backgroundColor: Colors.red,
           ),
         );
@@ -584,7 +582,7 @@ class _KeywordAlertsScreenState extends State<KeywordAlertsScreen>
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('삭제 실패: ${e.toString().replaceFirst('Exception: ', '')}'),
+            content: Text('삭제 실패: ${e.toString()}'),
             backgroundColor: Colors.red,
           ),
         );

--- a/mobile/lib/utils/exceptions.dart
+++ b/mobile/lib/utils/exceptions.dart
@@ -1,0 +1,12 @@
+/// 사용자 친화적 에러 메시지를 위한 커스텀 Exception
+///
+/// Dart의 기본 Exception은 자동으로 "Exception: " 접두어를 추가하지만,
+/// 이 클래스는 접두어 없이 메시지만 전달하여 사용자 친화적인 에러 표시가 가능합니다.
+class UserFriendlyException implements Exception {
+  final String message;
+
+  UserFriendlyException(this.message);
+
+  @override
+  String toString() => message;
+}

--- a/server/internal/models/keyword_alert.go
+++ b/server/internal/models/keyword_alert.go
@@ -48,8 +48,8 @@ func (Keyword) TableName() string {
 // DB: keyword_alerts_alerts
 type KeywordAlert struct {
 	ID           uint      `gorm:"primaryKey" json:"id"`
-	KeywordID    uint      `gorm:"column:keyword_id;not null;index:keyword_ale_keyword_3d44d6_idx" json:"keyword_id"`
-	CampaignID   *uint     `gorm:"column:campaign_id;index:keyword_ale_campaig_2f61a0_idx" json:"campaign_id"`
+	KeywordID    uint      `gorm:"column:keyword_id;not null;uniqueIndex:keyword_alerts_keyword_campaign_unique,priority:1;index:keyword_ale_keyword_3d44d6_idx" json:"keyword_id"`
+	CampaignID   *uint     `gorm:"column:campaign_id;uniqueIndex:keyword_alerts_keyword_campaign_unique,priority:2;index:keyword_ale_campaig_2f61a0_idx" json:"campaign_id"`
 	MatchedField string    `gorm:"column:matched_field;size:50;not null" json:"matched_field"`
 	IsRead       bool      `gorm:"not null" json:"is_read"`
 	CreatedAt    time.Time `gorm:"not null;index:keyword_ale_created_704aa6_idx,sort:desc" json:"created_at"`

--- a/server/internal/services/keyword_alert.go
+++ b/server/internal/services/keyword_alert.go
@@ -114,13 +114,14 @@ func (s *KeywordAlertService) ToggleKeyword(userID, keywordID uint) (*models.Key
 }
 
 // ListAlerts retrieves alerts for a user with optional distance calculation and sorting
+// Only shows alerts from active keywords
 func (s *KeywordAlertService) ListAlerts(userID uint, page, limit int, lat, lng *float64, sortBy string) (*AlertListResponse, error) {
 	var alerts []models.KeywordAlert
 	var total int64
 
-	// Get user's keyword IDs
+	// Get user's active keyword IDs only
 	var keywordIDs []uint
-	s.db.Model(&models.Keyword{}).Where("user_id = ?", userID).Pluck("id", &keywordIDs)
+	s.db.Model(&models.Keyword{}).Where("user_id = ? AND is_active = ?", userID, true).Pluck("id", &keywordIDs)
 
 	// Return empty if no keywords
 	if len(keywordIDs) == 0 {


### PR DESCRIPTION
## 개요
모바일 앱의 키워드 알림 기능에서 발생하던 4가지 주요 UX 이슈를 수정합니다.

## 수정된 이슈

### 1. ✅ Exception 접두어 제거
**문제**: 사용자에게 "Exception: 이미 삭제되었거나..." 와 같은 개발자용 에러 메시지 노출
**해결**: 
- `UserFriendlyException` 커스텀 클래스 생성
- `mobile/lib/services/keyword_service.dart`의 모든 `throw Exception()` 변경
- UI 레이어의 `.replaceFirst('Exception: ', '')` 임시 처리 제거

### 2. ✅ 키워드 삭제 404 에러 개선
**문제**: 이미 삭제된 키워드 삭제 시 에러 메시지 표시
**해결**:
- DELETE 작업을 멱등성(idempotent) 보장
- 404 응답을 성공으로 처리 (이미 삭제됨 = 목표 달성)
- `deleteKeyword`, `deleteAlert` 메서드에 404 허용 로직 추가

### 3. ✅ 비활성화 키워드 알림 필터링  
**문제**: 키워드 비활성화 후에도 기존 알림이 계속 표시됨
**해결**:
- `ListAlerts`에서 `is_active = true` 키워드만 조회
- 비활성화된 키워드의 알림은 목록에서 자동 제외

### 4. ✅ 중복 알림 방지
**문제**: 동일 키워드+캠페인 조합으로 중복 알림 생성
**해결**:
- `KeywordAlert` 모델에 `(keyword_id, campaign_id)` unique 제약조건 추가
- `DeduplicateKeywordAlerts` 함수로 기존 중복 정리 기능 제공
- `dedupe-alerts` 명령어 추가

## 변경 파일
- `mobile/lib/utils/exceptions.dart` (신규)
- `mobile/lib/services/keyword_service.dart`
- `mobile/lib/screens/keyword_alerts_screen.dart`
- `server/internal/models/keyword_alert.go`
- `server/internal/services/keyword_alert.go`
- `go-scraper/cmd/scraper/main.go`
- `go-scraper/internal/cleanup/dedupe.go`

## 테스트 계획
- [ ] 키워드 삭제 시 에러 메시지 확인 ("Exception:" 접두어 없어야 함)
- [ ] 이미 삭제된 키워드 재삭제 시 성공 처리 확인
- [ ] 키워드 비활성화 후 알림 목록에서 제외 확인
- [ ] 중복 알림 방지 확인 (unique constraint)

## 배포 순서
1. **먼저**: 기존 중복 알림 정리
   ```bash
   cd go-scraper && go run cmd/scraper/main.go dedupe-alerts
   ```
2. **그 다음**: 서버 배포 (unique constraint 적용)
3. **마지막**: 모바일 앱 배포

## 영향 범위
- 🟢 모바일 앱: 사용자 경험 개선 (에러 메시지, 알림 관리)
- 🟢 서버: 데이터 무결성 강화 (중복 방지)
- 🟢 스크레이퍼: 중복 정리 도구 추가

Resolves #230