### PR TITLE
feat(database): Add deleted_at column to campaign table for soft delete

### DIFF
--- a/server/migrations/add_deleted_at_to_campaign.sql
+++ b/server/migrations/add_deleted_at_to_campaign.sql
@@ -1,0 +1,20 @@
+-- Migration: Add deleted_at column to campaign table for soft delete support
+-- Created: 2025-12-23
+-- Purpose: Fix "column campaign.deleted_at does not exist" error
+
+BEGIN;
+
+-- Add deleted_at column (nullable timestamp with timezone)
+ALTER TABLE campaign
+ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP WITH TIME ZONE;
+
+-- Create index for soft delete queries (matching GORM definition)
+CREATE INDEX IF NOT EXISTS idx_cpg_deleted ON campaign(deleted_at);
+
+COMMIT;
+
+-- Rollback script (if needed):
+-- BEGIN;
+-- DROP INDEX IF EXISTS idx_cpg_deleted;
+-- ALTER TABLE campaign DROP COLUMN IF EXISTS deleted_at;
+-- COMMIT;


### PR DESCRIPTION
## Summary
- `campaign` 테이블에 `deleted_at` 컬럼 추가 (soft delete 지원)
- `idx_cpg_deleted` 인덱스 생성
- "column campaign.deleted_at does not exist" 에러 수정

## Changes
- ✅ `deleted_at` 컬럼 추가 (TIMESTAMP WITH TIME ZONE, nullable)
- ✅ Soft delete 쿼리를 위한 인덱스 생성
- ✅ GORM DeletedAt 필드와 DB 스키마 동기화

## Testing
- ✅ Kubernetes Job으로 마이그레이션 실행 완료
- ✅ `/v1/campaigns` API 정상 동작 확인 (200 OK)
- ✅ 프로덕션 API 테스트 통과

## Related Issue
Fixes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)