### PR TITLE
chore(mobile): pubspec.yaml에 댕미 블로그 배너 이미지 경로 추가

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -115,6 +115,7 @@ flutter:
     - asset/image/banner/
     - asset/image/logo/application/
     - asset/image/login/
+    - asset/image/ads/dangmi/
     - .env
 
 


### PR DESCRIPTION
## 수정 사항

pubspec.yaml의 assets 섹션에 댕미 블로그 배너 이미지 경로 추가

### 변경 내용
- `asset/image/ads/dangmi/` 경로 추가

### 관련 PR
- #233 (댕미 블로그 배너 추가)

### 이유
이전 PR에서 이미지 파일은 추가했지만 pubspec.yaml에 assets 경로를 누락했습니다.
이 경로가 없으면 Flutter가 이미지를 찾을 수 없어 런타임 에러가 발생합니다.

### 테스트
- [ ] Flutter 앱에서 블로그 배너 이미지 정상 표시 확인