### PR TITLE
feat(mobile): KeywordService Riverpod Provider 통합 (Phase 1)

### DIFF
--- a/mobile/lib/screens/keyword_alerts_screen.dart
+++ b/mobile/lib/screens/keyword_alerts_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:mobile/services/keyword_service.dart';
@@ -7,16 +8,15 @@ import 'package:mobile/models/keyword_models.dart';
 import 'package:mobile/screens/home_screen.dart'; // buildChannelIcons
 
 /// 키워드 알람 관리 화면
-class KeywordAlertsScreen extends StatefulWidget {
+class KeywordAlertsScreen extends ConsumerStatefulWidget {
   const KeywordAlertsScreen({super.key});
 
   @override
-  State<KeywordAlertsScreen> createState() => _KeywordAlertsScreenState();
+  ConsumerState<KeywordAlertsScreen> createState() => _KeywordAlertsScreenState();
 }
 
-class _KeywordAlertsScreenState extends State<KeywordAlertsScreen>
+class _KeywordAlertsScreenState extends ConsumerState<KeywordAlertsScreen>
     with SingleTickerProviderStateMixin {
-  final KeywordService _keywordService = KeywordService();
   late TabController _tabController;
 
   bool _isLoading = true;
@@ -55,9 +55,10 @@ class _KeywordAlertsScreenState extends State<KeywordAlertsScreen>
 
     try {
       // 병렬로 API 호출
+      final keywordService = ref.read(keywordServiceProvider);
       final results = await Future.wait([
-        _keywordService.getMyKeywords(),
-        _keywordService.getMyAlerts(),
+        keywordService.getMyKeywords(),
+        keywordService.getMyAlerts(),
       ]);
 
       if (!mounted) return;
@@ -124,7 +125,7 @@ class _KeywordAlertsScreenState extends State<KeywordAlertsScreen>
 
     if (result == true && controller.text.trim().isNotEmpty) {
       try {
-        final newKeyword = await _keywordService.registerKeyword(controller.text.trim());
+        final newKeyword = await ref.read(keywordServiceProvider).registerKeyword(controller.text.trim());
         if (!mounted) return;
 
         // UI 즉시 업데이트 (전체 리로드 없이)
@@ -169,7 +170,7 @@ class _KeywordAlertsScreenState extends State<KeywordAlertsScreen>
 
     if (confirmed == true) {
       try {
-        await _keywordService.deleteKeyword(keyword.id);
+        await ref.read(keywordServiceProvider).deleteKeyword(keyword.id);
         if (!mounted) return;
 
         // UI 즉시 업데이트 (전체 리로드 없이)
@@ -193,7 +194,7 @@ class _KeywordAlertsScreenState extends State<KeywordAlertsScreen>
   /// 알람 읽음 처리
   Future<void> _markAlertsAsRead(List<int> alertIds) async {
     try {
-      await _keywordService.markAlertsAsRead(alertIds);
+      await ref.read(keywordServiceProvider).markAlertsAsRead(alertIds);
       if (!mounted) return;
 
       // UI 즉시 업데이트 (전체 리로드 없이)
@@ -217,7 +218,7 @@ class _KeywordAlertsScreenState extends State<KeywordAlertsScreen>
     final alertIds = unreadAlerts.map((a) => a.id).toList();
 
     try {
-      await _keywordService.markAlertsAsRead(alertIds);
+      await ref.read(keywordServiceProvider).markAlertsAsRead(alertIds);
       if (!mounted) return;
 
       // UI 즉시 업데이트
@@ -564,7 +565,7 @@ class _KeywordAlertsScreenState extends State<KeywordAlertsScreen>
     });
 
     try {
-      await _keywordService.deleteAlert(alertId);
+      await ref.read(keywordServiceProvider).deleteAlert(alertId);
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
@@ -902,7 +903,7 @@ class _KeywordAlertsScreenState extends State<KeywordAlertsScreen>
   void dispose() {
     _tabController.removeListener(_onTabChanged);
     _tabController.dispose();
-    _keywordService.dispose();
+    // Provider를 사용하므로 수동 dispose 불필요
     super.dispose();
   }
 }

--- a/mobile/lib/screens/my_page_screen.dart
+++ b/mobile/lib/screens/my_page_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mobile/services/auth_service.dart';
 import 'package:mobile/services/keyword_service.dart';
 import 'package:mobile/const/colors.dart';
@@ -8,16 +9,15 @@ import 'package:mobile/screens/keyword_alerts_screen.dart';
 import 'package:mobile/models/auth_models.dart';
 
 /// 내정보 화면
-class MyPageScreen extends StatefulWidget {
+class MyPageScreen extends ConsumerStatefulWidget {
   const MyPageScreen({super.key});
 
   @override
-  State<MyPageScreen> createState() => _MyPageScreenState();
+  ConsumerState<MyPageScreen> createState() => _MyPageScreenState();
 }
 
-class _MyPageScreenState extends State<MyPageScreen> {
+class _MyPageScreenState extends ConsumerState<MyPageScreen> {
   final AuthService _authService = AuthService();
-  final KeywordService _keywordService = KeywordService();
   bool _isLoading = true;
   bool _isLoggedIn = false;
   bool _isAnonymous = false;
@@ -85,8 +85,8 @@ class _MyPageScreenState extends State<MyPageScreen> {
   /// 키워드 및 알람 정보 로드
   Future<void> _loadKeywordInfo() async {
     try {
-      final keywords = await _keywordService.getMyKeywords();
-      final alerts = await _keywordService.getMyAlerts(isRead: false);
+      final keywords = await ref.read(keywordServiceProvider).getMyKeywords();
+      final alerts = await ref.read(keywordServiceProvider).getMyAlerts(isRead: false);
       setState(() {
         _keywordCount = keywords.length;
         _unreadAlertCount = alerts.unreadCount;
@@ -540,7 +540,6 @@ class _MyPageScreenState extends State<MyPageScreen> {
   @override
   void dispose() {
     _authService.dispose();
-    _keywordService.dispose();
     super.dispose();
   }
 }

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -820,10 +820,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -1257,26 +1257,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   timezone:
     dependency: transitive
     description:


### PR DESCRIPTION
## 요약
KeywordService를 Riverpod Provider로 변환하여 401 에러 발생 시 authProvider 상태를 자동으로 업데이트할 수 있도록 개선했습니다.

## 변경사항

### 1. KeywordService Provider 변환
- ✅ KeywordService를 Riverpod Provider로 변환
- ✅ keywordServiceProvider 생성 (Provider<KeywordService>)
- ✅ 401 HTTP 에러 발생 시 authProvider.logout() 자동 호출

### 2. 화면 업데이트
- ✅ KeywordAlertsScreen → ConsumerStatefulWidget 변환
- ✅ NotificationScreen → ConsumerStatefulWidget 변환
- ✅ MyPageScreen → ConsumerStatefulWidget 변환
- ✅ 모든 화면에서 ref.read(keywordServiceProvider) 사용

### 3. 하위 호환성 유지
- ✅ KeywordService 생성자를 optional Ref로 변경 ([this._ref])
- ✅ fcm_service.dart 등 레거시 코드와의 호환성 유지

### 4. 코드 품질
- ✅ Flutter analyze 통과 (0 issues)
- ✅ 불필요한 dispose() 호출 제거
- ✅ prefer_final_fields 린트 경고 수정

## 테스트 계획
- [x] Flutter analyze 통과
- [ ] 수동 테스트: 401 에러 시 자동 로그아웃 확인
- [ ] 수동 테스트: 키워드 알람 기능 정상 동작 확인

## 관련 문서
- `docs/authentication-session-management-fix.md` 참고

🤖 Generated with [Claude Code](https://claude.com/claude-code)