### PR TITLE
feat(mobile): AuthService Riverpod Provider 통합 및 401 에러 처리 (Phase 2)

### DIFF
--- a/mobile/lib/screens/my_page_screen.dart
+++ b/mobile/lib/screens/my_page_screen.dart
@@ -17,7 +17,6 @@ class MyPageScreen extends ConsumerStatefulWidget {
 }
 
 class _MyPageScreenState extends ConsumerState<MyPageScreen> {
-  final AuthService _authService = AuthService();
   bool _isLoading = true;
   bool _isLoggedIn = false;
   bool _isAnonymous = false;
@@ -39,8 +38,9 @@ class _MyPageScreenState extends ConsumerState<MyPageScreen> {
     });
 
     try {
-      final isLoggedIn = await _authService.isLoggedIn();
-      final isAnonymous = await _authService.isAnonymous();
+      final authService = ref.read(authServiceProvider);
+      final isLoggedIn = await authService.isLoggedIn();
+      final isAnonymous = await authService.isAnonymous();
 
       setState(() {
         _isLoggedIn = isLoggedIn;
@@ -51,7 +51,7 @@ class _MyPageScreenState extends ConsumerState<MyPageScreen> {
         if (isAnonymous) {
           // 익명 사용자 정보 로드
           try {
-            final anonymousInfo = await _authService.getAnonymousUserInfo();
+            final anonymousInfo = await authService.getAnonymousUserInfo();
             setState(() {
               _anonymousUserInfo = anonymousInfo;
             });
@@ -61,7 +61,7 @@ class _MyPageScreenState extends ConsumerState<MyPageScreen> {
         } else {
           // 일반 사용자 정보 로드
           try {
-            final userInfo = await _authService.getUserInfo();
+            final userInfo = await authService.getUserInfo();
             setState(() {
               _userInfo = userInfo;
             });
@@ -126,7 +126,7 @@ class _MyPageScreenState extends ConsumerState<MyPageScreen> {
       });
 
       try {
-        await _authService.logout();
+        await ref.read(authServiceProvider).logout();
 
         if (!mounted) return;
 
@@ -539,7 +539,6 @@ class _MyPageScreenState extends ConsumerState<MyPageScreen> {
 
   @override
   void dispose() {
-    _authService.dispose();
     super.dispose();
   }
 }


### PR DESCRIPTION
## 요약
AuthService를 Riverpod Provider로 변환하고, 모든 인증 API에서 401 에러 발생 시 authProvider 상태를 자동으로 업데이트하도록 개선했습니다.

## 변경사항

### 1. AuthService Provider 변환
- ✅ AuthService를 Riverpod Provider로 변환
- ✅ authServiceProvider 생성 (Provider<AuthService>)
- ✅ 401 HTTP 에러 발생 시 authProvider.logout() 자동 호출

### 2. 중앙화된 401 에러 처리
- ✅ _handleHttpError() 메서드 추가 (KeywordService와 동일한 패턴)
- ✅ getUserInfo() - 사용자 정보 조회 시 401 처리
- ✅ refreshToken() - 토큰 갱신 시 401 처리
- ✅ getAnonymousUserInfo() - 익명 사용자 정보 조회 시 401 처리
- ✅ deleteAccount() - 회원 탈퇴 시 401 처리

### 3. 화면 업데이트
- ✅ MyPageScreen에서 authServiceProvider 사용
- ✅ 불필요한 dispose() 호출 제거

### 4. 하위 호환성 유지
- ✅ AuthService 생성자를 optional Ref로 변경 ([this._ref])
- ✅ auth_provider.dart 등 레거시 코드와의 호환성 유지

### 5. 코드 품질
- ✅ Flutter analyze 통과 (0 issues)
- ✅ Phase 1과 동일한 아키텍처 패턴 적용

## 테스트 계획
- [x] Flutter analyze 통과
- [ ] 수동 테스트: 토큰 만료 시 자동 로그아웃 확인
- [ ] 수동 테스트: getUserInfo() 401 에러 시 상태 동기화 확인

## 관련 이슈
- Phase 1 PR #235 후속 작업
- Phase 2: 401 에러 처리 중앙화 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)