### PR TITLE
feat(mobile): Phase 3 - 401 에러 시 자동 로그인 화면 이동 구현

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -31,6 +31,7 @@ import 'package:mobile/services/interstitial_ad_manager.dart'; // 전면광고 �
 import 'package:mobile/services/firebase_service.dart'; // Firebase 통합 서비스
 import 'package:mobile/services/remote_config_service.dart'; // Firebase Remote Config 서비스
 import 'package:mobile/services/fcm_service.dart'; // FCM 푸시 알림 서비스
+import 'package:mobile/providers/auth_provider.dart'; // AuthProvider
 
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -144,11 +145,43 @@ Future<void> main() async {
   );
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends ConsumerWidget {
   const MyApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    // authProvider 상태 변화 감지: 로그인 만료 시 자동 로그인 화면 이동
+    ref.listen<AuthState>(authProvider, (previous, next) {
+      // 로그인 상태에서 비로그인 상태로 변경된 경우 (401 에러 발생)
+      if (previous != null &&
+          previous.isAuthenticated &&
+          !next.isAuthenticated) {
+
+        debugPrint('[MyApp] 로그인 만료 감지 - 로그인 화면으로 이동');
+
+        // 현재 컨텍스트가 유효한지 확인
+        final currentContext = navigatorKey.currentContext;
+        if (currentContext != null && currentContext.mounted) {
+          // 스낵바 표시: "로그인이 만료되었습니다"
+          ScaffoldMessenger.of(currentContext).showSnackBar(
+            const SnackBar(
+              content: Text('로그인이 만료되었습니다. 다시 로그인해 주세요.'),
+              duration: Duration(seconds: 3),
+              backgroundColor: Colors.red,
+            ),
+          );
+
+          // 로그인 화면으로 이동 (모든 스택 제거)
+          Navigator.of(currentContext).pushAndRemoveUntil(
+            MaterialPageRoute(
+              builder: (context) => const LoginScreen(),
+            ),
+            (route) => false,
+          );
+        }
+      }
+    });
+
     // ScreenUtilInit:
     //  - 디자인 시안 기준 해상도 지정(여기서는 375x812, iPhone X 계열 기준)
     //  - .w/.h/.sp 단위를 통해 다양한 해상도/비율에서 일관된 UI 제공
@@ -161,7 +194,7 @@ class MyApp extends StatelessWidget {
         return MaterialApp(
           // 글로벌 네비게이터 키 설정
           navigatorKey: navigatorKey,
-          
+
           // 릴리즈에서 디버그 배너 제거
           debugShowCheckedModeBanner: false,
           title: 'Review Schedule',


### PR DESCRIPTION
## Summary
Phase 3: 401 에러 발생 시 자동으로 로그인 화면으로 이동하는 기능을 구현했습니다.

## Changes
### Main.dart
- `MyApp`을 `StatelessWidget`에서 `ConsumerWidget`으로 변경
- `ref.listen<AuthState>(authProvider)` 추가로 인증 상태 변화 감지
- 로그인 → 비로그인 전환 감지 시 자동 처리:
  - 스낵바: "로그인이 만료되었습니다. 다시 로그인해 주세요."
  - 로그인 화면으로 자동 네비게이션 (모든 스택 제거)

## Flow
```
1. API 호출 → 401 에러 발생
2. KeywordService/AuthService._handleHttpError()
3. authProvider.logout() 호출
4. authProvider.isAuthenticated: true → false
5. MyApp의 ref.listen 감지
6. 스낵바 표시 + 로그인 화면 이동
```

## Impact
- ✅ **자동 네비게이션**: 사용자가 수동으로 로그인 화면 찾을 필요 없음
- ✅ **즉시 안내**: 세션 만료 즉시 스낵바로 알림
- ✅ **일관된 UX**: 모든 401 에러에 대해 동일한 처리

## Test Plan
- [x] Flutter analyze 통과 (0 issues)
- [x] ConsumerWidget 정상 동작 확인
- [x] ref.listen 콜백 로직 검증
- [x] navigatorKey.currentContext 안전성 확인

## Related
- Phase 1: #235 (KeywordService Provider 변환)
- Phase 2: #236 (AuthService Provider 변환)
- Phase 2 Fix: #237 (에러 타입 일관성)
- Phase 3: 이 PR (자동 네비게이션)

## Next Steps
- Phase 4: 로그인 후 원래 작업으로 복귀 기능
- Phase 5: AuthGuard 위젯 구현 (선택사항)

🤖 Generated with [Claude Code](https://claude.com/claude-code)