### PR TITLE
refactor(mobile): AuthNotifier 아키텍처 개선 - authServiceProvider 통합

### DIFF
--- a/mobile/lib/providers/auth_provider.dart
+++ b/mobile/lib/providers/auth_provider.dart
@@ -41,10 +41,14 @@ class AuthState {
 
 /// 인증 상태 관리 노티파이어
 class AuthNotifier extends Notifier<AuthState> {
-  final AuthService _authService = AuthService();
+  late final AuthService _authService;
 
   @override
   AuthState build() {
+    // authServiceProvider를 통해 AuthService 인스턴스 가져오기
+    // 이를 통해 401 에러 발생 시 authProvider.logout() 호출 가능
+    _authService = ref.read(authServiceProvider);
+
     // 초기 상태는 비인증
     return const AuthState();
   }
@@ -149,8 +153,14 @@ class AuthNotifier extends Notifier<AuthState> {
   }
 
   /// 리소스 정리
+  ///
+  /// 참고: _authService는 authServiceProvider가 관리하므로
+  /// Riverpod이 자동으로 dispose 처리함.
+  /// 명시적 dispose 호출은 불필요하지만 호환성을 위해 유지.
   void dispose() {
-    _authService.dispose();
+    // authServiceProvider가 관리하는 인스턴스이므로
+    // 실제로는 Riverpod이 자동 정리함
+    // _authService.dispose();
   }
 }
 


### PR DESCRIPTION
## Summary
Phase 1-3 통합 분석에서 발견된 아키텍처 불일치를 해결했습니다.

## 문제점
AuthNotifier가 AuthService를 두 가지 방식으로 사용:
- **AuthNotifier 내부**: `AuthService()` - Ref 없이 직접 인스턴스화
- **다른 컴포넌트**: `authServiceProvider` - Ref와 함께 Provider 사용
- **결과**: AuthService 인스턴스 2개 존재 (아키텍처 불일치)

## 해결 방법
```dart
// Before
class AuthNotifier extends Notifier<AuthState> {
  final AuthService _authService = AuthService();  // ❌ 직접 생성
}

// After
class AuthNotifier extends Notifier<AuthState> {
  late final AuthService _authService;

  @override
  AuthState build() {
    _authService = ref.read(authServiceProvider);  // ✅ Provider 사용
    return const AuthState();
  }
}
```

## 개선 효과
- ✅ **단일 인스턴스**: 모든 곳에서 authServiceProvider 사용
- ✅ **아키텍처 일관성**: Provider 패턴 통일
- ✅ **메모리 효율**: 중복 인스턴스 제거
- ✅ **생명주기 관리**: Riverpod이 자동 처리

## Phase 1-3 통합 검증

### Phase 1: KeywordService (변경 없음)
```dart
// KeywordService._handleHttpError()
ref.read(authProvider.notifier).logout();  // ✅ 정상
```

### Phase 2: AuthService (변경 없음)
```dart
// AuthService._handleHttpError()
ref.read(authProvider.notifier).logout();  // ✅ 정상
```

### Phase 3: MyApp ref.listen (변경 없음)
```dart
// main.dart - MyApp
ref.listen<AuthState>(authProvider, (previous, next) {
  // 401 에러 감지 → 자동 로그인 화면 이동  // ✅ 정상
});
```

## 통합 플로우 검증
```
[API 호출: getUserInfo()]
    ↓
[401 Unauthorized]
    ↓
[AuthService._handleHttpError()]  ← Phase 2
    ↓
[authProvider.logout()]
    ↓
[AuthNotifier.logout()]
    ├─ FcmService.unregisterToken()
    ├─ _authService.logout()  ← 이제 authServiceProvider 인스턴스 사용
    └─ state = const AuthState()
    ↓
[MyApp ref.listen 감지]  ← Phase 3
    ↓
[스낵바 + 로그인 화면 이동]
```

## Impact
- ✅ **Phase 1-3 모두 정상 동작 유지**
- ✅ **아키텍처 개선으로 향후 확장성 향상**
- ✅ **코드 품질 및 유지보수성 개선**

## Test Plan
- [x] Flutter analyze 통과 (0 issues)
- [x] Phase 1 검증: KeywordService 401 처리
- [x] Phase 2 검증: AuthService 401 처리
- [x] Phase 3 검증: 자동 네비게이션
- [x] 통합 플로우 검증

## Related
- Phase 1: #235 (KeywordService Provider 변환)
- Phase 2: #236 (AuthService Provider 변환)
- Phase 2 Fix: #237 (에러 타입 일관성)
- Phase 3: #238 (자동 네비게이션)
- 이 PR: Phase 1-3 아키텍처 통합 개선

🤖 Generated with [Claude Code](https://claude.com/claude-code)