### PR TITLE
fix(mobile): LoginScreen에서 AuthService Provider 사용하도록 수정

### DIFF
--- a/mobile/lib/screens/auth/login_screen.dart
+++ b/mobile/lib/screens/auth/login_screen.dart
@@ -9,6 +9,7 @@ import 'package:mobile/services/sns/kakao_login_service.dart';
 import 'package:mobile/services/sns/google_login_service.dart';
 import 'package:mobile/services/sns/apple_login_service.dart';
 import 'package:mobile/providers/auth_provider.dart';
+import 'package:mobile/services/auth_service.dart' show authServiceProvider;
 import 'package:mobile/const/colors.dart';
 import 'dart:io';
 
@@ -36,13 +37,11 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
   final _passwordController = TextEditingController();
   bool _obscurePassword = true;
   bool _isLoading = false;
-  final AuthService _authService = AuthService();
 
   @override
   void dispose() {
     _emailController.dispose();
     _passwordController.dispose();
-    _authService.dispose();
     super.dispose();
   }
 
@@ -86,13 +85,14 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     });
 
     try {
-      // 1. AuthService로 로그인 수행 (토큰 저장)
-      await _authService.login(email: email, password: password);
+      // 1. AuthService (Provider 방식) 로그인 수행 (토큰 저장)
+      final authService = ref.read(authServiceProvider);
+      await authService.login(email: email, password: password);
 
       if (!mounted) return;
 
       // 2. 사용자 정보 가져오기
-      final userInfo = await _authService.getUserInfo();
+      final userInfo = await authService.getUserInfo();
 
       if (!mounted) return;
 
@@ -148,12 +148,13 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
       final kakaoAccessToken = await KakaoLoginService.login();
       if (!mounted) return;
 
-      // 2. 서버 로그인
-      await _authService.kakaoLogin(kakaoAccessToken);
+      // 2. AuthService (Provider 방식) 서버 로그인
+      final authService = ref.read(authServiceProvider);
+      await authService.kakaoLogin(kakaoAccessToken);
       if (!mounted) return;
 
       // 3. 토큰 저장 확인
-      final storedAccessToken = await _authService.getStoredAccessToken();
+      final storedAccessToken = await authService.getStoredAccessToken();
       if (storedAccessToken == null) {
         throw Exception('토큰 저장에 실패했습니다.\n다시 시도해 주세요.');
       }
@@ -161,7 +162,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
       if (!mounted) return;
 
       // 4. 사용자 정보 가져오기
-      final userInfo = await _authService.getUserInfo();
+      final userInfo = await authService.getUserInfo();
       if (!mounted) return;
 
       // 5. authProvider 상태 업데이트
@@ -218,12 +219,13 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
       final googleAccessToken = await GoogleLoginService.login();
       if (!mounted) return;
 
-      // 2. 서버 로그인
-      await _authService.googleLogin(googleAccessToken);
+      // 2. AuthService (Provider 방식) 서버 로그인
+      final authService = ref.read(authServiceProvider);
+      await authService.googleLogin(googleAccessToken);
       if (!mounted) return;
 
       // 3. 사용자 정보 가져오기
-      final userInfo = await _authService.getUserInfo();
+      final userInfo = await authService.getUserInfo();
       if (!mounted) return;
 
       // 4. authProvider 상태 업데이트
@@ -287,15 +289,16 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
       final appleCredentials = await AppleLoginService.login();
       if (!mounted) return;
 
-      // 2. 서버 로그인
-      await _authService.appleLogin(
+      // 2. AuthService (Provider 방식) 서버 로그인
+      final authService = ref.read(authServiceProvider);
+      await authService.appleLogin(
         appleCredentials['identity_token']!,
         appleCredentials['authorization_code'],
       );
       if (!mounted) return;
 
       // 3. 사용자 정보 가져오기
-      final userInfo = await _authService.getUserInfo();
+      final userInfo = await authService.getUserInfo();
       if (!mounted) return;
 
       // 4. authProvider 상태 업데이트


### PR DESCRIPTION
## 문제

Phase 1~4 통합성 검증 중 LoginScreen에서 레거시 방식의 AuthService 사용 발견:
- `final AuthService _authService = AuthService();`
- Ref가 null이어서 로그인 중 401 에러 발생 시 `authProvider.logout()` 호출 불가
- Phase 1, 2의 401 에러 처리 통합이 LoginScreen에만 적용되지 않음

## 해결

### 코드 수정
- `_authService` 필드 제거
- 모든 로그인 메서드에서 `ref.read(authServiceProvider)` 사용:
  - ✅ 이메일 로그인: `_handleLogin()`
  - ✅ Kakao 로그인: `_handleKakaoLogin()`
  - ✅ Google 로그인: `_handleGoogleLogin()`
  - ✅ Apple 로그인: `_handleAppleLogin()`

### 효과
- 로그인 중 401 에러 발생 시에도 authProvider 상태 업데이트 가능
- Phase 1~4 전체 플로우 완전 통합 완료

## 테스트
- ✅ Flutter analyze 통과
- ✅ 모든 로그인 메서드에서 AuthService Provider 정상 사용

## 문서
- `authentication-session-management-fix.md` 업데이트:
  - Phase 1, 2 완료 표시
  - Phase 4.1 (통합성 검토 및 수정) 섹션 추가
  - 검토 결과 및 수정 내용 문서화

🤖 Generated with [Claude Code](https://claude.com/claude-code)