### PR TITLE
fix(mobile): Phase 5 누락 파일 추가 - FCM Provider 통합

### DIFF
--- a/mobile/lib/screens/notification_screen.dart
+++ b/mobile/lib/screens/notification_screen.dart
@@ -68,13 +68,13 @@ class _NotificationScreenState extends ConsumerState<NotificationScreen>
     }
 
     // FCM 알림 수신 리스너 등록 (푸시 수신 시 알림 기록 실시간 업데이트)
-    FcmService.instance.addNotificationListener(_onFcmNotificationReceived);
+    ref.read(fcmServiceProvider).addNotificationListener(_onFcmNotificationReceived);
   }
 
   @override
   void dispose() {
     // FCM 알림 수신 리스너 해제
-    FcmService.instance.removeNotificationListener(_onFcmNotificationReceived);
+    ref.read(fcmServiceProvider).removeNotificationListener(_onFcmNotificationReceived);
 
     _tabController.removeListener(_onTabChanged);
     _tabController.dispose();

--- a/mobile/lib/screens/splash_screen.dart
+++ b/mobile/lib/screens/splash_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mobile/services/app_open_ad_service.dart';
 import 'package:mobile/services/ad_service.dart';
 import 'package:mobile/services/campaign_cache_manager.dart';
+import 'package:mobile/services/fcm_service.dart';
 import 'package:mobile/config/app_version.dart';
 import 'package:mobile/const/colors.dart';
 import 'package:mobile/screens/main_screen.dart';
@@ -14,14 +16,14 @@ import 'package:mobile/widgets/friendly.dart';
 /// - 브랜드 로고 및 로딩 애니메이션
 /// - 전면광고 준비되면 표시 후 메인 화면으로 이동
 /// - 광고 로딩 실패 시에도 자연스럽게 메인 화면으로 이동
-class SplashScreen extends StatefulWidget {
+class SplashScreen extends ConsumerStatefulWidget {
   const SplashScreen({super.key});
 
   @override
-  State<SplashScreen> createState() => _SplashScreenState();
+  ConsumerState<SplashScreen> createState() => _SplashScreenState();
 }
 
-class _SplashScreenState extends State<SplashScreen>
+class _SplashScreenState extends ConsumerState<SplashScreen>
     with SingleTickerProviderStateMixin {
   late AnimationController _animationController;
   late Animation<double> _fadeAnimation;
@@ -73,6 +75,14 @@ class _SplashScreenState extends State<SplashScreen>
   /// 광고 로딩 중 백그라운드에서 데이터 프리페치하여 홈 화면 즉시 표시
   Future<void> _startSplashSequence() async {
     final stopwatch = Stopwatch()..start();
+
+    // Phase 5: FCM 서비스 초기화 (Provider 방식)
+    try {
+      await ref.read(fcmServiceProvider).initialize();
+      debugPrint('[SplashScreen] FCM 서비스 초기화 완료');
+    } catch (e) {
+      debugPrint('[SplashScreen] FCM 서비스 초기화 실패: $e');
+    }
 
     // 1. 병렬 실행: 최소 대기 + 데이터 프리로드 + 세션 로깅
     // 광고가 표시되는 동안 백그라운드에서 추천 + 가까운 캠페인을 모두 미리 로드


### PR DESCRIPTION
## 개요
Phase 5 작업 중 누락된 notification_screen.dart와 splash_screen.dart의 FcmService Provider 통합을 완료합니다.

## 수정 내용

### 📱 notification_screen.dart
**변경사항:**
- `FcmService.instance` → `ref.read(fcmServiceProvider)` 변경
- `addNotificationListener()`, `removeNotificationListener()` 호출 부분 수정
- Phase 5 FCM Provider 패턴 적용

**위치:**
- Line 71: FCM 알림 수신 리스너 등록
- Line 77: FCM 알림 수신 리스너 해제

### 🚀 splash_screen.dart
**변경사항:**
- `StatefulWidget` → `ConsumerStatefulWidget` 변경
- FCM 서비스 초기화를 Provider 방식으로 변경
- `ref.read(fcmServiceProvider).initialize()` 호출 추가

**위치:**
- Line 19-27: ConsumerStatefulWidget 변환
- Line 79-83: FCM 서비스 초기화 (Provider 방식)

## 관련 작업
- ✅ Phase 5: FCM 딥링크 인증 상태 체크 구현 (#246 이전)
- ✅ Phase 6: 안정성 개선 (#246)

## 플로우
### Before (누락)
```dart
// notification_screen.dart
FcmService.instance.addNotificationListener(...)  // ❌ Singleton 패턴

// splash_screen.dart
class SplashScreen extends StatefulWidget  // ❌ ref 접근 불가
```

### After (수정)
```dart
// notification_screen.dart
ref.read(fcmServiceProvider).addNotificationListener(...)  // ✅ Provider 패턴

// splash_screen.dart
class SplashScreen extends ConsumerStatefulWidget  // ✅ ref 접근 가능
await ref.read(fcmServiceProvider).initialize()  // ✅ Provider 초기화
```

## 검증 결과
- ✅ Flutter analyze 통과
- ✅ Phase 1~6 전체 Provider 패턴 일관성 확보
- ✅ FCM Service 관련 모든 파일 Provider 패턴 적용 완료

## 영향 범위
- **Low Risk**: 기존 로직 변경 없음, Provider 패턴만 적용
- **호환성**: Phase 5, 6와 완벽 호환

🤖 Generated with [Claude Code](https://claude.com/claude-code)