### PR TITLE
fix(server): Apple 로그인 identity_token 필드 처리 수정

### DIFF
--- a/server/internal/handlers/auth.go
+++ b/server/internal/handlers/auth.go
@@ -248,11 +248,11 @@ func truncateString(s string, maxLen int) string {
 // @Tags auth
 // @Accept json
 // @Produce json
-// @Param request body services.SNSLoginRequest true "Apple ID token"
+// @Param request body services.AppleLoginRequest true "Apple ID token"
 // @Success 200 {object} services.AuthResponse
 // @Router /auth/apple [post]
 func (h *AuthHandler) AppleLogin(c *fiber.Ctx) error {
-	var req services.SNSLoginRequest
+	var req services.AppleLoginRequest
 	if err := c.BodyParser(&req); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": "Invalid request body",
@@ -260,10 +260,10 @@ func (h *AuthHandler) AppleLogin(c *fiber.Ctx) error {
 		})
 	}
 
-	response, err := h.service.AppleLogin(req.AccessToken)
+	response, err := h.service.AppleLogin(req.IdentityToken)
 	if err != nil {
 		// Log detailed error to console
-		c.Context().Logger().Printf("[AppleLogin] Error: %v, Token (first 20 chars): %s", err, truncateString(req.AccessToken, 20))
+		c.Context().Logger().Printf("[AppleLogin] Error: %v, Token (first 20 chars): %s", err, truncateString(req.IdentityToken, 20))
 
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
 			"error": "Apple login failed",


### PR DESCRIPTION
## 🐛 문제점

Apple 로그인 시 iPad 환경에서 다음과 같은 에러가 발생했습니다:
```
apple 토큰 감옥에 실패하였습니다: failed to parse token: token is malformed: token contains an invalid number of segments
```

### 근본 원인
서버 엔드포인트 `/auth/apple`이 잘못된 요청 구조체를 사용:
- **기대**: `AppleLoginRequest` (identity_token 필드)
- **실제**: `SNSLoginRequest` (access_token 필드)
- **결과**: 빈 문자열이 JWT 파서에 전달되어 파싱 실패

## 🔧 수정 사항

`server/internal/handlers/auth.go`에서:
- `SNSLoginRequest` → `AppleLoginRequest` 구조체 사용
- `req.AccessToken` → `req.IdentityToken` 필드 접근
- Swagger 주석 업데이트

## ✅ 검증 계획

- [x] 서버 빌드 성공 확인
- [ ] 실기기 테스트 (iPad Air 11-inch M3)
- [ ] Apple 로그인 정상 동작 확인

## 📦 배포 영향

- App Store 리뷰 거절 대응
- Guideline 2.1 - Performance - App Completeness
- Review Device: iPad Air 11-inch (M3), iPadOS 26.2

## 🔗 관련 정보

- 제출 ID: d32a4134-ed96-489f-9528-eaf27644ea01
- 리뷰 날짜: 2025-12-31
- 버전: 2.0.9