### PR TITLE
chore(mobile): 앱 버전 2.1.0 업데이트

### DIFF
--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -274,9 +274,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -366,9 +370,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -495,7 +503,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.8;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.reviewmaps.mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -685,7 +693,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.8;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.reviewmaps.mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -714,7 +722,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.8;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.reviewmaps.mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/mobile/lib/config/app_version.dart
+++ b/mobile/lib/config/app_version.dart
@@ -14,7 +14,7 @@ class AppVersion {
   ///
   /// 새 버전 배포 시 이 값을 업데이트합니다.
   /// Semantic Versioning (major.minor.patch) 형식을 따릅니다.
-  static const String current = '2.0.9';
+  static const String current = '2.1.0';
 
   /// 버전 문자열을 파싱하여 비교 가능한 형태로 변환
   ///

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -28,10 +28,10 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # of the product and file versions while build-number is used as the build suffix.
 
 # # ios
-version: 2.0.9+2
+version: 2.1.0+1
 
 # android
-# version: 2.0.9+88
+# version: 2.1.0+90
 
 # minversion: 2.0.2
 


### PR DESCRIPTION
## Summary

- 모바일 앱 버전을 2.0.9에서 2.1.0으로 업데이트
- iOS 빌드 번호 2 → 1 변경 (2.1.0+1)
- Android 버전 코드 88 → 90 변경 (2.1.0+90)

## 변경 파일

- `mobile/lib/config/app_version.dart`: 앱 내 버전 상수 업데이트
- `mobile/pubspec.yaml`: Flutter 버전 선언 업데이트
- `mobile/ios/Runner.xcodeproj/project.pbxproj`: iOS 프로젝트 빌드 번호 업데이트

## Test plan

- [ ] iOS 빌드 정상 확인
- [ ] Android 빌드 정상 확인
- [ ] 앱 내 버전 표시 2.1.0 확인