### PR TITLE
revert(mobile): PR #254 앱 버전 2.1.0 업데이트 되돌리기

### DIFF
--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -274,13 +274,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -370,13 +366,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -503,7 +495,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.reviewmaps.mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -693,7 +685,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.reviewmaps.mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -722,7 +714,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.reviewmaps.mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/mobile/lib/config/app_version.dart
+++ b/mobile/lib/config/app_version.dart
@@ -14,7 +14,7 @@ class AppVersion {
   ///
   /// 새 버전 배포 시 이 값을 업데이트합니다.
   /// Semantic Versioning (major.minor.patch) 형식을 따릅니다.
-  static const String current = '2.1.0';
+  static const String current = '2.0.9';
 
   /// 버전 문자열을 파싱하여 비교 가능한 형태로 변환
   ///

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -28,10 +28,10 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # of the product and file versions while build-number is used as the build suffix.
 
 # # ios
-version: 2.1.0+1
+version: 2.0.9+2
 
 # android
-# version: 2.1.0+90
+# version: 2.0.9+88
 
 # minversion: 2.0.2
 


### PR DESCRIPTION
## Summary

- PR #254 (`chore(mobile): 앱 버전 2.0.9 → 2.1.0 업데이트`) 를 실수로 머지하여 되돌립니다.
- squash merge 커밋 `adec7f3` 을 `git revert` 로 복구합니다.
- 모바일 앱 버전을 2.1.0 → 2.0.9 로 원복합니다.

## 변경 내용

- 버전 변경 revert: 2.1.0 → 2.0.9

## Test plan

- [ ] 모바일 앱 버전 코드가 2.0.9 로 복구되었는지 확인