### PR TITLE
fix: reviewnote 페이지네이션 조기 종료 버그 수정

### DIFF
--- a/go-scraper/internal/config/config.go
+++ b/go-scraper/internal/config/config.go
@@ -85,6 +85,7 @@ func (b *BatchConfig) Location() *time.Location {
 // ScrapeConfig 스크래핑 관련 설정
 type ScrapeConfig struct {
 	MaxItems int // 최대 수집 개수 (0 = 무제한)
+	MaxPages int // 최대 페이지 수 (0 = 무제한, 기본 500 - 무한루프 방지)
 }
 
 // ServerAPIConfig Server API 연동 설정
@@ -141,7 +142,8 @@ func Load() (*Config, error) {
 			WaitTimeout:     time.Duration(getEnvInt("WAIT_TIMEOUT", 15)) * time.Second,
 		},
 		Scrape: ScrapeConfig{
-			MaxItems: getEnvInt("SCRAPE_MAX_ITEMS", 100),
+			MaxItems: getEnvInt("SCRAPE_MAX_ITEMS", 0),
+			MaxPages: getEnvInt("SCRAPE_MAX_PAGES", 500),
 		},
 		ServerAPI: ServerAPIConfig{
 			BaseURL: getEnv("SERVER_API_BASE_URL", ""),

--- a/go-scraper/internal/scraper/reviewnote/reviewnote.go
+++ b/go-scraper/internal/scraper/reviewnote/reviewnote.go
@@ -171,9 +171,13 @@ func (s *Scraper) Scrape(ctx context.Context, keyword *string) ([]map[string]int
 	var allData []map[string]interface{}
 	page := 0
 	maxItems := s.Config.Scrape.MaxItems
+	maxPages := s.Config.Scrape.MaxPages
 
 	if maxItems > 0 {
 		log.Infof("MaxItems 제한 설정: %d개", maxItems)
+	}
+	if maxPages > 0 {
+		log.Infof("MaxPages 안전장치 설정: %d페이지", maxPages)
 	}
 
 	for {
@@ -265,8 +269,9 @@ func (s *Scraper) Scrape(ctx context.Context, keyword *string) ([]map[string]int
 			break
 		}
 
-		// 받은 데이터가 limit보다 적으면 마지막 페이지
-		if len(apiResp.Objects) < pageLimit {
+		// MaxPages 안전장치: API가 빈 페이지를 반환하지 않는 경우 무한루프 방지
+		if maxPages > 0 && page >= maxPages-1 {
+			log.Warnf("MaxPages 안전장치(%d페이지)에 도달, 수집 중단 (total: %d)", maxPages, len(allData))
 			break
 		}
 


### PR DESCRIPTION
## Summary
- `len(apiResp.Objects) < pageLimit` 조건으로 인해 첫 페이지(96개)만 수집 후 종료되던 버그 수정
- `ScrapeConfig`에 `MaxPages` 필드 추가 (기본값 500, 무한루프 방지)
- `MaxItems` 기본값 100 → 0 (무제한)으로 수정

## Root Cause
리뷰노트 API 첫 페이지가 96개(< 100)를 반환하면 `< pageLimit` 조건으로 break 발생 → 이후 페이지 전체 누락

## Test plan
- [ ] reviewnote scraper 실행 후 page 1+ 캠페인 수집 확인
- [ ] `네일식스 마곡점` 등 누락 캠페인 DB 입력 확인
- [ ] MaxPages(500) 안전장치로 무한루프 방지 확인