### PR TITLE
fix: keyword 삭제 시 FK 제약 위반 수정

### DIFF
--- a/mobile/lib/config/app_version.dart
+++ b/mobile/lib/config/app_version.dart
@@ -14,7 +14,7 @@ class AppVersion {
   ///
   /// 새 버전 배포 시 이 값을 업데이트합니다.
   /// Semantic Versioning (major.minor.patch) 형식을 따릅니다.
-  static const String current = '2.0.9';
+  static const String current = '2.1.1';
 
   /// 버전 문자열을 파싱하여 비교 가능한 형태로 변환
   ///

--- a/server/internal/handlers/keyword_alert.go
+++ b/server/internal/handlers/keyword_alert.go
@@ -99,7 +99,10 @@ func (h *KeywordAlertHandler) DeleteKeyword(c *fiber.Ctx) error {
 	id, _ := strconv.Atoi(c.Params("id"))
 
 	if err := h.service.DeleteKeyword(userID, uint(id)); err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": err.Error()})
+		if err.Error() == "keyword not found" {
+			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": err.Error()})
+		}
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
 	}
 
 	return c.SendStatus(fiber.StatusNoContent)

--- a/server/internal/services/keyword_alert.go
+++ b/server/internal/services/keyword_alert.go
@@ -93,13 +93,19 @@ func (s *KeywordAlertService) ListKeywords(userID uint) ([]models.Keyword, error
 	return keywords, err
 }
 
-// DeleteKeyword deletes a keyword
+// DeleteKeyword deletes a keyword and its associated alerts
 func (s *KeywordAlertService) DeleteKeyword(userID, keywordID uint) error {
-	result := s.db.Where("id = ? AND user_id = ?", keywordID, userID).Delete(&models.Keyword{})
-	if result.RowsAffected == 0 {
+	var keyword models.Keyword
+	if err := s.db.Where("id = ? AND user_id = ?", keywordID, userID).First(&keyword).Error; err != nil {
 		return errors.New("keyword not found")
 	}
-	return result.Error
+
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("keyword_id = ?", keywordID).Delete(&models.KeywordAlert{}).Error; err != nil {
+			return err
+		}
+		return tx.Delete(&keyword).Error
+	})
 }
 
 // ToggleKeyword toggles keyword active status


### PR DESCRIPTION
## Summary
- `keyword_alerts_alerts` 테이블이 keyword를 FK 참조하고 있어 keyword 삭제 시 DB 제약 위반 발생
- 서버가 FK 에러를 404로 응답 → Flutter가 삭제 성공으로 오인 → UI에서만 삭제, DB는 그대로
- 트랜잭션으로 연관 alerts를 먼저 삭제 후 keyword 삭제하도록 수정

## Changes
- `server/internal/services/keyword_alert.go`: DeleteKeyword에서 트랜잭션으로 관련 alerts 선삭제
- `server/internal/handlers/keyword_alert.go`: "keyword not found" → 404, 기타 서버 에러 → 500 분리
- `mobile/lib/config/app_version.dart`: 앱 논리 버전 2.0.9 → 2.1.1 동기화 (pubspec.yaml 불일치 수정)

## Test plan
- [ ] 키워드 삭제 후 새로고침해도 키워드가 사라져 있는지 확인
- [ ] 알림 기록이 있는 키워드 삭제 시 정상 동작 확인
- [ ] 존재하지 않는 keyword 삭제 시 404 응답 확인