### PR TITLE
fix: staticcheck ST1005 에러 문자열 마침표 제거

### DIFF
--- a/server/internal/services/keyword_alert.go
+++ b/server/internal/services/keyword_alert.go
@@ -58,7 +58,7 @@ func (s *KeywordAlertService) CreateKeyword(userID uint, req *CreateKeywordReque
 	var existingCount int64
 	s.db.Model(&models.Keyword{}).Where("user_id = ? AND keyword = ?", userID, req.Keyword).Count(&existingCount)
 	if existingCount > 0 {
-		return nil, errors.New("이미 등록된 키워드입니다.")
+		return nil, errors.New("이미 등록된 키워드입니다")
 	}
 
 	// 현재 키워드 수 확인


### PR DESCRIPTION
## Summary
- `이미 등록된 키워드입니다.` → `이미 등록된 키워드입니다` (ST1005: error strings should not end with punctuation)
- 이전 CI 빌드 실패 원인이었던 기존 린트 오류 수정