### PR TITLE
fix: keyword_alerts_alerts 테이블 deleted_at 컬럼 추가 및 hard delete 적용

### DIFF
--- a/server/internal/services/keyword_alert.go
+++ b/server/internal/services/keyword_alert.go
@@ -101,7 +101,7 @@ func (s *KeywordAlertService) DeleteKeyword(userID, keywordID uint) error {
 	}
 
 	return s.db.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Where("keyword_id = ?", keywordID).Delete(&models.KeywordAlert{}).Error; err != nil {
+		if err := tx.Unscoped().Where("keyword_id = ?", keywordID).Delete(&models.KeywordAlert{}).Error; err != nil {
 			return err
 		}
 		return tx.Delete(&keyword).Error

--- a/server/migrations/add_deleted_at_to_keyword_alerts.sql
+++ b/server/migrations/add_deleted_at_to_keyword_alerts.sql
@@ -1,0 +1,18 @@
+-- Migration: Add deleted_at column to keyword_alerts_alerts table for soft delete support
+-- Created: 2026-05-05
+-- Purpose: Fix "column keyword_alerts_alerts.deleted_at does not exist" error
+
+BEGIN;
+
+ALTER TABLE keyword_alerts_alerts
+ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP WITH TIME ZONE;
+
+CREATE INDEX IF NOT EXISTS idx_keyword_ale_deleted ON keyword_alerts_alerts(deleted_at);
+
+COMMIT;
+
+-- Rollback script (if needed):
+-- BEGIN;
+-- DROP INDEX IF EXISTS idx_keyword_ale_deleted;
+-- ALTER TABLE keyword_alerts_alerts DROP COLUMN IF EXISTS deleted_at;
+-- COMMIT;


### PR DESCRIPTION
## Summary

- `keyword_alerts_alerts` 테이블에 `deleted_at` 컬럼이 없어 alerts 삭제 시 발생하던 에러 수정
- `DeleteKeyword` 메서드에서 `Unscoped()`를 사용하여 soft delete 컬럼 없이도 hard delete가 가능하도록 변경
- `add_deleted_at_to_keyword_alerts.sql` 마이그레이션 파일 추가: `deleted_at` 컬럼 및 인덱스 생성

## 변경 파일

| 파일 | 변경 유형 | 설명 |
|------|-----------|------|
| `server/internal/services/keyword_alert.go` | 수정 | `Unscoped()` 추가로 hard delete 적용 |
| `server/migrations/add_deleted_at_to_keyword_alerts.sql` | 신규 | `deleted_at` 컬럼 및 인덱스 추가 마이그레이션 |

## Test plan

- [ ] `keyword_alerts_alerts` 테이블에 마이그레이션 SQL 적용 확인
- [ ] keyword 삭제 시 연관 alerts가 에러 없이 삭제되는지 확인
- [ ] `deleted_at` 컬럼 인덱스 생성 여부 확인 (`idx_keyword_ale_deleted`)